### PR TITLE
Fixes #9783

### DIFF
--- a/user/src/com/google/gwt/user/client/ui/RootPanel.java
+++ b/user/src/com/google/gwt/user/client/ui/RootPanel.java
@@ -183,7 +183,7 @@ public class RootPanel extends AbsolutePanel {
         // current body to handle scenarios where body gets replaced/refreshed
         // from DOM on certain actions like page navigation.
         if(id == null && elem == null) {
-          rp.setElement((Element) natGetBodyElement());
+          rp.setElement((Element) getBodyElement());
         }
         // There's already an existing RootPanel for this element. Return it.
         return rp;

--- a/user/src/com/google/gwt/user/client/ui/RootPanel.java
+++ b/user/src/com/google/gwt/user/client/ui/RootPanel.java
@@ -182,7 +182,7 @@ public class RootPanel extends AbsolutePanel {
         // if id and elem are null, set the element of existing rp with the 
         // current body to handle scenarios where body gets replaced/refreshed
         // from DOM on certain actions like page navigation.
-        if(id == null && elem == null) {
+        if(id == null) {
           rp.setElement((Element) getBodyElement());
         }
         // There's already an existing RootPanel for this element. Return it.

--- a/user/src/com/google/gwt/user/client/ui/RootPanel.java
+++ b/user/src/com/google/gwt/user/client/ui/RootPanel.java
@@ -179,6 +179,12 @@ public class RootPanel extends AbsolutePanel {
       // for any reason, return a new RootPanel rather than the existing one (
       // see issue 1937).
       if ((elem == null) || (rp.getElement() == elem)) {
+        // if id and elem are null, set the element of existing rp with the 
+        // current body to handle scenarios where body gets replaced/refreshed
+        // from DOM on certain actions like page navigation.
+        if(id == null && elem == null) {
+          rp.setElement((Element) natGetBodyElement());
+        }
         // There's already an existing RootPanel for this element. Return it.
         return rp;
       }


### PR DESCRIPTION
Consider a scenario where on page navigation , application removes the body from DOM and add it again . on calling RootPanel.get() from new page will return a existing rootpanel cached on previous page with id equals null . Here the element of root panel is nothing but the DOM's body. The cached rootPanel will have reference to the old body and all the actions would try to be performed on wrong body reference.  Putting id and elem null check will handle this scenario well and will not touch the other positive scenarios .