### PR TITLE
Update installScriptEarlyDownload.js to remove old workaround

### DIFF
--- a/dev/core/src/com/google/gwt/core/ext/linker/impl/installScriptEarlyDownload.js
+++ b/dev/core/src/com/google/gwt/core/ext/linker/impl/installScriptEarlyDownload.js
@@ -20,7 +20,7 @@ function installScript(filename) {
     var docbody = doc.body;
     var script;
     // for sourcemaps, we inject the code as a single string for Chrome
-    if (navigator.userAgent.includes("Chrome")) {
+    if (navigator.userAgent.indexOf("Chrome") > -1) {
       var codeString = "";
       for (var i = 0; i < code.length; i++) {
         codeString += code[i];

--- a/dev/core/src/com/google/gwt/core/ext/linker/impl/installScriptEarlyDownload.js
+++ b/dev/core/src/com/google/gwt/core/ext/linker/impl/installScriptEarlyDownload.js
@@ -21,19 +21,13 @@ function installScript(filename) {
     var script;
     // for sourcemaps, we inject the code as a single string for Chrome
     if (navigator.userAgent.indexOf("Chrome") > -1) {
-      var codeString = "";
-      for (var i = 0; i < code.length; i++) {
-        codeString += code[i];
-      }
       script = doc.createElement('script');
-      script.language = 'javascript';
-      script.text = codeString;
+      script.text = code.join('');
       docbody.appendChild(script);
       removeScript(docbody, script);
     } else {
       for (var i = 0; i < code.length; i++) {
         script = doc.createElement('script');
-        script.language='javascript';
         script.text = code[i];
         docbody.appendChild(script);
         removeScript(docbody, script);

--- a/dev/core/src/com/google/gwt/core/ext/linker/impl/installScriptEarlyDownload.js
+++ b/dev/core/src/com/google/gwt/core/ext/linker/impl/installScriptEarlyDownload.js
@@ -19,23 +19,15 @@ function installScript(filename) {
     var doc = getInstallLocationDoc();
     var docbody = doc.body;
     var script;
-    // for sourcemaps, we inject textNodes into the script element on Chrome
-    if (navigator.userAgent.indexOf("Chrome") > -1 && window.JSON) {
-      var scriptFrag = doc.createDocumentFragment()
-      // surround code with eval until crbug #90707 
-      scriptFrag.appendChild(doc.createTextNode("eval(\""));
+    // for sourcemaps, we inject the code as a single string for Chrome
+    if (navigator.userAgent.includes("Chrome")) {
+      var codeString = "";
       for (var i = 0; i < code.length; i++) {
-        // escape newlines, backslashes, and quotes with JSON.stringify
-        // rather than create multiple script tags which mess up line numbers, we use 1 tag, multiple text nodes
-        var c = window.JSON.stringify(code[i]); 
-        // trim beginning/end quotes
-        scriptFrag.appendChild(doc.createTextNode(c.substring(1, c.length - 1)));
+        codeString += code[i];
       }
-      // close the eval
-      scriptFrag.appendChild(doc.createTextNode("\");"));
       script = doc.createElement('script');
-      script.language='javascript';
-      script.appendChild(scriptFrag);
+      script.language = 'javascript';
+      script.text = codeString;
       docbody.appendChild(script);
       removeScript(docbody, script);
     } else {


### PR DESCRIPTION
The eval behavior in GWT is no longer needed since that chrome bug ([#90707](https://bugs.chromium.org/p/chromium/issues/detail?id=90707)) was fixed (it looked like the bug got lost in the weeds at some point.) Removing that behavior improves the performance of bootstrapping. It also coincidently fixes the referenced CSP issue.

Considered unifying the logic between browsers, but Safari took a bit of a perf hit when trying to insert a single large text.

Fixes https://github.com/gwtproject/gwt/issues/9725