### PR TITLE
Correct Java versions numbers to support -sourceLevel auto

### DIFF
--- a/dev/core/src/com/google/gwt/dev/util/arg/SourceLevel.java
+++ b/dev/core/src/com/google/gwt/dev/util/arg/SourceLevel.java
@@ -24,9 +24,9 @@ import com.google.gwt.util.tools.Utility;
 public enum SourceLevel {
   // Source levels must appear in ascending order for the default setting logic to work.
   JAVA8("1.8", "8"),
-  JAVA9("1.9", "9"),
-  JAVA10("1.10", "10"),
-  JAVA11("1.11", "11");
+  JAVA9("9", "1.9"),
+  JAVA10("10", "1.10"),
+  JAVA11("11", "1.11");
 
   /**
    * The default java sourceLevel.
@@ -85,7 +85,7 @@ public enum SourceLevel {
   @VisibleForTesting
   public static SourceLevel getBestMatchingVersion(String javaVersionString) {
     try {
-      // Find the first version that is less than or equal to javaSpecLevel by iterating in reverse
+      // Find the last version that is less than or equal to javaSpecLevel by iterating in reverse
       // order.
       SourceLevel[] sourceLevels = SourceLevel.values();
       for (int i = sourceLevels.length - 1; i >= 0; i--) {

--- a/dev/core/test/com/google/gwt/dev/CompilerTest.java
+++ b/dev/core/test/com/google/gwt/dev/CompilerTest.java
@@ -957,9 +957,9 @@ public class CompilerTest extends ArgProcessorTestBase {
 
     assertEquals(SourceLevel.JAVA8, SourceLevel.getBestMatchingVersion("1.7"));
     assertEquals(SourceLevel.JAVA8, SourceLevel.getBestMatchingVersion("1.8"));
-    assertEquals(SourceLevel.JAVA9, SourceLevel.getBestMatchingVersion("1.9"));
-    assertEquals(SourceLevel.JAVA10, SourceLevel.getBestMatchingVersion("1.10"));
-    assertEquals(SourceLevel.JAVA11, SourceLevel.getBestMatchingVersion("1.11"));
+    assertEquals(SourceLevel.JAVA9, SourceLevel.getBestMatchingVersion("9"));
+    assertEquals(SourceLevel.JAVA10, SourceLevel.getBestMatchingVersion("10"));
+    assertEquals(SourceLevel.JAVA11, SourceLevel.getBestMatchingVersion("11"));
 
     // not proper version strings => default to JAVA8.
     assertEquals(SourceLevel.JAVA8, SourceLevel.getBestMatchingVersion("1.6u3"));


### PR DESCRIPTION
Starting in Java 9, the value of the system property java.specification.version has been an integer, with no "1." prefix. As a result, using -sourceLevel auto with any version 9 and above has automatically used the latest version of Java that GWT supports, rather than an actual matching version.

This doesn't matter a lot today for Java 9 and 10, but with coming Java 17 support while 8 and 11 are still allowed, it may make a difference.

The altStringValues have been updated to still use the 1.x versions for backward compatibility.

Partial fix for #9813