### PR TITLE
Finish moving away from Google groupIds

### DIFF
--- a/maven/poms/gwt/pom-template.xml
+++ b/maven/poms/gwt/pom-template.xml
@@ -29,7 +29,7 @@
             <dependency>
                 <groupId>com.google.gwt</groupId>
                 <artifactId>gwt-user</artifactId>
-                <version>${project.version}</version>
+                <version>2.10.0</version>
             </dependency>
             <dependency>
                 <groupId>org.gwtproject</groupId>
@@ -39,7 +39,7 @@
             <dependency>
                 <groupId>com.google.gwt</groupId>
                 <artifactId>gwt-dev</artifactId>
-                <version>${project.version}</version>
+                <version>2.10.0</version>
             </dependency>
             <dependency>
                 <groupId>org.gwtproject</groupId>
@@ -49,7 +49,7 @@
             <dependency>
                 <groupId>com.google.gwt</groupId>
                 <artifactId>gwt-codeserver</artifactId>
-                <version>${project.version}</version>
+                <version>2.10.0</version>
             </dependency>
             <dependency>
                 <groupId>org.gwtproject</groupId>
@@ -59,7 +59,7 @@
             <dependency>
                 <groupId>com.google.gwt</groupId>
                 <artifactId>gwt-servlet</artifactId>
-                <version>${project.version}</version>
+                <version>2.10.0</version>
             </dependency>
             <dependency>
                 <groupId>org.gwtproject</groupId>

--- a/maven/poms/requestfactory/pom-template.xml
+++ b/maven/poms/requestfactory/pom-template.xml
@@ -25,7 +25,7 @@
             <dependency>
                 <groupId>com.google.web.bindery</groupId>
                 <artifactId>requestfactory-apt</artifactId>
-                <version>${project.version}</version>
+                <version>2.10.0</version>
             </dependency>
             <dependency>
                 <groupId>org.gwtproject.web.bindery</groupId>
@@ -35,7 +35,7 @@
             <dependency>
                 <groupId>com.google.web.bindery</groupId>
                 <artifactId>requestfactory-client</artifactId>
-                <version>${project.version}</version>
+                <version>2.10.0</version>
             </dependency>
             <dependency>
                 <groupId>org.gwtproject.web.bindery</groupId>
@@ -45,7 +45,7 @@
             <dependency>
                 <groupId>com.google.web.bindery</groupId>
                 <artifactId>requestfactory-server</artifactId>
-                <version>${project.version}</version>
+                <version>2.10.0</version>
             </dependency>
             <dependency>
                 <groupId>org.gwtproject.web.bindery</groupId>

--- a/samples/dynatablerf/pom.xml
+++ b/samples/dynatablerf/pom.xml
@@ -155,8 +155,8 @@
 
   <repositories>
     <repository>
-      <id>google-snapshots</id>
-      <url>https://oss.sonatype.org/content/repositories/google-snapshots/</url>
+      <id>sonatype-snapshots</id>
+      <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
       <releases>
         <enabled>false</enabled>
       </releases>

--- a/samples/mobilewebapp/pom.xml
+++ b/samples/mobilewebapp/pom.xml
@@ -241,8 +241,8 @@
 
   <repositories>
     <repository>
-      <id>google-snapshots</id>
-      <url>https://oss.sonatype.org/content/repositories/google-snapshots/</url>
+      <id>sonatype-snapshots</id>
+      <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
       <releases>
         <enabled>false</enabled>
       </releases>

--- a/samples/validation/pom.xml
+++ b/samples/validation/pom.xml
@@ -158,8 +158,8 @@
 
   <repositories>
     <repository>
-      <id>google-snapshots</id>
-      <url>https://oss.sonatype.org/content/repositories/google-snapshots/</url>
+      <id>sonatype-snapshots</id>
+      <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
       <releases>
         <enabled>false</enabled>
       </releases>


### PR DESCRIPTION
Hardcodes the com.google groupIds for GWT to 2.10.0 going forward, and
switches from google snapshot repository to general sonatype snapshots
now that we have nightly builds deployed there.