### PR TITLE
prevent StackEmptyException in StoryRecorder.java

### DIFF
--- a/dev/core/src/com/google/gwt/core/ext/soyc/impl/StoryRecorder.java
+++ b/dev/core/src/com/google/gwt/core/ext/soyc/impl/StoryRecorder.java
@@ -168,18 +168,16 @@ public class StoryRecorder {
       SourceInfo info = range.getSourceInfo();
       assert info != null;
 
-      // Infer dependency information
-      if (!dependencyScope.isEmpty()) {
-
-        /*
-         * Pop frames until we get back to a container, using this as a chance
-         * to build up our list of non-overlapping Ranges to report back to the
-         * user.
-         */
-        while (!dependencyScope.peek().range.contains(range)) {
-          popAndRecord(dependencyScope, fragment);
-        }
+      /*
+       * Infer dependency information
+       * Pop frames until we get back to a container, using this as a chance
+       * to build up our list of non-overlapping Ranges to report back to the
+       * user.
+       */
+      while (!dependencyScope.isEmpty() && !dependencyScope.peek().range.contains(range)) {
+        popAndRecord(dependencyScope, fragment);
       }
+      
 
       // Possibly create and record Members
       if (!sourceInfoSeen.contains(info)) {


### PR DESCRIPTION
prevents

[INFO] java.util.EmptyStackException
[INFO]  at java.util.Stack.peek(Stack.java:102)
[INFO]  at com.google.gwt.core.ext.soyc.impl.StoryRecorder.analyzeFragment(StoryRecorder.java:179)
[INFO]  at com.google.gwt.core.ext.soyc.impl.StoryRecorder.recordStoriesImpl(StoryRecorder.java:132)
[INFO]  at com.google.gwt.core.ext.soyc.impl.StoryRecorder.recordStories(StoryRecorder.java:73)
[INFO]  at com.google.gwt.dev.jjs.JavaToJavaScriptCompiler.makeSoycArtifacts(JavaToJavaScriptCompiler.java:843)
[INFO]  at com.google.gwt.dev.jjs.JavaToJavaScriptCompiler.addSoycArtifacts(JavaToJavaScriptCompiler.java:710)
[INFO]  at com.google.gwt.dev.jjs.JavaToJavaScriptCompiler.addSyntheticArtifacts(JavaToJavaScriptCompiler.java:731)
[INFO]  at com.google.gwt.dev.jjs.JavaToJavaScriptCompiler.compilePermutation(JavaToJavaScriptCompiler.java:454)
[INFO]  at com.google.gwt.dev.jjs.JavaToJavaScriptCompiler.compilePermutation(JavaToJavaScriptCompiler.java:272)
[INFO]  at com.google.gwt.dev.CompilePerms.compile(CompilePerms.java:198)
[INFO]  at com.google.gwt.dev.ThreadedPermutationWorkerFactory$ThreadedPermutationWorker.compile(ThreadedPermutationWorkerFactory.java:50)
[INFO]  at com.google.gwt.dev.PermutationWorkerFactory$Manager$WorkerThread.run(PermutationWorkerFactory.java:74)

!!! GWT DOES NOT ACCEPT PULL REQUESTS ON GITHUB !!!

Thank you for creating a patch for GWT. This project uses Gerrit
to sign CLAs (Contributor License Agreement) and to review
code contributions. For that reason we can not accept pull requests
on Github.


If you want your patch to be accepted please follow the instructions on

http://www.gwtproject.org/makinggwtbetter.html

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gwtproject/gwt/9634)
<!-- Reviewable:end -->
