### PR TITLE
SimplePager fastForward is sometimes clickable when disabled

### DIFF
--- a/user/src/com/google/gwt/user/cellview/client/SimplePager.java
+++ b/user/src/com/google/gwt/user/cellview/client/SimplePager.java
@@ -624,6 +624,7 @@ public class SimplePager extends AbstractPager {
       fastForward.getElement().getParentElement().removeClassName(
           style.disabledButton());
     }
+    fastForward.setDisabled(disabled);
   }
 
   /**


### PR DESCRIPTION
The setFastForwardDisabled method in SimplePager changes the style of the button without actually calling setDisabled on the button. The result is that sometimes the button is greyed out, but can still be clicked.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gwtproject/gwt/9481)
<!-- Reviewable:end -->
