### PR TITLE
Fix Long.highestOneBit

### DIFF
--- a/user/super/com/google/gwt/emul/java/lang/Long.java
+++ b/user/super/com/google/gwt/emul/java/lang/Long.java
@@ -66,7 +66,7 @@ public final class Long extends Number implements Comparable<Long> {
     if (high != 0) {
       return ((long) Integer.highestOneBit(high)) << 32;
     } else {
-      return Integer.highestOneBit((int) i);
+      return Integer.highestOneBit((int) i) & 0xFFFFFFFFL;
     }
   }
 


### PR DESCRIPTION
Long.highestOneBit(1L << 31) currently returns -(1L << 31), which is a bug.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/gwtproject/gwt/9285)

<!-- Reviewable:end -->
