### PR TITLE
Fixed compiler Bug for Violations (Issue 8992)

### DIFF
--- a/user/src/com/google/gwt/validation/client/impl/ConstraintViolationImpl.java
+++ b/user/src/com/google/gwt/validation/client/impl/ConstraintViolationImpl.java
@@ -150,14 +150,19 @@ public final class ConstraintViolationImpl<T> implements ConstraintViolation<T>,
       return false;
     }
     ConstraintViolationImpl<?> other = (ConstraintViolationImpl<?>) o;
-    return (message == null ? other.message == null : message.equals(other.message)
-        && propertyPath == null ? other.propertyPath == null :
-          propertyPath.equals(other.propertyPath)
-        && rootBean == null ? other.rootBean == null : rootBean.equals(other.rootBean)
-        && leafBean == null ? other.leafBean == null : leafBean.equals(other.leafBean)
-        && elementType == null ? other.elementType == null : elementType.equals(other.elementType)
-        && invalidValue == null ? other.invalidValue == null :
-          invalidValue.equals(other.invalidValue));
+    if(!(message == null ? other.message == null : message.equals(other.message)))
+      return false;
+    if(!(propertyPath == null ? other.propertyPath == null : propertyPath.equals(other.propertyPath)))
+      return false;
+    if(!(rootBean == null ? other.rootBean == null : rootBean.equals(other.rootBean)))
+      return false;
+    if(!(leafBean == null ? other.leafBean == null : leafBean.equals(other.leafBean)))
+      return false;
+    if(!(elementType == null ? other.elementType == null : elementType.equals(other.elementType)))
+      return false;
+    if(!(invalidValue == null ? other.invalidValue == null : invalidValue.equals(other.invalidValue)))
+      return false;
+    return true;
   }
 
   @Override


### PR DESCRIPTION
Equals doesn't work on different propertyPath's, when all other
properties are the same (in js-mode only). Refactoring to many single if
statements fixed the problem for this class.

https://code.google.com/p/google-web-toolkit/issues/detail?id=8992
