### PR TITLE
Migrate java9 tests to their own class, run java 8 on java 8

### DIFF
--- a/user/test-super/com/google/gwt/dev/jjs/super/com/google/gwt/dev/jjs/test/Java8Test.java
+++ b/user/test-super/com/google/gwt/dev/jjs/super/com/google/gwt/dev/jjs/test/Java8Test.java
@@ -2003,78 +2003,6 @@ public class Java8Test extends GWTTestCase {
     assertEquals(2, (int) unboxBox.apply(new Integer(2)));
   }
 
-  ////////////////////////////////////////////////////////////
-  //
-  //   Tests for language features introduced in Java 9
-
-  class Resource implements AutoCloseable {
-    boolean isOpen = true;
-
-    public void close() {
-      this.isOpen = false;
-    }
-  }
-
-  public void testTryWithResourcesJava9() {
-    Resource r1 = new Resource();
-    assertTrue(r1.isOpen);
-    Resource r2Copy;
-    try (r1; Resource r2 = new Resource()) {
-      assertTrue(r1.isOpen);
-      assertTrue(r2.isOpen);
-      r2Copy = r2;
-    }
-    assertFalse(r1.isOpen);
-    assertFalse(r2Copy.isOpen);
-  }
-
-  private interface InterfaceWithPrivateMethods {
-    int implementedMethod();
-
-    default int defaultMethod() {
-      return privateMethod();
-    }
-
-    private int privateMethod() {
-      return implementedMethod();
-    }
-
-    private int staticPrivateMethod() {
-      return 42;
-    }
-  }
-
-  public void testInterfacePrivateMethodsJava9() {
-    InterfaceWithPrivateMethods implementor = () -> 50;
-    assertEquals(50, implementor.implementedMethod());
-    assertEquals(50, implementor.defaultMethod());
-    assertEquals(42, implementor.staticPrivateMethod());
-  }
-
-  public void testAnonymousDiamondJava9() {
-    Supplier<String> helloSupplier = new Supplier<>() {
-      @Override
-      public String get() {
-        return "hello";
-      }
-    };
-    assertEquals("hello", helloSupplier.get());
-  }
-
-  interface Selector extends Predicate<String> {
-    @Override
-    boolean test(String object);
-
-    default Selector trueSelector() {
-      // Unused variable that creates a lambda with a bridge for the method test. The bug #9598
-      // was caused by GwtAstBuilder associating the bridge method Lambda.test(Object) on the
-      // lambda below to the method Predicate.test(Object), causing the method resolution in the
-      // code that refers to the Predicate.test(Object) in the test below to refer to
-      // Lambda.test(Object) which is the wrong method.
-      return receiver -> true;
-    }
-  }
-
   // Regression tests for #9598
   public void testImproperMethodResolution() {
     Predicate p = o -> true;
@@ -2099,11 +2027,11 @@ public class Java8Test extends GWTTestCase {
     assertEquals("#2", lambda.foo("2"));
   }
 
-  static class C { public static String append(String str) { return "#" + str; } }
+  static class C2 { public static String append(String str) { return "#" + str; } }
   @SuppressWarnings({"rawtypes", "unchecked"})
   public void testIntersectionCastMethodReference() {
 
-    Object instance = (I1 & I2<String>) C::append;
+    Object instance = (I1 & I2<String>) C2::append;
 
     assertTrue(instance instanceof I1);
     assertTrue(instance instanceof I2);

--- a/user/test-super/com/google/gwt/dev/jjs/super/com/google/gwt/dev/jjs/test/Java9Test.java
+++ b/user/test-super/com/google/gwt/dev/jjs/super/com/google/gwt/dev/jjs/test/Java9Test.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright 2023 GwtProject contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.gwt.dev.jjs.test;
+
+import com.google.gwt.core.client.GwtScriptOnly;
+import com.google.gwt.junit.client.GWTTestCase;
+
+import java.util.function.Predicate;
+import java.util.function.Supplier;
+
+@GwtScriptOnly
+public class Java9Test extends GWTTestCase {
+
+    @Override
+    public String getModuleName() {
+        return "com.google.gwt.dev.jjs.Java9Test";
+    }
+
+    class Resource implements AutoCloseable {
+        boolean isOpen = true;
+
+        public void close() {
+            this.isOpen = false;
+        }
+    }
+
+    public void testTryWithResourcesJava9() {
+        Resource r1 = new Resource();
+        assertTrue(r1.isOpen);
+        Resource r2Copy;
+        try (r1; Resource r2 = new Resource()) {
+            assertTrue(r1.isOpen);
+            assertTrue(r2.isOpen);
+            r2Copy = r2;
+        }
+        assertFalse(r1.isOpen);
+        assertFalse(r2Copy.isOpen);
+    }
+
+    interface Selector extends Predicate<String> {
+        @Override
+        boolean test(String object);
+
+        default Selector trueSelector() {
+            // Unused variable that creates a lambda with a bridge for the method test. The bug #9598
+            // was caused by GwtAstBuilder associating the bridge method Lambda.test(Object) on the
+            // lambda below to the method Predicate.test(Object), causing the method resolution in the
+            // code that refers to the Predicate.test(Object) in the test below to refer to
+            // Lambda.test(Object) which is the wrong method.
+            return receiver -> true;
+        }
+    }
+
+    private interface InterfaceWithPrivateMethods {
+        int implementedMethod();
+
+        default int defaultMethod() {
+            return privateMethod();
+        }
+
+        private int privateMethod() {
+            return implementedMethod();
+        }
+
+        private int staticPrivateMethod() {
+            return 42;
+        }
+    }
+
+    public void testInterfacePrivateMethodsJava9() {
+        InterfaceWithPrivateMethods implementor = () -> 50;
+        assertEquals(50, implementor.implementedMethod());
+        assertEquals(50, implementor.defaultMethod());
+        assertEquals(42, implementor.staticPrivateMethod());
+    }
+
+    public void testAnonymousDiamondJava9() {
+        Supplier<String> helloSupplier = new Supplier<>() {
+            @Override
+            public String get() {
+                return "hello";
+            }
+        };
+        assertEquals("hello", helloSupplier.get());
+    }
+}

--- a/user/test/com/google/gwt/dev/jjs/CompilerSuite.java
+++ b/user/test/com/google/gwt/dev/jjs/CompilerSuite.java
@@ -31,6 +31,7 @@ import com.google.gwt.dev.jjs.test.Java10Test;
 import com.google.gwt.dev.jjs.test.Java11Test;
 import com.google.gwt.dev.jjs.test.Java7Test;
 import com.google.gwt.dev.jjs.test.Java8Test;
+import com.google.gwt.dev.jjs.test.Java9Test;
 import com.google.gwt.dev.jjs.test.JavaAccessFromJavaScriptTest;
 import com.google.gwt.dev.jjs.test.JsniConstructorTest;
 import com.google.gwt.dev.jjs.test.JsniDispatchTest;
@@ -73,6 +74,7 @@ public class CompilerSuite {
     // Java8Test cannot be the first one in a suite. It uses a hack
     // to avoid executing if not in a Java 8+ environment.
     suite.addTestSuite(Java8Test.class);
+    suite.addTestSuite(Java9Test.class);
     suite.addTestSuite(Java10Test.class);
     suite.addTestSuite(Java11Test.class);
     suite.addTestSuite(JavaAccessFromJavaScriptTest.class);

--- a/user/test/com/google/gwt/dev/jjs/Java9Test.gwt.xml
+++ b/user/test/com/google/gwt/dev/jjs/Java9Test.gwt.xml
@@ -1,0 +1,19 @@
+<!--                                                                        -->
+<!-- Copyright 2014 Google Inc.                                             -->
+<!-- Licensed under the Apache License, Version 2.0 (the "License"); you    -->
+<!-- may not use this file except in compliance with the License. You may   -->
+<!-- may obtain a copy of the License at                                    -->
+<!--                                                                        -->
+<!-- http://www.apache.org/licenses/LICENSE-2.0                             -->
+<!--                                                                        -->
+<!-- Unless required by applicable law or agreed to in writing, software    -->
+<!-- distributed under the License is distributed on an "AS IS" BASIS,      -->
+<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or        -->
+<!-- implied. License for the specific language governing permissions and   -->
+<!-- limitations under the License.                                         -->
+
+<!-- Contains tests for breaking out of the client source path  -->
+<module>
+  <inherits name="com.google.gwt.core.Core" />
+  <super-source path='super' />
+</module>

--- a/user/test/com/google/gwt/dev/jjs/test/Java8Test.java
+++ b/user/test/com/google/gwt/dev/jjs/test/Java8Test.java
@@ -22,7 +22,7 @@ import com.google.gwt.junit.Platform;
 import com.google.gwt.junit.client.GWTTestCase;
 
 /**
- * Dummy test case. Java8Test is super sourced so that GWT can be compiled by Java 6.
+ * Dummy test case. Java8Test was historically super sourced so that GWT can be compiled by Java 6.
  *
  * NOTE: Make sure this class has the same test methods of its supersourced variant.
  */
@@ -36,8 +36,8 @@ public class Java8Test extends GWTTestCase {
 
   @Override
   public void runTest() throws Throwable {
-    // Only run these tests if -sourceLevel 9 (or greater) is enabled.
-    if (isGwtSourceLevel9()) {
+    // Only run these tests if -sourceLevel 8 (or greater) is enabled.
+    if (isGwtSourceLevel8()) {
       super.runTest();
     }
   }
@@ -45,330 +45,318 @@ public class Java8Test extends GWTTestCase {
   public void testLambdaNoCapture() {
     // Make sure we are using the right Java8Test if the source compatibility level is set to Java 8
     // or above.
-    assertFalse(isGwtSourceLevel9());
+    assertFalse(isGwtSourceLevel8());
   }
 
   public void testLambdaCaptureLocal() {
-    assertFalse(isGwtSourceLevel9());
+    assertFalse(isGwtSourceLevel8());
   }
 
   public void testLambdaCaptureLocalWithInnerClass() {
-    assertFalse(isGwtSourceLevel9());
+    assertFalse(isGwtSourceLevel8());
   }
 
   public void testLambdaCaptureLocalAndField() {
-    assertFalse(isGwtSourceLevel9());
+    assertFalse(isGwtSourceLevel8());
   }
 
   public void testLambdaCaptureLocalAndFieldWithInnerClass() {
-    assertFalse(isGwtSourceLevel9());
+    assertFalse(isGwtSourceLevel8());
   }
 
   public void testCompileLambdaCaptureOuterInnerField() throws Exception {
-    assertFalse(isGwtSourceLevel9());
+    assertFalse(isGwtSourceLevel8());
   }
 
   public void testStaticReferenceBinding() throws Exception {
-    assertFalse(isGwtSourceLevel9());
+    assertFalse(isGwtSourceLevel8());
   }
 
   public void testInstanceReferenceBinding() throws Exception {
-    assertFalse(isGwtSourceLevel9());
+    assertFalse(isGwtSourceLevel8());
   }
 
   public void testImplicitQualifierReferenceBinding() throws Exception {
-    assertFalse(isGwtSourceLevel9());
+    assertFalse(isGwtSourceLevel8());
   }
 
   public void testConstructorReferenceBinding() {
-    assertFalse(isGwtSourceLevel9());
+    assertFalse(isGwtSourceLevel8());
   }
 
   public void testStaticInterfaceMethod() {
-    assertFalse(isGwtSourceLevel9());
+    assertFalse(isGwtSourceLevel8());
   }
 
   public void testArrayConstructorReference() {
-    assertFalse(isGwtSourceLevel9());
+    assertFalse(isGwtSourceLevel8());
   }
 
   public void testArrayConstructorReferenceBoxed() {
-    assertFalse(isGwtSourceLevel9());
+    assertFalse(isGwtSourceLevel8());
   }
 
   public void testVarArgsReferenceBinding() {
-    assertFalse(isGwtSourceLevel9());
+    assertFalse(isGwtSourceLevel8());
   }
 
   public void testVarArgsPassthroughReferenceBinding() {
-    assertFalse(isGwtSourceLevel9());
+    assertFalse(isGwtSourceLevel8());
   }
 
   public void testVarArgsPassthroughReferenceBindingProvidedArray() {
-    assertFalse(isGwtSourceLevel9());
+    assertFalse(isGwtSourceLevel8());
   }
 
   public void testSuperReferenceExpression() {
-    assertFalse(isGwtSourceLevel9());
+    assertFalse(isGwtSourceLevel8());
   }
 
   public void testQualifiedSuperReferenceExpression() {
-    assertFalse(isGwtSourceLevel9());
+    assertFalse(isGwtSourceLevel8());
   }
 
   public void testSuperReferenceExpressionWithVarArgs() {
-    assertFalse(isGwtSourceLevel9());
+    assertFalse(isGwtSourceLevel8());
   }
 
   public void testPrivateConstructorReference() {
-    assertFalse(isGwtSourceLevel9());
+    assertFalse(isGwtSourceLevel8());
   }
 
   public void testDefaultInterfaceMethod() {
-    assertFalse(isGwtSourceLevel9());
+    assertFalse(isGwtSourceLevel8());
   }
 
   public void testDefaultInterfaceMethodVirtualUpRef() {
-    assertFalse(isGwtSourceLevel9());
+    assertFalse(isGwtSourceLevel8());
   }
 
   public void testInterfaceWithDefaultMethodsInitialization() {
-    assertFalse(isGwtSourceLevel9());
+    assertFalse(isGwtSourceLevel8());
   }
 
   public void testDefaultInterfaceMethodMultiple() {
-    assertFalse(isGwtSourceLevel9());
+    assertFalse(isGwtSourceLevel8());
   }
 
   public void testDefaultMethodReference() {
-    assertFalse(isGwtSourceLevel9());
+    assertFalse(isGwtSourceLevel8());
   }
 
   public void testDefenderMethodByInterfaceInstance() {
-    assertFalse(isGwtSourceLevel9());
+    assertFalse(isGwtSourceLevel8());
   }
 
   public void testDefaultMethod_staticInitializer() {
-    assertFalse(isGwtSourceLevel9());
+    assertFalse(isGwtSourceLevel8());
   }
 
   public void testThisRefInDefenderMethod() {
-    assertFalse(isGwtSourceLevel9());
+    assertFalse(isGwtSourceLevel8());
   }
 
   public void testClassImplementsTwoInterfacesWithSameDefenderMethod() {
-    assertFalse(isGwtSourceLevel9());
+    assertFalse(isGwtSourceLevel8());
   }
 
   public void testAbstractClassImplementsInterface() {
-    assertFalse(isGwtSourceLevel9());
+    assertFalse(isGwtSourceLevel8());
   }
 
   public void testSuperRefInDefenderMethod() {
-    assertFalse(isGwtSourceLevel9());
+    assertFalse(isGwtSourceLevel8());
   }
 
   public void testSuperThisRefsInDefenderMethod() {
-    assertFalse(isGwtSourceLevel9());
+    assertFalse(isGwtSourceLevel8());
   }
 
   public void testNestedInterfaceClass() {
-    assertFalse(isGwtSourceLevel9());
+    assertFalse(isGwtSourceLevel8());
   }
 
   public void testBaseIntersectionCast() {
-    assertFalse(isGwtSourceLevel9());
+    assertFalse(isGwtSourceLevel8());
   }
 
   public void testIntersectionCastWithLambdaExpr() {
-    assertFalse(isGwtSourceLevel9());
+    assertFalse(isGwtSourceLevel8());
   }
 
   public void testIntersectionCastPolymorphism() {
-    assertFalse(isGwtSourceLevel9());
+    assertFalse(isGwtSourceLevel8());
   }
 
   public void testLambdaCaptureParameter() {
-    assertFalse(isGwtSourceLevel9());
+    assertFalse(isGwtSourceLevel8());
   }
 
   public void testLambdaNestingCaptureLocal() {
-    assertFalse(isGwtSourceLevel9());
+    assertFalse(isGwtSourceLevel8());
   }
 
   public void testLambdaNestingInAnonymousCaptureLocal() {
-    assertFalse(isGwtSourceLevel9());
+    assertFalse(isGwtSourceLevel8());
   }
 
   public void testLambdaNestingInMultipleMixedAnonymousCaptureLocal() {
-    assertFalse(isGwtSourceLevel9());
+    assertFalse(isGwtSourceLevel8());
   }
 
   public void testLambdaNestingInMultipleMixedAnonymousCaptureLocal_withInterference() {
-    assertFalse(isGwtSourceLevel9());
+    assertFalse(isGwtSourceLevel8());
   }
 
   public void testLambdaNestingInMultipleMixedAnonymousCaptureLocalAndField() {
-    assertFalse(isGwtSourceLevel9());
+    assertFalse(isGwtSourceLevel8());
   }
 
   public void testLambdaNestingInMultipleAnonymousCaptureLocal() {
-    assertFalse(isGwtSourceLevel9());
+    assertFalse(isGwtSourceLevel8());
   }
 
   public void testLambdaNestingCaptureField_InnerClassCapturingOuterClassVariable() {
-    assertFalse(isGwtSourceLevel9());
+    assertFalse(isGwtSourceLevel8());
   }
 
   public void testInnerClassCaptureLocalFromOuterLambda() {
-    assertFalse(isGwtSourceLevel9());
+    assertFalse(isGwtSourceLevel8());
   }
 
   public void testLambdaNestingCaptureField() {
-    assertFalse(isGwtSourceLevel9());
+    assertFalse(isGwtSourceLevel8());
   }
 
   public void testLambdaMultipleNestingCaptureFieldAndLocal() {
-    assertFalse(isGwtSourceLevel9());
+    assertFalse(isGwtSourceLevel8());
   }
 
   public void testLambdaMultipleNestingCaptureFieldAndLocalInnerClass() {
-    assertFalse(isGwtSourceLevel9());
+    assertFalse(isGwtSourceLevel8());
   }
 
   public void testMethodRefWithSameName() {
-    assertFalse(isGwtSourceLevel9());
+    assertFalse(isGwtSourceLevel8());
   }
 
   public void testMultipleDefaults_fromInterfaces_left() {
-    assertFalse(isGwtSourceLevel9());
+    assertFalse(isGwtSourceLevel8());
   }
 
   public void testMultipleDefaults_fromInterfaces_right() {
-    assertFalse(isGwtSourceLevel9());
+    assertFalse(isGwtSourceLevel8());
   }
 
   public void testMultipleDefaults_superclass_left() {
-    assertFalse(isGwtSourceLevel9());
+    assertFalse(isGwtSourceLevel8());
   }
 
   public void testMultipleDefaults_superclass_right() {
-    assertFalse(isGwtSourceLevel9());
+    assertFalse(isGwtSourceLevel8());
   }
 
   public void testMultipleDefaults_defaultShadowsOverSyntheticAbstractStub() {
-    assertFalse(isGwtSourceLevel9());
+    assertFalse(isGwtSourceLevel8());
   }
 
   public void testMultipleDefaults_defaultShadowsOverDefaultOnSuperAbstract() {
-    assertFalse(isGwtSourceLevel9());
+    assertFalse(isGwtSourceLevel8());
   }
 
   public void testInterfaceThis() {
-    assertFalse(isGwtSourceLevel9());
+    assertFalse(isGwtSourceLevel8());
   }
 
   public void testMethodReference_generics() {
-    assertFalse(isGwtSourceLevel9());
+    assertFalse(isGwtSourceLevel8());
   }
 
   public void testNativeJsTypeWithStaticInitializer() {
-    assertFalse(isGwtSourceLevel9());
+    assertFalse(isGwtSourceLevel8());
   }
 
   public void testJsVarargsLambda() {
-    assertFalse(isGwtSourceLevel9());
+    assertFalse(isGwtSourceLevel8());
   }
 
   public void testMethodReference_implementedInSuperclass() {
-    assertFalse(isGwtSourceLevel9());
+    assertFalse(isGwtSourceLevel8());
   }
 
   public void testMethodReference_genericTypeParameters() {
-    assertFalse(isGwtSourceLevel9());
+    assertFalse(isGwtSourceLevel8());
   }
 
   public void testMethodReference_autoboxing() {
-    assertFalse(isGwtSourceLevel9());
+    assertFalse(isGwtSourceLevel8());
   }
 
   public void testMethodReference_varargs() {
-    assertFalse(isGwtSourceLevel9());
+    assertFalse(isGwtSourceLevel8());
   }
 
   public void testNativeJsOverlay_lambda() {
-    assertFalse(isGwtSourceLevel9());
+    assertFalse(isGwtSourceLevel8());
   }
 
   public void testLambdaCapturingThis_onDefaultMethod() {
-    assertFalse(isGwtSourceLevel9());
+    assertFalse(isGwtSourceLevel8());
   }
 
   public void testJsFunction_withOverlay() {
-    assertFalse(isGwtSourceLevel9());
+    assertFalse(isGwtSourceLevel8());
   }
 
   public void testFunctionalExpressionBridges() {
-    assertFalse(isGwtSourceLevel9());
+    assertFalse(isGwtSourceLevel8());
   }
 
   public void testCorrectNaming() {
-    assertFalse(isGwtSourceLevel9());
+    assertFalse(isGwtSourceLevel8());
   }
 
   public void testInterfaceWithOverlayAndNativeSubclass() {
-    assertFalse(isGwtSourceLevel9());
+    assertFalse(isGwtSourceLevel8());
   }
 
   public void testLocalClassConstructorReferenceInStaticMethod() {
-    assertFalse(isGwtSourceLevel9());
+    assertFalse(isGwtSourceLevel8());
   }
 
   public void testDefaultMethodDevirtualizationOrder() {
-    assertFalse(isGwtSourceLevel9());
+    assertFalse(isGwtSourceLevel8());
   }
 
   public void testVarargsFunctionalConversion() {
-    assertFalse(isGwtSourceLevel9());
+    assertFalse(isGwtSourceLevel8());
   }
 
   public void testJSOLivenessSingleImplErasure() {
-    assertFalse(isGwtSourceLevel9());
+    assertFalse(isGwtSourceLevel8());
   }
 
   public void testLambdaErasureCasts() {
-    assertFalse(isGwtSourceLevel9());
+    assertFalse(isGwtSourceLevel8());
   }
 
   public void testLambdaBoxing() {
-    assertFalse(isGwtSourceLevel9());
-  }
-
-  public void testTryWithResourcesJava9() {
-    assertFalse(isGwtSourceLevel9());
-  }
-
-  public void testInterfacePrivateMethodsJava9() {
-    assertFalse(isGwtSourceLevel9());
-  }
-
-  public void testAnonymousDiamondJava9() {
-    assertFalse(isGwtSourceLevel9());
+    assertFalse(isGwtSourceLevel8());
   }
 
   public void testImproperMethodResolution() {
-    assertFalse(isGwtSourceLevel9());
+    assertFalse(isGwtSourceLevel8());
   }
 
   public void testIntersectionCastLambda() {
-    assertFalse(isGwtSourceLevel9());
+    assertFalse(isGwtSourceLevel8());
   }
 
   public void testIntersectionCastMethodReference() {
-    assertFalse(isGwtSourceLevel9());
+    assertFalse(isGwtSourceLevel8());
   }
 
-  private boolean isGwtSourceLevel9() {
-    return JUnitShell.getCompilerOptions().getSourceLevel().compareTo(SourceLevel.JAVA9) >= 0;
+  private boolean isGwtSourceLevel8() {
+    return JUnitShell.getCompilerOptions().getSourceLevel().compareTo(SourceLevel.JAVA8) >= 0;
   }
 }

--- a/user/test/com/google/gwt/dev/jjs/test/Java9Test.java
+++ b/user/test/com/google/gwt/dev/jjs/test/Java9Test.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 GwtProject contributors
+ * Copyright 2023 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/user/test/com/google/gwt/dev/jjs/test/Java9Test.java
+++ b/user/test/com/google/gwt/dev/jjs/test/Java9Test.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023 GwtProject contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
 package com.google.gwt.dev.jjs.test;
 
 import com.google.gwt.dev.util.arg.SourceLevel;

--- a/user/test/com/google/gwt/dev/jjs/test/Java9Test.java
+++ b/user/test/com/google/gwt/dev/jjs/test/Java9Test.java
@@ -1,0 +1,44 @@
+package com.google.gwt.dev.jjs.test;
+
+import com.google.gwt.dev.util.arg.SourceLevel;
+import com.google.gwt.junit.DoNotRunWith;
+import com.google.gwt.junit.JUnitShell;
+import com.google.gwt.junit.Platform;
+import com.google.gwt.junit.client.GWTTestCase;
+
+/**
+ * Dummy test case. Java9Test is super sourced so that GWT can be compiled by Java 8.
+ *
+ * NOTE: Make sure this class has the same test methods of its supersourced variant.
+ */
+@DoNotRunWith(Platform.Devel)
+public class Java9Test extends GWTTestCase {
+    @Override
+    public String getModuleName() {
+        return "com.google.gwt.dev.jjs.Java9Test";
+    }
+
+    @Override
+    public void runTest() throws Throwable {
+        // Only run these tests if -sourceLevel 9 (or greater) is enabled.
+        if (isGwtSourceLevel9()) {
+            super.runTest();
+        }
+    }
+
+    public void testTryWithResourcesJava9() {
+        assertFalse(isGwtSourceLevel9());
+    }
+
+    public void testInterfacePrivateMethodsJava9() {
+        assertFalse(isGwtSourceLevel9());
+    }
+
+    public void testAnonymousDiamondJava9() {
+        assertFalse(isGwtSourceLevel9());
+    }
+
+    private boolean isGwtSourceLevel9() {
+        return JUnitShell.getCompilerOptions().getSourceLevel().compareTo(SourceLevel.JAVA9) >= 0;
+    }
+}


### PR DESCRIPTION
Also corrects a compile error that went unnoticed in the Java 8 test, since these tests were never run even under Java 8. 

Once #9780 is merged, we can either switch to `-sourceLevel auto` or `-sourceLevel 11`, depending on what legacy dev mode breakage is acceptable and what Java versions we run tests on.

Partial fix for #9813 

