### PR TITLE
Implement SafeUriString#toString

### DIFF
--- a/user/src/com/google/gwt/safehtml/shared/SafeUriString.java
+++ b/user/src/com/google/gwt/safehtml/shared/SafeUriString.java
@@ -75,4 +75,9 @@ class SafeUriString implements SafeUri {
   public int hashCode() {
     return uri.hashCode();
   }
+
+  @Override
+  public String toString() {
+    return asString();
+  }
 }


### PR DESCRIPTION
Implement SafeUriString#toString because if a Mockito verify or an assertion fails, you'd want to get an actionable message. Also, it's a good idea to have toString anyways.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/gwtproject/gwt/9211)

<!-- Reviewable:end -->
