### PR TITLE
Enable GitHub Actions for pushes, nightly builds, and PRs

### DIFF
--- a/.github/workflows/full-check.yml
+++ b/.github/workflows/full-check.yml
@@ -1,0 +1,77 @@
+# Run all tests and builds all aspects of GWT using Java 8. Runs nightly (plus
+# or minus timzeones) on the main branch, and will also run right away on a
+# push to a release branch. Release zips are uploaded as part of the build,
+# though maven snapshots are not yet deployed.
+name: Full build
+on:
+  schedule:
+    # This time is selected to be early in the morning in NA/SA/EU/ME. This
+    # only runs on the default branch.
+    - cron:  '0 6 * * *'
+  push:
+    # Build on pushes to main and release branches. For forks, the -test may
+    # be helpful to run tests when preparing a merge.
+    branches:
+      - 'main'
+      - 'release/*'
+      - '*-test'
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout GWT itself into one directory
+        uses: actions/checkout@v2
+        with:
+          path: 'gwt'
+      - name: Checkout GWT tools into a sibling directory
+        uses: actions/checkout@v2
+        with:
+          repository: 'gwtproject/tools'
+          path: 'tools'
+      - name: Set up JDK 8
+        # GWT presently requires Java8 to build, but can run on newer Java versions
+        uses: actions/setup-java@v2
+        with:
+          java-version: '8'
+          distribution: 'temurin'
+
+      - name: Build, style/api checks, test, produce docs
+        run: |
+          set -eux
+          cd gwt
+          java -version
+          ant -version
+          # Set env vars to ensure we get the build/test we expect
+          export \
+            TZ=America/Los_Angeles \
+            ANT_OPTS='-Dfile.encoding=UTF8 -Xmx2g'
+          # Run the ant tasks, disabling watchFileChanges to work around a github actions limitation
+          ant clean test dist doc \
+            -Dtest.jvmargs='-ea -Dgwt.watchFileChanges=false' \
+            -Dtest.web.htmlunit.disable=true \
+            -Dtest.nometa.htmlunit.disable=true \
+            -Dtest.emma.htmlunit.disable=true
+
+      - name: Report test results
+        uses: mikepenz/action-junit-report@v3.1.0
+        if: always()
+        with:
+          report_paths: 'gwt/build/out/**/test/**/reports/TEST-*.xml'
+      - name: Upload checkstyle xml for manual review in its own artifact
+        uses: actions/upload-artifact@v2
+        if: always()
+        with:
+          name: checkstyle-reports
+          path: 'gwt/build/out/**/checkstyle*.xml'
+      - name: Upload test xml files for manual review in its own artifact
+        uses: actions/upload-artifact@v2
+        if: always()
+        with:
+          name: junit-reports
+          path: 'gwt/build/out/**/test/**/reports/TEST-*.xml'
+
+      - name: On success, upload the release zip
+        uses: actions/upload-artifact@v2
+        with:
+          name: gwt
+          path: 'gwt/build/dist/gwt-*.zip'

--- a/.github/workflows/quick-check.yml
+++ b/.github/workflows/quick-check.yml
@@ -47,10 +47,11 @@ jobs:
           REVIEWDOG_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -eux
+          shopt -s extglob
           cd gwt
-          for xml in $(find build/out | grep checkstyle); do
-            echo $xml
-            reviewdog -f=checkstyle -filter-mode=diff_context -reporter=github-pr-review -level=info < $xml
+          for f in build/out/**/checkstyle*.xml ; do
+            echo $f
+            reviewdog -f=checkstyle -filter-mode=diff_context -reporter=github-pr-review -level=info < $f
           done
       - name: Upload checkstyle xml for manual review
         uses: actions/upload-artifact@v2

--- a/.github/workflows/quick-check.yml
+++ b/.github/workflows/quick-check.yml
@@ -1,0 +1,61 @@
+# Run simple checks to make sure that the build is sane when any branch is pushed or pull
+# request created. Comments or annotations will be added to a pull request in the case of
+# style guide violations. Presently, tests are not run on pull requests.
+name: Quick smoke test
+on: [push, pull_request]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout GWT itself into one directory
+        uses: actions/checkout@v2
+        with:
+          path: 'gwt'
+          # we need depth=2 to see which style violations overlap with the current changes
+          fetch-depth: 2
+      - name: Checkout GWT tools into a sibling directory
+        uses: actions/checkout@v2
+        with:
+          repository: 'gwtproject/tools'
+          path: 'tools'
+      - name: Set up JDK 8
+        # GWT presently requires Java8 to build, but can run on newer Java versions
+        uses: actions/setup-java@v2
+        with:
+          java-version: '8'
+          distribution: 'temurin'
+      - name: Set up reviewdog for easier checks on the PR's checkstyle output
+        uses: reviewdog/action-setup@v1
+        with:
+          reviewdog_version: latest
+
+      - name: Build, style/api checks, produce docs
+        # Presently this runs no tests at all, but could run quick tests
+        run: |
+          set -eux
+          cd gwt
+          # Set env vars to ensure we get the build we expect
+          export \
+            TZ=America/Los_Angeles \
+            ANT_OPTS=-Dfile.encoding=UTF8 \
+            ANT_OPTS=-Xmx2g
+          ant clean dist doc checkstyle apicheck
+
+      - name: Create pull request comments/annotations for checkstyle, even on failure
+        if: always() && github.event_name == 'pull_request'
+        env:
+          REVIEWDOG_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -eux
+          cd gwt
+          for xml in $(find build/out | grep checkstyle); do
+            echo $xml
+            reviewdog -f=checkstyle -filter-mode=diff_context -reporter=github-pr-review -level=info < $xml
+          done
+      - name: Upload checkstyle xml for manual review
+        uses: actions/upload-artifact@v2
+        if: always()
+        with:
+          name: checkstyle-reports
+          path: 'gwt/build/out/**/checkstyle*.xml'
+          retention-days: 5


### PR DESCRIPTION
This introduces two builds, intended to fairly closely reflect the
builds that used to be run on the build.gwtproject.org Jenkins instance.

Nightly builds run most tests, and provide both a simple visualization
of the test summary as well as access to download all test reports, and
in the case of successful builds, the sdk zip can be downloaded. Maven
artifacts are not yet available. This full build can also be run by
pushing to main or release branches, and can be run by creating branches
that end with "-test", which may be helpful for forks to run their own
actions.

On each Pull Request, only checkstyle and apicheck will be run, in
addition to verifying that the SDK and samples can be built, but the ~2
hours of tests are not run. Any checkstyle errors that overlap with the
git diff will be posted as comments or annotations to the diff.

Partial #9756 