### PR TITLE
Fixed set- and clearTimeout to make debugging working with Firefox

### DIFF
--- a/user/src/com/google/gwt/core/client/impl/Impl.java
+++ b/user/src/com/google/gwt/core/client/impl/Impl.java
@@ -393,7 +393,7 @@ public final class Impl {
   }-*/;
 
   private static native void watchdogEntryDepthCancel(int timerId) /*-{
-    $wnd.clearTimeout(timerId);
+    clearTimeout(timerId);
   }-*/;
 
   private static void watchdogEntryDepthRun() {
@@ -406,6 +406,6 @@ public final class Impl {
   }
 
   private static native int watchdogEntryDepthSchedule() /*-{
-    return $wnd.setTimeout(@Impl::watchdogEntryDepthRun(), 10);
+    return setTimeout(@Impl::watchdogEntryDepthRun(), 10);
   }-*/;
 }


### PR DESCRIPTION
This fixes a problem that only occurs in firefox while debugging.
Without the fix SDBG Users would be forced to super-source the Impl class.
After a few weeks of testing i did'nt find any negative effects on runtime, or in other browsers.
Has been discussed in #9787.
Fixes #9787
