### PR TITLE
Match closing namespace on example

### DIFF
--- a/user/src/com/google/gwt/user/client/ui/CustomButton.java
+++ b/user/src/com/google/gwt/user/client/ui/CustomButton.java
@@ -127,10 +127,10 @@ import com.google.gwt.user.client.Event;
  * &lt;g:PushButton ui:field='pushButton' enabled='true'>
  *   &lt;g:upFace>
  *     &lt;b>click me&lt;/b>
- *   &lt;/gwt:upFace>
+ *   &lt;/g:upFace>
  *   &lt;g:upHoveringFace>
  *     &lt;b>Click ME!&lt;/b>
- *   &lt;/gwt:upHoveringFace>
+ *   &lt;/g:upHoveringFace>
  *
  *   &lt;g:downFace image='{downButton}'/>
  *   &lt;g:downHoveringFace image='{downButton}'/>


### PR DESCRIPTION
Just discovered this when blindly copy-pasting an example from the docs. I'm guessing others will do the same thing, so just making a tiny PR :)

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gwtproject/gwt/9380)

<!-- Reviewable:end -->
