### PR TITLE
Return all resources that match a default suffix.

### DIFF
--- a/user/src/com/google/gwt/resources/ext/ResourceGeneratorUtil.java
+++ b/user/src/com/google/gwt/resources/ext/ResourceGeneratorUtil.java
@@ -432,6 +432,7 @@ public final class ResourceGeneratorUtil {
 
     if (resourceAnnotation == null) {
       if (defaultSuffixes != null) {
+        List<URL> l = new ArrayList<URL>();
         for (String extension : defaultSuffixes) {
           if (logger.isLoggable(TreeLogger.SPAM)) {
             logger.log(TreeLogger.SPAM, "Trying default extension " + extension);
@@ -444,9 +445,13 @@ public final class ResourceGeneratorUtil {
             // Take the first match
             if (resourceUrl != null) {
               addTypeRequirementsForMethod(context, method);
-              return new URL[] {resourceUrl};
+              l.add(resourceUrl);
+              break;
             }
           }
+        }
+        if (l.size() > 0) {
+            return l.toArray(new URL[l.size()]);
         }
       }
 


### PR DESCRIPTION
This is more of a question, so I'm creating a pull request here just to get some feedback.

I'm thinking that this code should return all resources that match a default suffix. Most of the built in generators already check that the length returned by this function is exactly 1, since they are expecting to embed only a single resource. However, for building custom resource loaders that need to determine the proper suffix at runtime (i.e. mp3 vs ogg), we would need to make the attached change.

Is there another way to accomplish what I'm trying to do, or is this a good change?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gwtproject/gwt/9580)
<!-- Reviewable:end -->
