### PR TITLE
Correctly write Long.toBinaryString as an unsigned value

### DIFF
--- a/user/super/com/google/gwt/emul/java/lang/Long.java
+++ b/user/super/com/google/gwt/emul/java/lang/Long.java
@@ -237,7 +237,7 @@ public final class Long extends Number implements Comparable<Long> {
 
     int highBits = LongUtils.getHighBits(value);
     if (highBits == 0) {
-      return Integer.toString((int) value, radix);
+      return Integer.toUnsignedString((int) value, radix);
     }
 
     final int mask = radix - 1;

--- a/user/test/com/google/gwt/emultest/java/lang/LongTest.java
+++ b/user/test/com/google/gwt/emultest/java/lang/LongTest.java
@@ -254,6 +254,14 @@ public class LongTest extends GWTTestCase {
     assertEquals(
         "1111111111111111111111111111111111111111111111111111111111111111",
         Long.toBinaryString(-1));
+
+    // Test int MAX+1 and int -1, as both are positive longs, but negative ints
+    assertEquals(
+        "10000000000000000000000000000000",
+        Long.toBinaryString(((long) Integer.MAX_VALUE) + 1));
+    assertEquals(
+        "11111111111111111111111111111111",
+        Long.toBinaryString(4294967295L));
   }
 
   public void testToHexString() {
@@ -262,6 +270,8 @@ public class LongTest extends GWTTestCase {
     assertEquals("1234500000000", Long.toHexString(0x1234500000000L));
     assertEquals("fff1234500000000", Long.toHexString(0xFFF1234500000000L));
     assertEquals("ffffffffffffffff", Long.toHexString(-1));
+    assertEquals("80000000", Long.toHexString(((long) Integer.MAX_VALUE) + 1));
+    assertEquals("ffffffff", Long.toHexString(4294967295L));
   }
 
   public void testToOctalString() {
@@ -270,6 +280,8 @@ public class LongTest extends GWTTestCase {
     assertEquals("1000000000000000000000", Long.toOctalString(Long.MIN_VALUE));
     assertEquals("777777777777777777777", Long.toOctalString(Long.MAX_VALUE));
     assertEquals("1777777777777777777777", Long.toOctalString(-1));
+    assertEquals("20000000000", Long.toOctalString(((long) Integer.MAX_VALUE) + 1));
+    assertEquals("37777777777", Long.toOctalString(4294967295L));
   }
 
   public void testToString() {
@@ -281,6 +293,8 @@ public class LongTest extends GWTTestCase {
     assertEquals("80765", Long.toString(80765L));
     assertEquals("-2147483648", Long.toString((long) Integer.MIN_VALUE));
     assertEquals("2147483647", Long.toString((long) Integer.MAX_VALUE));
+    assertEquals("2147483648", Long.toString(((long) Integer.MAX_VALUE) + 1));
+    assertEquals("4294967295", Long.toString((long) 4294967295L));
     assertEquals("-89000000005", Long.toString(-89000000005L));
     assertEquals("89000000005", Long.toString(89000000005L));
     assertEquals("-9223372036854775808", Long.toString(Long.MIN_VALUE));


### PR DESCRIPTION
A previous fix to negative longs incorrectly allowed some positive longs
that would be represented as negative ints to be printed as negative
binary values, instead of as unsigned values. This patch fixes that case
and adds tests to confirm that these edge cases are well represented.
This bug was introduced by 7616ceb5.

The binary, hex, and octal tests all fail before this change, the
toString test was just for completeness, but wasn't actually broken.

Additionally, getHighBits could be expensive, and a range check against
two constants (that easily fit in a "small long") should be cheaper at
runtime. This is not required for the fix, and I will validate this
performance assumption.

Fixes #9764