### PR TITLE
Response-Streaming GWT RPC; Fixes #7987

### DIFF
--- a/user/src/com/google/gwt/user/client/rpc/SerializationStreamReader.java
+++ b/user/src/com/google/gwt/user/client/rpc/SerializationStreamReader.java
@@ -32,6 +32,8 @@ public interface SerializationStreamReader {
 
   int readInt() throws SerializationException;
 
+  int readIntFromEnd() throws SerializationException;
+
   long readLong() throws SerializationException;
 
   Object readObject() throws SerializationException;

--- a/user/src/com/google/gwt/user/client/rpc/impl/AbstractSerializationStream.java
+++ b/user/src/com/google/gwt/user/client/rpc/impl/AbstractSerializationStream.java
@@ -42,7 +42,15 @@ public abstract class AbstractSerializationStream {
   /**
    * The newest supported RPC protocol version.
    */
-  public static final int SERIALIZATION_STREAM_MAX_VERSION = 8;
+  public static final int SERIALIZATION_STREAM_MAX_VERSION = 9;
+  
+  /**
+   * The first version that is streaming content in forward order from
+   * server to client, passing through a {@link Writer} for writing the
+   * serialization payload to the HTTP response with close to no additional
+   * memory footprint for buffering and converting.
+   */
+  public static final int SERIALIZATION_STREAM_FORWARD_STREAMING_VERSION = 9;
 
   /**
    * The current RPC protocol version.

--- a/user/src/com/google/gwt/user/client/rpc/impl/AbstractSerializationStreamReader.java
+++ b/user/src/com/google/gwt/user/client/rpc/impl/AbstractSerializationStreamReader.java
@@ -93,11 +93,11 @@ public abstract class AbstractSerializationStreamReader extends
 
     // Read the stream version number
     //
-    setVersion(readInt());
+    setVersion(readIntFromEnd());
 
     // Read the flags from the stream
     //
-    setFlags(readInt());
+    setFlags(readIntFromEnd());
   }
 
   public final Object readObject() throws SerializationException {

--- a/user/src/com/google/gwt/user/client/rpc/impl/ClientSerializationStreamReader.java
+++ b/user/src/com/google/gwt/user/client/rpc/impl/ClientSerializationStreamReader.java
@@ -342,25 +342,25 @@ public final class ClientSerializationStreamReader extends
 
   @Override
   public boolean readBoolean() {
-    JsValueLiteral literal = decoder.getValues().get(index++);
+    JsValueLiteral literal = decoder.getValues().get(getVersion() >= SERIALIZATION_STREAM_FORWARD_STREAMING_VERSION ? index++ : --indexFromEnd);
     return literal.isBooleanTrue();
   }
 
   @Override
   public byte readByte() {    
-    JsNumberLiteral literal = (JsNumberLiteral) decoder.getValues().get(index++);
+    JsNumberLiteral literal = (JsNumberLiteral) decoder.getValues().get(getVersion() >= SERIALIZATION_STREAM_FORWARD_STREAMING_VERSION ? index++ : --indexFromEnd);
     return (byte) literal.getValue();
   }
   
   @Override
   public char readChar() {    
-    JsNumberLiteral literal = (JsNumberLiteral) decoder.getValues().get(index++);
+    JsNumberLiteral literal = (JsNumberLiteral) decoder.getValues().get(getVersion() >= SERIALIZATION_STREAM_FORWARD_STREAMING_VERSION ? index++ : --indexFromEnd);
     return (char) literal.getValue();
   }
   
   @Override
   public double readDouble() {    
-    JsValueLiteral valueLiteral = decoder.getValues().get(index++);
+    JsValueLiteral valueLiteral = decoder.getValues().get(getVersion() >= SERIALIZATION_STREAM_FORWARD_STREAMING_VERSION ? index++ : --indexFromEnd);
     if (valueLiteral instanceof JsNumberLiteral) {
       JsNumberLiteral literal = (JsNumberLiteral) valueLiteral;
       return literal.getValue();
@@ -379,7 +379,7 @@ public final class ClientSerializationStreamReader extends
   
   @Override
   public int readInt() {    
-    JsNumberLiteral literal = (JsNumberLiteral) decoder.getValues().get(index++);
+    JsNumberLiteral literal = (JsNumberLiteral) decoder.getValues().get(getVersion() >= SERIALIZATION_STREAM_FORWARD_STREAMING_VERSION ? index++ : --indexFromEnd);
     return (int) literal.getValue();
   }
   
@@ -392,12 +392,12 @@ public final class ClientSerializationStreamReader extends
   @Override
   public long readLong() {    
     return Base64Utils.longFromBase64(
-        ((JsStringLiteral) decoder.getValues().get(index++)).getValue());
+        ((JsStringLiteral) decoder.getValues().get(getVersion() >= SERIALIZATION_STREAM_FORWARD_STREAMING_VERSION ? index++ : --indexFromEnd)).getValue());
   }
   
   @Override
   public short readShort() {    
-    JsNumberLiteral literal = (JsNumberLiteral) decoder.getValues().get(index++);
+    JsNumberLiteral literal = (JsNumberLiteral) decoder.getValues().get(getVersion() >= SERIALIZATION_STREAM_FORWARD_STREAMING_VERSION ? index++ : --indexFromEnd);
     return (short) literal.getValue();
   }
   

--- a/user/src/com/google/gwt/user/client/rpc/impl/ClientSerializationStreamReader.java
+++ b/user/src/com/google/gwt/user/client/rpc/impl/ClientSerializationStreamReader.java
@@ -322,7 +322,7 @@ public final class ClientSerializationStreamReader extends
       throw new SerializationException("Failed to parse RPC payload", e);
     }
 
-    index = decoder.getValues().size();
+    index = 0;
     super.prepareToRead(encoded);
 
     if (getVersion() < SERIALIZATION_STREAM_MIN_VERSION
@@ -340,25 +340,25 @@ public final class ClientSerializationStreamReader extends
 
   @Override
   public boolean readBoolean() {
-    JsValueLiteral literal = decoder.getValues().get(--index);
+    JsValueLiteral literal = decoder.getValues().get(index++);
     return literal.isBooleanTrue();
   }
 
   @Override
   public byte readByte() {    
-    JsNumberLiteral literal = (JsNumberLiteral) decoder.getValues().get(--index);
+    JsNumberLiteral literal = (JsNumberLiteral) decoder.getValues().get(index++);
     return (byte) literal.getValue();
   }
   
   @Override
   public char readChar() {    
-    JsNumberLiteral literal = (JsNumberLiteral) decoder.getValues().get(--index);
+    JsNumberLiteral literal = (JsNumberLiteral) decoder.getValues().get(index++);
     return (char) literal.getValue();
   }
   
   @Override
   public double readDouble() {    
-    JsValueLiteral valueLiteral = decoder.getValues().get(--index);
+    JsValueLiteral valueLiteral = decoder.getValues().get(index++);
     if (valueLiteral instanceof JsNumberLiteral) {
       JsNumberLiteral literal = (JsNumberLiteral) valueLiteral;
       return literal.getValue();
@@ -377,19 +377,19 @@ public final class ClientSerializationStreamReader extends
   
   @Override
   public int readInt() {    
-    JsNumberLiteral literal = (JsNumberLiteral) decoder.getValues().get(--index);
+    JsNumberLiteral literal = (JsNumberLiteral) decoder.getValues().get(index++);
     return (int) literal.getValue();
   }
   
   @Override
   public long readLong() {    
     return Base64Utils.longFromBase64(
-        ((JsStringLiteral) decoder.getValues().get(--index)).getValue());
+        ((JsStringLiteral) decoder.getValues().get(index++)).getValue());
   }
   
   @Override
   public short readShort() {    
-    JsNumberLiteral literal = (JsNumberLiteral) decoder.getValues().get(--index);
+    JsNumberLiteral literal = (JsNumberLiteral) decoder.getValues().get(index++);
     return (short) literal.getValue();
   }
   

--- a/user/src/com/google/gwt/user/client/rpc/impl/ClientSerializationStreamReader.java
+++ b/user/src/com/google/gwt/user/client/rpc/impl/ClientSerializationStreamReader.java
@@ -186,6 +186,7 @@ public final class ClientSerializationStreamReader extends
 
   private RpcDecoder decoder;
   private int index;
+  private int indexFromEnd;
   private Serializer serializer;
 
   /**
@@ -323,6 +324,7 @@ public final class ClientSerializationStreamReader extends
     }
 
     index = 0;
+    indexFromEnd = decoder.getValues().size();
     super.prepareToRead(encoded);
 
     if (getVersion() < SERIALIZATION_STREAM_MIN_VERSION
@@ -378,6 +380,12 @@ public final class ClientSerializationStreamReader extends
   @Override
   public int readInt() {    
     JsNumberLiteral literal = (JsNumberLiteral) decoder.getValues().get(index++);
+    return (int) literal.getValue();
+  }
+  
+  @Override
+  public int readIntFromEnd() {    
+    JsNumberLiteral literal = (JsNumberLiteral) decoder.getValues().get(--indexFromEnd);
     return (int) literal.getValue();
   }
   

--- a/user/src/com/google/gwt/user/server/rpc/RPC.java
+++ b/user/src/com/google/gwt/user/server/rpc/RPC.java
@@ -18,7 +18,6 @@ package com.google.gwt.user.server.rpc;
 import com.google.gwt.user.client.rpc.IncompatibleRemoteServiceException;
 import com.google.gwt.user.client.rpc.RemoteService;
 import com.google.gwt.user.client.rpc.RpcToken;
-import com.google.gwt.user.client.rpc.RpcTokenException;
 import com.google.gwt.user.client.rpc.SerializationException;
 import com.google.gwt.user.client.rpc.impl.AbstractSerializationStream;
 import com.google.gwt.user.server.rpc.impl.DequeMap;

--- a/user/src/com/google/gwt/user/server/rpc/RPC.java
+++ b/user/src/com/google/gwt/user/server/rpc/RPC.java
@@ -15,18 +15,6 @@
  */
 package com.google.gwt.user.server.rpc;
 
-import java.io.IOException;
-import java.io.Writer;
-import java.lang.reflect.InvocationTargetException;
-import java.lang.reflect.Method;
-import java.lang.reflect.Type;
-import java.lang.reflect.TypeVariable;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.Map;
-import java.util.Set;
-
 import com.google.gwt.user.client.rpc.IncompatibleRemoteServiceException;
 import com.google.gwt.user.client.rpc.RemoteService;
 import com.google.gwt.user.client.rpc.RpcToken;
@@ -39,6 +27,18 @@ import com.google.gwt.user.server.rpc.impl.SerializabilityUtil;
 import com.google.gwt.user.server.rpc.impl.ServerSerializationStreamReader;
 import com.google.gwt.user.server.rpc.impl.ServerSerializationStreamWriter;
 import com.google.gwt.user.server.rpc.impl.TypeNameObfuscator;
+
+import java.io.IOException;
+import java.io.Writer;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.lang.reflect.Type;
+import java.lang.reflect.TypeVariable;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
 
 /**
  * Utility class for integrating with the RPC system. This class exposes methods

--- a/user/src/com/google/gwt/user/server/rpc/RPC.java
+++ b/user/src/com/google/gwt/user/server/rpc/RPC.java
@@ -361,7 +361,6 @@ public final class RPC {
    *          <code>null</code>
    * @param cause the {@link Throwable} that was thrown
    * @param writer the writer to serialize the output to
-   * @return a string that encodes the exception
    * 
    * @throws NullPointerException if the cause is <code>null</code>
    * @throws SerializationException if the result cannot be serialized
@@ -391,7 +390,6 @@ public final class RPC {
    * @param cause the {@link Throwable} that was thrown
    * @param serializationPolicy determines the serialization policy to be used
    * @param writer the writer to serialize the output to
-   * @return a string that encodes the exception
    * 
    * @throws NullPointerException if the cause or the serializationPolicy
    *           are <code>null</code>

--- a/user/src/com/google/gwt/user/server/rpc/RPC.java
+++ b/user/src/com/google/gwt/user/server/rpc/RPC.java
@@ -587,7 +587,6 @@ public final class RPC {
     if (serializationPolicy == null) {
       throw new NullPointerException("serializationPolicy");
     }
-
     try {
       Object result = serviceMethod.invoke(target, args);
       encodeResponseForSuccess(serviceMethod, result, serializationPolicy, flags, writer);
@@ -609,7 +608,7 @@ public final class RPC {
     }
   }
 
-  private static int getRpcVersion() throws SerializationException {
+  static int getRpcVersion() throws SerializationException {
     int version =
         Integer.getInteger("gwt.rpc.version",
             AbstractSerializationStream.SERIALIZATION_STREAM_VERSION);

--- a/user/src/com/google/gwt/user/server/rpc/RPCServletUtils.java
+++ b/user/src/com/google/gwt/user/server/rpc/RPCServletUtils.java
@@ -19,7 +19,6 @@ package com.google.gwt.user.server.rpc;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.OutputStream;
 import java.io.OutputStreamWriter;
 import java.io.Writer;
 import java.lang.reflect.Method;

--- a/user/src/com/google/gwt/user/server/rpc/RPCServletUtils.java
+++ b/user/src/com/google/gwt/user/server/rpc/RPCServletUtils.java
@@ -337,30 +337,19 @@ public class RPCServletUtils {
   public static Writer createWriterForResponse(ServletContext servletContext,
       HttpServletResponse response, boolean gzipResponse)
       throws IOException {
-    final Writer writer;
-    final OutputStream output = response.getOutputStream();
-    if (gzipResponse) {
-      // Compress the reply and adjust headers.
-      //
-      GZIPOutputStream gzipOutputStream = null;
-      try {
-        gzipOutputStream = new GZIPOutputStream(output);
-        setGzipEncodingHeader(response);
-      } finally {
-        if (null != gzipOutputStream) {
-          gzipOutputStream.close();
-        }
-      }
-      writer = new OutputStreamWriter(gzipOutputStream, CHARSET_UTF8);
-    } else {
-      writer = new OutputStreamWriter(output, CHARSET_UTF8);
-    }
-
-    // Send the reply.
-    //
     response.setContentType(CONTENT_TYPE_APPLICATION_JSON_UTF8);
     response.setStatus(HttpServletResponse.SC_OK);
     response.setHeader(CONTENT_DISPOSITION, ATTACHMENT);
+    final Writer writer;
+    if (gzipResponse) {
+      // Compress the reply and adjust headers.
+      //
+      setGzipEncodingHeader(response);
+      final GZIPOutputStream gzipOutputStream = new GZIPOutputStream(response.getOutputStream());
+      writer = new OutputStreamWriter(gzipOutputStream, CHARSET_UTF8);
+    } else {
+      writer = new OutputStreamWriter(response.getOutputStream(), CHARSET_UTF8);
+    }
     return writer;
   }
 

--- a/user/src/com/google/gwt/user/server/rpc/RemoteServiceServlet.java
+++ b/user/src/com/google/gwt/user/server/rpc/RemoteServiceServlet.java
@@ -20,6 +20,7 @@ import static com.google.gwt.user.client.rpc.RpcRequestBuilder.MODULE_BASE_HEADE
 import com.google.gwt.user.client.rpc.IncompatibleRemoteServiceException;
 import com.google.gwt.user.client.rpc.RpcTokenException;
 import com.google.gwt.user.client.rpc.SerializationException;
+import com.google.gwt.user.client.rpc.impl.AbstractSerializationStream;
 
 import java.io.IOException;
 import java.io.InputStream;

--- a/user/src/com/google/gwt/user/server/rpc/RemoteServiceServlet.java
+++ b/user/src/com/google/gwt/user/server/rpc/RemoteServiceServlet.java
@@ -324,9 +324,6 @@ public class RemoteServiceServlet extends AbstractRemoteServiceServlet
    *
    * @param rpcRequest the already decoded RPC request
    * @param writer output to be written to this writer
-   * @return a string which encodes either the method's return, a checked
-   *         exception thrown by the method, or an
-   *         {@link IncompatibleRemoteServiceException}
    * @throws SerializationException if we cannot serialize the response
    * @throws UnexpectedException if the invocation throws a checked exception
    *           that is not declared in the service method's signature

--- a/user/src/com/google/gwt/user/server/rpc/RemoteServiceServlet.java
+++ b/user/src/com/google/gwt/user/server/rpc/RemoteServiceServlet.java
@@ -17,6 +17,10 @@ package com.google.gwt.user.server.rpc;
 
 import static com.google.gwt.user.client.rpc.RpcRequestBuilder.MODULE_BASE_HEADER;
 
+import com.google.gwt.user.client.rpc.IncompatibleRemoteServiceException;
+import com.google.gwt.user.client.rpc.RpcTokenException;
+import com.google.gwt.user.client.rpc.SerializationException;
+
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.StringWriter;
@@ -34,10 +38,6 @@ import javax.servlet.ServletException;
 import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
-
-import com.google.gwt.user.client.rpc.IncompatibleRemoteServiceException;
-import com.google.gwt.user.client.rpc.RpcTokenException;
-import com.google.gwt.user.client.rpc.SerializationException;
 
 /**
  * The servlet base class for your RPC service implementations that

--- a/user/src/com/google/gwt/user/server/rpc/RemoteServiceServlet.java
+++ b/user/src/com/google/gwt/user/server/rpc/RemoteServiceServlet.java
@@ -26,7 +26,6 @@ import java.io.InputStream;
 import java.io.StringWriter;
 import java.io.Writer;
 import java.lang.reflect.Method;
-import java.lang.reflect.Modifier;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.text.ParseException;

--- a/user/src/com/google/gwt/user/server/rpc/RemoteServiceServlet.java
+++ b/user/src/com/google/gwt/user/server/rpc/RemoteServiceServlet.java
@@ -282,9 +282,6 @@ public class RemoteServiceServlet extends AbstractRemoteServiceServlet
    *
    * @param payload the UTF-8 request payload
    * @param writer the writer to write the output to
-   * @return a string which encodes either the method's return, a checked
-   *         exception thrown by the method, or an
-   *         {@link IncompatibleRemoteServiceException}
    * @throws SerializationException if we cannot serialize the response
    * @throws UnexpectedException if the invocation throws a checked exception
    *           that is not declared in the service method's signature

--- a/user/src/com/google/gwt/user/server/rpc/TeeWriter.java
+++ b/user/src/com/google/gwt/user/server/rpc/TeeWriter.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2008 Google Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
 package com.google.gwt.user.server.rpc;
 
 import java.io.FilterWriter;
@@ -7,9 +22,6 @@ import java.io.Writer;
 /**
  * A writer that wraps one writer and copies all output written to it not only to that one
  * writer but also to another writer ("tee").
- * 
- * @author Axel Uhl
- *
  */
 public class TeeWriter extends FilterWriter {
     private final Writer tee;

--- a/user/src/com/google/gwt/user/server/rpc/TeeWriter.java
+++ b/user/src/com/google/gwt/user/server/rpc/TeeWriter.java
@@ -1,0 +1,51 @@
+package com.google.gwt.user.server.rpc;
+
+import java.io.FilterWriter;
+import java.io.IOException;
+import java.io.Writer;
+
+/**
+ * A writer that wraps one writer and copies all output written to it not only to that one
+ * writer but also to another writer ("tee").
+ * 
+ * @author Axel Uhl
+ *
+ */
+public class TeeWriter extends FilterWriter {
+    private final Writer tee;
+    
+    protected TeeWriter(Writer out, Writer tee) {
+        super(out);
+        this.tee = tee;
+    }
+
+    @Override
+    public void write(int c) throws IOException {
+        super.write(c);
+        tee.write(c);
+    }
+
+    @Override
+    public void write(char[] cbuf, int off, int len) throws IOException {
+        super.write(cbuf, off, len);
+        tee.write(cbuf, off, len);
+    }
+
+    @Override
+    public void write(String str, int off, int len) throws IOException {
+        super.write(str, off, len);
+        tee.write(str, off, len);
+    }
+
+    @Override
+    public void flush() throws IOException {
+        super.flush();
+        tee.flush();
+    }
+
+    @Override
+    public void close() throws IOException {
+        super.close();
+        tee.close();
+    }
+}

--- a/user/src/com/google/gwt/user/server/rpc/TeeWriter.java
+++ b/user/src/com/google/gwt/user/server/rpc/TeeWriter.java
@@ -14,7 +14,7 @@ import java.io.Writer;
 public class TeeWriter extends FilterWriter {
     private final Writer tee;
     
-    protected TeeWriter(Writer out, Writer tee) {
+    public TeeWriter(Writer out, Writer tee) {
         super(out);
         this.tee = tee;
     }

--- a/user/src/com/google/gwt/user/server/rpc/impl/ServerSerializationStreamReader.java
+++ b/user/src/com/google/gwt/user/server/rpc/impl/ServerSerializationStreamReader.java
@@ -555,7 +555,12 @@ public final class ServerSerializationStreamReader extends AbstractSerialization
 
   @Override
   public int readIntFromEnd() throws SerializationException {
-	  throw new UnsupportedOperationException();
+    String value = extractFromEnd();
+    try {
+      return Integer.parseInt(value);
+    } catch (NumberFormatException e) {
+      throw getNumberFormatException(value, "int", Integer.MIN_VALUE, Integer.MAX_VALUE);
+    }
   }
 
   @Override

--- a/user/src/com/google/gwt/user/server/rpc/impl/ServerSerializationStreamReader.java
+++ b/user/src/com/google/gwt/user/server/rpc/impl/ServerSerializationStreamReader.java
@@ -1002,20 +1002,20 @@ public final class ServerSerializationStreamReader extends AbstractSerialization
   }
 
   private String extract() throws SerializationException {
-	    try {
-	      return tokenList.get(tokenListIndex++);
-	    } catch (IndexOutOfBoundsException e) {
-	      throw new SerializationException("Too few tokens in RPC request", e);
-	    }
-	  }
+    try {
+      return tokenList.get(tokenListIndex++);
+    } catch (IndexOutOfBoundsException e) {
+      throw new SerializationException("Too few tokens in RPC request", e);
+    }
+  }
 
   private String extractFromEnd() throws SerializationException {
-	    try {
-	      return tokenList.get(tokenListIndex++);
-	    } catch (IndexOutOfBoundsException e) {
-	      throw new SerializationException("Too few tokens in RPC request", e);
-	    }
-	  }
+    try {
+      return tokenList.get(tokenListIndex++);
+    } catch (IndexOutOfBoundsException e) {
+      throw new SerializationException("Too few tokens in RPC request", e);
+    }
+  }
 
   /**
    * Returns a suitable NumberFormatException with an explanatory message when a

--- a/user/src/com/google/gwt/user/server/rpc/impl/ServerSerializationStreamReader.java
+++ b/user/src/com/google/gwt/user/server/rpc/impl/ServerSerializationStreamReader.java
@@ -383,6 +383,7 @@ public final class ServerSerializationStreamReader extends AbstractSerialization
   private final ArrayList<String> tokenList = new ArrayList<String>();
 
   private int tokenListIndex;
+  private int tokenListIndexFromEnd;
 
   {
     CLASS_TO_VECTOR_READER.put(boolean[].class, VectorReader.BOOLEAN_VECTOR);
@@ -550,6 +551,11 @@ public final class ServerSerializationStreamReader extends AbstractSerialization
     } catch (NumberFormatException e) {
       throw getNumberFormatException(value, "int", Integer.MIN_VALUE, Integer.MAX_VALUE);
     }
+  }
+
+  @Override
+  public int readIntFromEnd() throws SerializationException {
+	  throw new UnsupportedOperationException();
   }
 
   @Override
@@ -991,12 +997,20 @@ public final class ServerSerializationStreamReader extends AbstractSerialization
   }
 
   private String extract() throws SerializationException {
-    try {
-      return tokenList.get(tokenListIndex++);
-    } catch (IndexOutOfBoundsException e) {
-      throw new SerializationException("Too few tokens in RPC request", e);
-    }
-  }
+	    try {
+	      return tokenList.get(tokenListIndex++);
+	    } catch (IndexOutOfBoundsException e) {
+	      throw new SerializationException("Too few tokens in RPC request", e);
+	    }
+	  }
+
+  private String extractFromEnd() throws SerializationException {
+	    try {
+	      return tokenList.get(tokenListIndex++);
+	    } catch (IndexOutOfBoundsException e) {
+	      throw new SerializationException("Too few tokens in RPC request", e);
+	    }
+	  }
 
   /**
    * Returns a suitable NumberFormatException with an explanatory message when a

--- a/user/src/com/google/gwt/user/server/rpc/impl/ServerSerializationStreamWriter.java
+++ b/user/src/com/google/gwt/user/server/rpc/impl/ServerSerializationStreamWriter.java
@@ -873,10 +873,6 @@ public final class ServerSerializationStreamWriter extends
     }
   }
 
-  /**
-   * Notice that the field are written in reverse order that the client can just
-   * pop items out of the stream.
-   */
   private void writeHeader() throws IOException {
     encoder.addToken(getFlags());
     if (encoder.isJavaScript() && getVersion() >= SERIALIZATION_STREAM_JSON_VERSION) {

--- a/user/src/com/google/gwt/user/server/rpc/impl/ServerSerializationStreamWriter.java
+++ b/user/src/com/google/gwt/user/server/rpc/impl/ServerSerializationStreamWriter.java
@@ -130,8 +130,8 @@ public final class ServerSerializationStreamWriter extends
     
     @Override
     public String toString() {
-      return getClass().getSimpleName()+" [writer=" + writer + ", needsComma=" + needsComma + ", total="
-          + total + ", javascript=" + javascript + "]";
+      return getClass().getSimpleName() + " [writer=" + writer + ", needsComma=" + needsComma
+          + ", total=" + total + ", javascript=" + javascript + "]";
     }
   }
 
@@ -634,7 +634,7 @@ public final class ServerSerializationStreamWriter extends
    */
   @Override
   public String toString() {
-    return getClass().getName()+" for serialization policy "+serializationPolicy;
+    return getClass().getName() + " for serialization policy " + serializationPolicy;
   }
   
   /**

--- a/user/src/com/google/gwt/user/server/rpc/impl/ServerSerializationStreamWriter.java
+++ b/user/src/com/google/gwt/user/server/rpc/impl/ServerSerializationStreamWriter.java
@@ -15,12 +15,6 @@
  */
 package com.google.gwt.user.server.rpc.impl;
 
-import com.google.gwt.user.client.rpc.CustomFieldSerializer;
-import com.google.gwt.user.client.rpc.SerializationException;
-import com.google.gwt.user.client.rpc.impl.AbstractSerializationStreamWriter;
-import com.google.gwt.user.server.Base64Utils;
-import com.google.gwt.user.server.rpc.SerializationPolicy;
-
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.ObjectOutputStream;
@@ -30,10 +24,16 @@ import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
 import java.util.ArrayList;
 import java.util.IdentityHashMap;
+import java.util.Iterator;
 import java.util.List;
-import java.util.ListIterator;
 import java.util.Map;
 import java.util.Set;
+
+import com.google.gwt.user.client.rpc.CustomFieldSerializer;
+import com.google.gwt.user.client.rpc.SerializationException;
+import com.google.gwt.user.client.rpc.impl.AbstractSerializationStreamWriter;
+import com.google.gwt.user.server.Base64Utils;
+import com.google.gwt.user.server.rpc.SerializationPolicy;
 
 /**
  * For internal use only. Used for server call serialization. This class is
@@ -872,9 +872,9 @@ public final class ServerSerializationStreamWriter extends
   }
 
   private void writePayload(LengthConstrainedArray stream) {
-    ListIterator<String> tokenIterator = tokenList.listIterator(tokenList.size());
-    while (tokenIterator.hasPrevious()) {
-      stream.addToken(tokenIterator.previous());
+    Iterator<String> tokenIterator = tokenList.iterator();
+    while (tokenIterator.hasNext()) {
+      stream.addToken(tokenIterator.next());
     }
   }
 

--- a/user/src/com/google/gwt/user/server/rpc/impl/ServerSerializationStreamWriter.java
+++ b/user/src/com/google/gwt/user/server/rpc/impl/ServerSerializationStreamWriter.java
@@ -893,6 +893,7 @@ public final class ServerSerializationStreamWriter extends
     for (String s : getStringTable()) {
       tableStream.addEscapedToken(s);
     }
+    tableStream.finish();
     encoder.addToken(buffer.toString());
     encoder.setJavaScript(encoder.isJavaScript() || tableStream.isJavaScript());
   }

--- a/user/src/com/google/gwt/user/server/rpc/impl/ServerSerializationStreamWriter.java
+++ b/user/src/com/google/gwt/user/server/rpc/impl/ServerSerializationStreamWriter.java
@@ -893,7 +893,7 @@ public final class ServerSerializationStreamWriter extends
     for (String s : getStringTable()) {
       tableStream.addEscapedToken(s);
     }
-    encoder.addToken(tableStream.toString());
+    encoder.addToken(buffer.toString());
     encoder.setJavaScript(encoder.isJavaScript() || tableStream.isJavaScript());
   }
 }

--- a/user/src/com/google/gwt/user/server/rpc/package-info.java
+++ b/user/src/com/google/gwt/user/server/rpc/package-info.java
@@ -24,7 +24,7 @@
  * interfaces, in which case incoming RPC calls will be directed to the
  * servlet subclass itself; or it can be overridden to give finer control over
  * routing RPC calls within a server framework.  (For more details on the
- * latter, see the {@link com.google.gwt.user.server.rpc.RemoteServiceServlet#processCall(String) RemoteServiceServlet.processCall(String)} method.)
+ * latter, see the {@link com.google.gwt.user.server.rpc.RemoteServiceServlet#processCall(String, Writer) RemoteServiceServlet.processCall(String)} method.)
  * </p>
  * 
  * <p>
@@ -37,7 +37,7 @@
  * <p>
  * Note that the default RemoteServiceServlet implementation never throws
  * exceptions to the servlet container.  All exceptions that escape the
- * {@link com.google.gwt.user.server.rpc.RemoteServiceServlet#processCall(String) RemoteServiceServlet.processCall(String)}
+ * {@link com.google.gwt.user.server.rpc.RemoteServiceServlet#processCall(String, Writer) RemoteServiceServlet.processCall(String)}
  * method will be caught, logged in the servlet context, and will cause a generic 
  * failure message to be sent to the GWT client -- with a 500 status code.  To 
  * customize this behavior, override 
@@ -45,3 +45,5 @@
  * </p>
  */
 package com.google.gwt.user.server.rpc;
+
+import java.io.Writer;

--- a/user/src/com/google/gwt/user/server/rpc/package-info.java
+++ b/user/src/com/google/gwt/user/server/rpc/package-info.java
@@ -45,5 +45,3 @@
  * </p>
  */
 package com.google.gwt.user.server.rpc;
-
-import java.io.Writer;

--- a/user/super/com/google/gwt/user/translatable/com/google/gwt/user/client/rpc/impl/ClientSerializationStreamReader.java
+++ b/user/super/com/google/gwt/user/translatable/com/google/gwt/user/client/rpc/impl/ClientSerializationStreamReader.java
@@ -85,37 +85,37 @@ public final class ClientSerializationStreamReader extends
   }
 
   public native boolean readBoolean() /*-{
-    return !!this.@com.google.gwt.user.client.rpc.impl.ClientSerializationStreamReader::results[--this.@com.google.gwt.user.client.rpc.impl.ClientSerializationStreamReader::index];
+    return !!this.@com.google.gwt.user.client.rpc.impl.ClientSerializationStreamReader::results[this.@com.google.gwt.user.client.rpc.impl.ClientSerializationStreamReader::index++];
   }-*/;
 
   public native byte readByte() /*-{
-    return this.@com.google.gwt.user.client.rpc.impl.ClientSerializationStreamReader::results[--this.@com.google.gwt.user.client.rpc.impl.ClientSerializationStreamReader::index];
+    return this.@com.google.gwt.user.client.rpc.impl.ClientSerializationStreamReader::results[this.@com.google.gwt.user.client.rpc.impl.ClientSerializationStreamReader::index++];
   }-*/;
 
   public native char readChar() /*-{
-    return this.@com.google.gwt.user.client.rpc.impl.ClientSerializationStreamReader::results[--this.@com.google.gwt.user.client.rpc.impl.ClientSerializationStreamReader::index];
+    return this.@com.google.gwt.user.client.rpc.impl.ClientSerializationStreamReader::results[this.@com.google.gwt.user.client.rpc.impl.ClientSerializationStreamReader::index++];
   }-*/;
 
   public native double readDouble() /*-{
-    return Number(this.@com.google.gwt.user.client.rpc.impl.ClientSerializationStreamReader::results[--this.@com.google.gwt.user.client.rpc.impl.ClientSerializationStreamReader::index]);
+    return Number(this.@com.google.gwt.user.client.rpc.impl.ClientSerializationStreamReader::results[this.@com.google.gwt.user.client.rpc.impl.ClientSerializationStreamReader::index++]);
   }-*/;
 
   public native float readFloat() /*-{
-    return Number(this.@com.google.gwt.user.client.rpc.impl.ClientSerializationStreamReader::results[--this.@com.google.gwt.user.client.rpc.impl.ClientSerializationStreamReader::index]);
+    return Number(this.@com.google.gwt.user.client.rpc.impl.ClientSerializationStreamReader::results[this.@com.google.gwt.user.client.rpc.impl.ClientSerializationStreamReader::index++]);
   }-*/;
 
   public native int readInt() /*-{
-    return this.@com.google.gwt.user.client.rpc.impl.ClientSerializationStreamReader::results[--this.@com.google.gwt.user.client.rpc.impl.ClientSerializationStreamReader::index];
+    return this.@com.google.gwt.user.client.rpc.impl.ClientSerializationStreamReader::results[this.@com.google.gwt.user.client.rpc.impl.ClientSerializationStreamReader::index++];
   }-*/;
 
   @UnsafeNativeLong
   public native long readLong() /*-{
-    var s = this.@com.google.gwt.user.client.rpc.impl.ClientSerializationStreamReader::results[--this.@com.google.gwt.user.client.rpc.impl.ClientSerializationStreamReader::index];
+    var s = this.@com.google.gwt.user.client.rpc.impl.ClientSerializationStreamReader::results[this.@com.google.gwt.user.client.rpc.impl.ClientSerializationStreamReader::index++];
     return @ClientSerializationStreamReader::longFromBase64(Ljava/lang/String;)(s);
   }-*/;
 
   public native short readShort() /*-{
-    return this.@com.google.gwt.user.client.rpc.impl.ClientSerializationStreamReader::results[--this.@com.google.gwt.user.client.rpc.impl.ClientSerializationStreamReader::index];
+    return this.@com.google.gwt.user.client.rpc.impl.ClientSerializationStreamReader::results[this.@com.google.gwt.user.client.rpc.impl.ClientSerializationStreamReader::index++];
   }-*/;
 
   public String readString() {
@@ -139,7 +139,7 @@ public final class ClientSerializationStreamReader extends
   }-*/;
 
   private native JavaScriptObject readJavaScriptObject() /*-{
-    return this.@com.google.gwt.user.client.rpc.impl.ClientSerializationStreamReader::results[--this.@com.google.gwt.user.client.rpc.impl.ClientSerializationStreamReader::index];
+    return this.@com.google.gwt.user.client.rpc.impl.ClientSerializationStreamReader::results[this.@com.google.gwt.user.client.rpc.impl.ClientSerializationStreamReader::index++];
   }-*/;
 
   private static int readVersion(String encodedString) {

--- a/user/super/com/google/gwt/user/translatable/com/google/gwt/user/client/rpc/impl/ClientSerializationStreamReader.java
+++ b/user/super/com/google/gwt/user/translatable/com/google/gwt/user/client/rpc/impl/ClientSerializationStreamReader.java
@@ -87,27 +87,51 @@ public final class ClientSerializationStreamReader extends
   }
 
   public native boolean readBoolean() /*-{
-    return !!this.@com.google.gwt.user.client.rpc.impl.ClientSerializationStreamReader::results[this.@com.google.gwt.user.client.rpc.impl.ClientSerializationStreamReader::index++];
+    return !!this.@com.google.gwt.user.client.rpc.impl.ClientSerializationStreamReader::results[
+      this.@com.google.gwt.user.client.rpc.impl.ClientSerializationStreamReader::getVersion() >=
+        @com.google.gwt.user.client.rpc.impl.AbstractSerializationStream::SERIALIZATION_STREAM_FORWARD_STREAMING_VERSION ?
+          this.@com.google.gwt.user.client.rpc.impl.ClientSerializationStreamReader::index++ :
+          --this.@com.google.gwt.user.client.rpc.impl.ClientSerializationStreamReader::indexFromEnd]
   }-*/;
 
   public native byte readByte() /*-{
-    return this.@com.google.gwt.user.client.rpc.impl.ClientSerializationStreamReader::results[this.@com.google.gwt.user.client.rpc.impl.ClientSerializationStreamReader::index++];
+    return this.@com.google.gwt.user.client.rpc.impl.ClientSerializationStreamReader::results[
+      this.@com.google.gwt.user.client.rpc.impl.ClientSerializationStreamReader::getVersion() >=
+        @com.google.gwt.user.client.rpc.impl.AbstractSerializationStream::SERIALIZATION_STREAM_FORWARD_STREAMING_VERSION ?
+          this.@com.google.gwt.user.client.rpc.impl.ClientSerializationStreamReader::index++ :
+          --this.@com.google.gwt.user.client.rpc.impl.ClientSerializationStreamReader::indexFromEnd];
   }-*/;
 
   public native char readChar() /*-{
-    return this.@com.google.gwt.user.client.rpc.impl.ClientSerializationStreamReader::results[this.@com.google.gwt.user.client.rpc.impl.ClientSerializationStreamReader::index++];
+    return this.@com.google.gwt.user.client.rpc.impl.ClientSerializationStreamReader::results[
+      this.@com.google.gwt.user.client.rpc.impl.ClientSerializationStreamReader::getVersion() >=
+        @com.google.gwt.user.client.rpc.impl.AbstractSerializationStream::SERIALIZATION_STREAM_FORWARD_STREAMING_VERSION ?
+          this.@com.google.gwt.user.client.rpc.impl.ClientSerializationStreamReader::index++ :
+          --this.@com.google.gwt.user.client.rpc.impl.ClientSerializationStreamReader::indexFromEnd];
   }-*/;
 
   public native double readDouble() /*-{
-    return Number(this.@com.google.gwt.user.client.rpc.impl.ClientSerializationStreamReader::results[this.@com.google.gwt.user.client.rpc.impl.ClientSerializationStreamReader::index++]);
+    return Number(this.@com.google.gwt.user.client.rpc.impl.ClientSerializationStreamReader::results[
+      this.@com.google.gwt.user.client.rpc.impl.ClientSerializationStreamReader::getVersion() >=
+        @com.google.gwt.user.client.rpc.impl.AbstractSerializationStream::SERIALIZATION_STREAM_FORWARD_STREAMING_VERSION ?
+          this.@com.google.gwt.user.client.rpc.impl.ClientSerializationStreamReader::index++ :
+          --this.@com.google.gwt.user.client.rpc.impl.ClientSerializationStreamReader::indexFromEnd]);
   }-*/;
 
   public native float readFloat() /*-{
-    return Number(this.@com.google.gwt.user.client.rpc.impl.ClientSerializationStreamReader::results[this.@com.google.gwt.user.client.rpc.impl.ClientSerializationStreamReader::index++]);
+    return Number(this.@com.google.gwt.user.client.rpc.impl.ClientSerializationStreamReader::results[
+      this.@com.google.gwt.user.client.rpc.impl.ClientSerializationStreamReader::getVersion() >=
+        @com.google.gwt.user.client.rpc.impl.AbstractSerializationStream::SERIALIZATION_STREAM_FORWARD_STREAMING_VERSION ?
+          this.@com.google.gwt.user.client.rpc.impl.ClientSerializationStreamReader::index++ :
+          --this.@com.google.gwt.user.client.rpc.impl.ClientSerializationStreamReader::indexFromEnd]);
   }-*/;
 
   public native int readInt() /*-{
-  return this.@com.google.gwt.user.client.rpc.impl.ClientSerializationStreamReader::results[this.@com.google.gwt.user.client.rpc.impl.ClientSerializationStreamReader::index++];
+  return this.@com.google.gwt.user.client.rpc.impl.ClientSerializationStreamReader::results[
+      this.@com.google.gwt.user.client.rpc.impl.ClientSerializationStreamReader::getVersion() >=
+        @com.google.gwt.user.client.rpc.impl.AbstractSerializationStream::SERIALIZATION_STREAM_FORWARD_STREAMING_VERSION ?
+          this.@com.google.gwt.user.client.rpc.impl.ClientSerializationStreamReader::index++ :
+          --this.@com.google.gwt.user.client.rpc.impl.ClientSerializationStreamReader::indexFromEnd];
 }-*/;
 
   public native int readIntFromEnd() /*-{
@@ -116,12 +140,20 @@ public final class ClientSerializationStreamReader extends
 
   @UnsafeNativeLong
   public native long readLong() /*-{
-    var s = this.@com.google.gwt.user.client.rpc.impl.ClientSerializationStreamReader::results[this.@com.google.gwt.user.client.rpc.impl.ClientSerializationStreamReader::index++];
+    var s = this.@com.google.gwt.user.client.rpc.impl.ClientSerializationStreamReader::results[
+      this.@com.google.gwt.user.client.rpc.impl.ClientSerializationStreamReader::getVersion() >=
+        @com.google.gwt.user.client.rpc.impl.AbstractSerializationStream::SERIALIZATION_STREAM_FORWARD_STREAMING_VERSION ?
+          this.@com.google.gwt.user.client.rpc.impl.ClientSerializationStreamReader::index++ :
+          --this.@com.google.gwt.user.client.rpc.impl.ClientSerializationStreamReader::indexFromEnd];
     return @ClientSerializationStreamReader::longFromBase64(Ljava/lang/String;)(s);
   }-*/;
 
   public native short readShort() /*-{
-    return this.@com.google.gwt.user.client.rpc.impl.ClientSerializationStreamReader::results[this.@com.google.gwt.user.client.rpc.impl.ClientSerializationStreamReader::index++];
+    return this.@com.google.gwt.user.client.rpc.impl.ClientSerializationStreamReader::results[
+      this.@com.google.gwt.user.client.rpc.impl.ClientSerializationStreamReader::getVersion() >=
+        @com.google.gwt.user.client.rpc.impl.AbstractSerializationStream::SERIALIZATION_STREAM_FORWARD_STREAMING_VERSION ?
+          this.@com.google.gwt.user.client.rpc.impl.ClientSerializationStreamReader::index++ :
+          --this.@com.google.gwt.user.client.rpc.impl.ClientSerializationStreamReader::indexFromEnd];
   }-*/;
 
   public String readString() {
@@ -145,8 +177,12 @@ public final class ClientSerializationStreamReader extends
   }-*/;
 
   private native JavaScriptObject readJavaScriptObject() /*-{
-  return this.@com.google.gwt.user.client.rpc.impl.ClientSerializationStreamReader::results[this.@com.google.gwt.user.client.rpc.impl.ClientSerializationStreamReader::index++];
-}-*/;
+    return this.@com.google.gwt.user.client.rpc.impl.ClientSerializationStreamReader::results[
+      this.@com.google.gwt.user.client.rpc.impl.ClientSerializationStreamReader::getVersion() >=
+        @com.google.gwt.user.client.rpc.impl.AbstractSerializationStream::SERIALIZATION_STREAM_FORWARD_STREAMING_VERSION ?
+          this.@com.google.gwt.user.client.rpc.impl.ClientSerializationStreamReader::index++ :
+          --this.@com.google.gwt.user.client.rpc.impl.ClientSerializationStreamReader::indexFromEnd];
+  }-*/;
 
   private native JavaScriptObject readJavaScriptObjectFromEnd() /*-{
     return this.@com.google.gwt.user.client.rpc.impl.ClientSerializationStreamReader::results[--this.@com.google.gwt.user.client.rpc.impl.ClientSerializationStreamReader::indexFromEnd];

--- a/user/super/com/google/gwt/user/translatable/com/google/gwt/user/client/rpc/impl/ClientSerializationStreamReader.java
+++ b/user/super/com/google/gwt/user/translatable/com/google/gwt/user/client/rpc/impl/ClientSerializationStreamReader.java
@@ -40,6 +40,7 @@ public final class ClientSerializationStreamReader extends
   }-*/;
 
   int index;
+  int indexFromEnd;
 
   JavaScriptObject results;
 
@@ -66,7 +67,8 @@ public final class ClientSerializationStreamReader extends
       results = JsonUtils.safeEval(encoded);
     }
 
-    index = getLength(results);
+    index = 0;
+    indexFromEnd = getLength(results);
     super.prepareToRead(encoded);
 
     if (getVersion() < SERIALIZATION_STREAM_MIN_VERSION
@@ -81,7 +83,7 @@ public final class ClientSerializationStreamReader extends
           + "server: " + getFlags());
     }
 
-    stringTable = readJavaScriptObject();
+    stringTable = readJavaScriptObjectFromEnd();
   }
 
   public native boolean readBoolean() /*-{
@@ -105,7 +107,11 @@ public final class ClientSerializationStreamReader extends
   }-*/;
 
   public native int readInt() /*-{
-    return this.@com.google.gwt.user.client.rpc.impl.ClientSerializationStreamReader::results[this.@com.google.gwt.user.client.rpc.impl.ClientSerializationStreamReader::index++];
+  return this.@com.google.gwt.user.client.rpc.impl.ClientSerializationStreamReader::results[this.@com.google.gwt.user.client.rpc.impl.ClientSerializationStreamReader::index++];
+}-*/;
+
+  public native int readIntFromEnd() /*-{
+  	return this.@com.google.gwt.user.client.rpc.impl.ClientSerializationStreamReader::results[--this.@com.google.gwt.user.client.rpc.impl.ClientSerializationStreamReader::indexFromEnd];
   }-*/;
 
   @UnsafeNativeLong
@@ -139,7 +145,11 @@ public final class ClientSerializationStreamReader extends
   }-*/;
 
   private native JavaScriptObject readJavaScriptObject() /*-{
-    return this.@com.google.gwt.user.client.rpc.impl.ClientSerializationStreamReader::results[this.@com.google.gwt.user.client.rpc.impl.ClientSerializationStreamReader::index++];
+  return this.@com.google.gwt.user.client.rpc.impl.ClientSerializationStreamReader::results[this.@com.google.gwt.user.client.rpc.impl.ClientSerializationStreamReader::index++];
+}-*/;
+
+  private native JavaScriptObject readJavaScriptObjectFromEnd() /*-{
+    return this.@com.google.gwt.user.client.rpc.impl.ClientSerializationStreamReader::results[--this.@com.google.gwt.user.client.rpc.impl.ClientSerializationStreamReader::indexFromEnd];
   }-*/;
 
   private static int readVersion(String encodedString) {


### PR DESCRIPTION
This PR changes the serialization such that instead of reversing the order of the payload tokens they are streamed in forward order. If payload-intercepting methods are provided in RemoteServiceServlet subclasses they will still be provided the full payload. Otherwise, the payload will only be streamed to the HTTP response stream and will not exist as a full byte[] or char[] or StringBuffer in the server's memory anymore.

This saves approximately 10% CPU time for response payloads in the 10s of MB range, and it eliminates a seven-times memory footprint during assembling and sending the response payload, reducing memory issues on RPC servers with many concurrent clients making requests that lead to large responses.

The PR makes incompatible changes to a few static public methods and to the processCall method where a new Writer parameter is introduced. Migration of subclasses overriding this method should, however, be straightforward.

Fixes #7987 