### PR TITLE
Deploy nightly builds to sonatype, using github secrets

### DIFF
--- a/.github/workflows/full-check.yml
+++ b/.github/workflows/full-check.yml
@@ -80,7 +80,7 @@ jobs:
       - name: Set up sonatype credentials
         # Using the same java version as above, set up a settings.xml file
         uses: actions/setup-java@v3
-        if: github.event_name == 'schedule'
+        if: github.event_name == 'schedule' && github.repository_owner == 'gwtproject'
         with:
           java-version: '8'
           distribution: 'temurin'
@@ -90,7 +90,7 @@ jobs:
           server-password: SONATYPE_PASSWORD
 
       - name: Nightly builds should be deployed as snapshots to sonatype
-        if: github.event_name == 'schedule'
+        if: github.event_name == 'schedule' && github.repository_owner == 'gwtproject'
         env:
           SONATYPE_USERNAME: ${{ secrets.SONATYPE_USERNAME }}
           SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}

--- a/.github/workflows/full-check.yml
+++ b/.github/workflows/full-check.yml
@@ -30,7 +30,7 @@ jobs:
           path: 'tools'
       - name: Set up JDK 8
         # GWT presently requires Java8 to build, but can run on newer Java versions
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v3
         with:
           java-version: '8'
           distribution: 'temurin'
@@ -77,23 +77,29 @@ jobs:
           name: gwt
           path: 'gwt/build/dist/gwt-*.zip'
 
-      - name: Create a settings.xml file with sonatype deploy credentials
+      - name: Set up sonatype credentials
+        # Using the same java version as above, set up a settings.xml file
+        uses: actions/setup-java@v3
         if: github.event_name == 'schedule'
-        uses: s4u/maven-settings-action@v2.6.0
         with:
-          servers: |
-            [{
-              "id": "sonatype-snapshots",
-              "username": "${{ secrets.SONATYPE_USERNAME }}",
-              "password": "${{ secrets.SONATYPE_PASSWORD }}"
-            }]
+          java-version: '8'
+          distribution: 'temurin'
+          # Define the ID for the server to put in settings.xml, and the env vars that will contain the secrets
+          server-id: sonatype-snapshots
+          server-username: SONATYPE_USERNAME
+          server-password: SONATYPE_PASSWORD
+
       - name: Nightly builds should be deployed as snapshots to sonatype
         if: github.event_name == 'schedule'
+        env:
+          SONATYPE_USERNAME: ${{ secrets.SONATYPE_USERNAME }}
+          SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}
         run: |
           set -eux
           # Set the version to deploy (it was also set in the build step above)
           export GWT_VERSION=HEAD-SNAPSHOT
           export GWT_MAVEN_REPO_URL=https://oss.sonatype.org/content/repositories/snapshots/
           export GWT_MAVEN_REPO_ID=sonatype-snapshots
+          cd gwt
           # With no user input, run the push-gwtproject.sh script to deploy org.gwtproject artifacts
           maven/push-gwtproject.sh < /dev/null

--- a/.github/workflows/full-check.yml
+++ b/.github/workflows/full-check.yml
@@ -44,7 +44,8 @@ jobs:
           # Set env vars to ensure we get the build/test we expect
           export \
             TZ=America/Los_Angeles \
-            ANT_OPTS='-Dfile.encoding=UTF8 -Xmx2g'
+            ANT_OPTS='-Dfile.encoding=UTF8 -Xmx2g' \
+            GWT_VERSION=HEAD-SNAPSHOT
           # Run the ant tasks, disabling watchFileChanges to work around a github actions limitation
           ant clean test dist doc \
             -Dtest.jvmargs='-ea -Dgwt.watchFileChanges=false' \
@@ -75,3 +76,24 @@ jobs:
         with:
           name: gwt
           path: 'gwt/build/dist/gwt-*.zip'
+
+      - name: Create a settings.xml file with sonatype deploy credentials
+        if: github.event_name == 'schedule'
+        uses: s4u/maven-settings-action@v2.6.0
+        with:
+          servers: |
+            [{
+              "id": "sonatype-snapshots",
+              "username": "${{ secrets.SONATYPE_USERNAME }}",
+              "password": "${{ secrets.SONATYPE_PASSWORD }}"
+            }]
+      - name: Nightly builds should be deployed as snapshots to sonatype
+        if: github.event_name == 'schedule'
+        run: |
+          set -eux
+          # Set the version to deploy (it was also set in the build step above)
+          export GWT_VERSION=HEAD-SNAPSHOT
+          export GWT_MAVEN_REPO_URL=https://oss.sonatype.org/content/repositories/snapshots/
+          export GWT_MAVEN_REPO_ID=sonatype-snapshots
+          # With no user input, run the push-gwtproject.sh script to deploy org.gwtproject artifacts
+          maven/push-gwtproject.sh < /dev/null


### PR DESCRIPTION
Configures nightly scheduled builds to push to sonatype snapshots, as
used to happen with the Google-managed Jenkins job. GitHub Actions
for the account is assumed to have SONATYPE_USERNAME and
SONATYPE_PASSWORD secrets configured. To avoid forks attempting to
deploy to org.gwtproject from their own actions, this is also set to
only run on the gwtproject organization's repository.

Partial #9756