### PR TITLE
Report the name of missing property on compile errror

### DIFF
--- a/dev/core/src/com/google/gwt/dev/jjs/impl/ResolvePermutationDependentValues.java
+++ b/dev/core/src/com/google/gwt/dev/jjs/impl/ResolvePermutationDependentValues.java
@@ -70,7 +70,12 @@ public class ResolvePermutationDependentValues {
       }
 
       assert x.isProperty();
-      ctx.replaceMe(propertyValueExpression(x));
+      try {
+        ctx.replaceMe(propertyValueExpression(x));
+      } catch (RuntimeException ex) {
+        throw new InternalCompilerException(x,
+                "Problem replacing '" + x.getRequestedValue() + "'", ex);
+      }
     }
 
     private JExpression propertyValueExpression(JPermutationDependentValue x) {


### PR DESCRIPTION
Fixes #9806

Wraps cryptic `NullPointerException` in internal compile exception to provide more context.

I didn't find any tests that would verify correct error messages from compiling invalid modules, if you think this needs a test please give me a pointer.