### PR TITLE
Implement a reasonable #toString() for AutoBeanFactory proxy instances

### DIFF
--- a/user/src/com/google/web/bindery/autobean/vm/impl/FactoryHandler.java
+++ b/user/src/com/google/web/bindery/autobean/vm/impl/FactoryHandler.java
@@ -64,6 +64,9 @@ public class FactoryHandler implements InvocationHandler {
     } else if (name.equals("getToken")) {
       Enum<?> e = (Enum<?>) args[0];
       return getToken(e);
+    } else if (name.equals("toString")) {
+      // Return a result similar to the Object#toString() implementation
+      return proxy.getClass().getName() + '@' + Integer.toHexString(System.identityHashCode(proxy));
     } else {
       // Declared factory method, use the parameterization
       // AutoBean<Foo> foo(); or Autobean<foo> foo(Foo toWrap);

--- a/user/test/com/google/web/bindery/autobean/gwt/client/AutoBeanTest.java
+++ b/user/test/com/google/web/bindery/autobean/gwt/client/AutoBeanTest.java
@@ -584,6 +584,10 @@ public class AutoBeanTest extends GWTTestCase {
     }
   }
 
+  public void testFactoryToString() {
+    assertNotNull(factory.toString());
+  }
+
   @Override
   protected void gwtSetUp() throws Exception {
     factory = GWT.create(Factory.class);


### PR DESCRIPTION
This fixes a ClassCastException when calling #toString(): the factory handler assumed
any method other than the ones explicitly handled would be returning a parameterized type (AutoBean<Foo>).

---

This fixes https://github.com/gwtproject/gwt/issues/9150 for `#toString()`.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/gwtproject/gwt/9151)

<!-- Reviewable:end -->
