### PR TITLE
performance enhancement: replace addAll() with parametrized constructor

### DIFF
--- a/build_tools/doctool/src/com/google/doctool/custom/EztDoclet.java
+++ b/build_tools/doctool/src/com/google/doctool/custom/EztDoclet.java
@@ -151,8 +151,7 @@ public class EztDoclet {
               cls.name(), cls.name());
 
           // Print out all fields
-          Collection<FieldDoc> fields = new ArrayList<FieldDoc>();
-          fields.addAll(Arrays.asList(cls.fields(true)));
+          Collection<FieldDoc> fields = new ArrayList<FieldDoc>(Arrays.asList(cls.fields(true)));
 
           if (!fields.isEmpty()) {
             pw.format("  <dd style='margin-bottom: 0.5em;'>%s</dd>\n", createFieldList(fields));

--- a/dev/codeserver/java/com/google/gwt/dev/codeserver/SourceMap.java
+++ b/dev/codeserver/java/com/google/gwt/dev/codeserver/SourceMap.java
@@ -71,8 +71,7 @@ class SourceMap {
       directories.add(lastSlashPos < 0 ? "" : filename.substring(0, lastSlashPos));
     }
 
-    List<String> result = new ArrayList<String>();
-    result.addAll(directories);
+    List<String> result = new ArrayList<String>(directories);
     Collections.sort(result);
     return result;
   }

--- a/dev/core/src/com/google/gwt/dev/cfg/BindingProperty.java
+++ b/dev/core/src/com/google/gwt/dev/cfg/BindingProperty.java
@@ -211,8 +211,7 @@ public class BindingProperty extends Property {
         LinkedList<LinkedHashSet<String>> alternates = new LinkedList<LinkedHashSet<String>>();
         valuesMap.put(from, alternates);
         LinkedList<String> childList = fallbackValues.get(from);
-        LinkedHashSet<String> children = new LinkedHashSet<String>();
-        children.addAll(childList);
+        LinkedHashSet<String> children = new LinkedHashSet<String>(childList);
         while (children != null && children.size() > 0) {
           alternates.add(children);
           LinkedHashSet<String> newChildren = new LinkedHashSet<String>();

--- a/dev/core/src/com/google/gwt/dev/cfg/ModuleDef.java
+++ b/dev/core/src/com/google/gwt/dev/cfg/ModuleDef.java
@@ -453,9 +453,7 @@ public class ModuleDef implements DepsInfoProvider {
    * deleted.
    */
   public int getInputFilenameHash() {
-    List<String> filenames = new ArrayList<String>();
-
-    filenames.addAll(gwtXmlPathByModuleName.values());
+    List<String> filenames = new ArrayList<String>(gwtXmlPathByModuleName.values());
 
     for (Resource resource : getResourcesNewerThan(Integer.MIN_VALUE)) {
       filenames.add(resource.getLocation());

--- a/dev/core/src/com/google/gwt/dev/shell/rewrite/WriteJsoImpl.java
+++ b/dev/core/src/com/google/gwt/dev/shell/rewrite/WriteJsoImpl.java
@@ -73,8 +73,7 @@ abstract class WriteJsoImpl extends ClassVisitor {
     public void visit(int version, int access, String name, String signature,
         String superName, String[] interfaces) {
 
-      ArrayList<String> jsoDescList = new ArrayList<String>();
-      jsoDescList.addAll(jsoDescriptors);
+      ArrayList<String> jsoDescList = new ArrayList<String>(jsoDescriptors);
       interfaces = jsoDescList.toArray(new String[jsoDescList.size()]);
 
       super.visit(version, access, name, signature, superName, interfaces);

--- a/user/src/com/google/gwt/i18n/rebind/LocalizableGenerator.java
+++ b/user/src/com/google/gwt/i18n/rebind/LocalizableGenerator.java
@@ -317,8 +317,7 @@ public class LocalizableGenerator extends Generator {
       }
     }
     // collect methods from superinterfaces until hitting Localizable
-    ArrayList<JClassType> todo = new ArrayList<JClassType>();
-    todo.addAll(Arrays.asList(targetClass.getImplementedInterfaces()));
+    ArrayList<JClassType> todo = new ArrayList<JClassType>(Arrays.asList(targetClass.getImplementedInterfaces()));
     while (!todo.isEmpty()) {
       JClassType clazz = todo.remove(0);
       for (JMethod method : clazz.getMethods()) {

--- a/user/src/com/google/gwt/user/rebind/rpc/SerializableTypeOracleBuilder.java
+++ b/user/src/com/google/gwt/user/rebind/rpc/SerializableTypeOracleBuilder.java
@@ -814,8 +814,7 @@ public class SerializableTypeOracleBuilder {
     // so that the leaf type's instantiableTypes variable is ready (if it's computed at all)
     // and all of the leaf's subtypes are ready.
     // (Copy values to avoid concurrent modification.)
-    List<TypeInfoComputed> ticsToCheck = new ArrayList<TypeInfoComputed>();
-    ticsToCheck.addAll(typeToTypeInfoComputed.values());
+    List<TypeInfoComputed> ticsToCheck = new ArrayList<TypeInfoComputed>(typeToTypeInfoComputed.values());
     for (TypeInfoComputed tic : ticsToCheck) {
       JArrayType type = tic.getType().isArray();
       if (type != null && tic.instantiable) {

--- a/user/src/com/google/gwt/validation/client/impl/AbstractGwtValidator.java
+++ b/user/src/com/google/gwt/validation/client/impl/AbstractGwtValidator.java
@@ -80,8 +80,7 @@ public abstract class AbstractGwtValidator implements Validator {
 
   protected void checkGroups(Class<?>... groups) {
     if (!validGroups.containsAll(Arrays.asList(groups))) {
-      HashSet<Class<?>> unknown = new HashSet<Class<?>>();
-      unknown.addAll(Arrays.asList(groups));
+      HashSet<Class<?>> unknown = new HashSet<Class<?>>(Arrays.asList(groups));
       unknown.removeAll(validGroups);
       throw new IllegalArgumentException(this.getClass()
           + " only processes the following groups " + validGroups + ". "

--- a/user/src/com/google/web/bindery/requestfactory/server/RequestFactoryJarExtractor.java
+++ b/user/src/com/google/web/bindery/requestfactory/server/RequestFactoryJarExtractor.java
@@ -795,8 +795,7 @@ public class RequestFactoryJarExtractor {
             ValidationTool.class));
     List<Class<?>> sharedClasses = Arrays.<Class<?>> asList(SHARED_CLASSES);
 
-    List<Class<?>> clientClasses = new ArrayList<Class<?>>();
-    clientClasses.addAll(sharedClasses);
+    List<Class<?>> clientClasses = new ArrayList<Class<?>>(sharedClasses);
     clientClasses.add(UrlRequestTransport.class);
 
     List<Class<?>> serverClasses = new ArrayList<Class<?>>();


### PR DESCRIPTION
it's possible to gain some performance enhancement by passing argument of addAll(), called right after collection creation, straight into constructor at creation time. This allows to allocate memory only once and of exact size and prevent data copying when expanding underlying data structure (array for ArrayList etc.)

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/gwtproject/gwt/9287)

<!-- Reviewable:end -->
