### PR TITLE
Proposal to update Javadoc to 17

### DIFF
--- a/build_tools/doctool/src/com/google/doctool/custom/JavaEmulSummaryDoclet.java
+++ b/build_tools/doctool/src/com/google/doctool/custom/JavaEmulSummaryDoclet.java
@@ -53,7 +53,7 @@ import java.util.stream.Stream;
 public class JavaEmulSummaryDoclet implements Doclet {
 
     public static final String OPT_OUTFILE = "-outfile";
-    private static final String JAVADOC_URL = "https://docs.oracle.com/javase/8/docs/api/";
+    private static final String JAVADOC_URL = "https://docs.oracle.com/en/java/javase/11/docs/api/";
 
     private Reporter reporter;
     private String outputFile;

--- a/doc/build.xml
+++ b/doc/build.xml
@@ -83,17 +83,14 @@
              access="package"
              packagenames="${USER_PKGS}"
              sourcefiles="${USER_CLASSES}"
-             noindex="true"
              notree="true"
              use="true"
              windowtitle="GWT Javadoc"
              doctitle="GWT API Reference"
              header="GWT ${gwt.version}"
-             linkoffline="http://download.oracle.com/javaee/6/api/ validation-package-list">
+             linkoffline="https://docs.oracle.com/en/java/javase/11/docs/api/ validation-package-list">
       <!-- suppress errors that don't break the output, we should refine this to just suppress things we haven't fixed yet -->
       <arg value="-Xdoclint:none" />
-      <!-- re-enable frames for now, until we get to >=13 and have search -->
-      <arg value="--frames" />
       <classpath refid="USER_CLASS_PATH" />
       <sourcepath refid="USER_SOURCE_PATH" />
 

--- a/doc/build.xml
+++ b/doc/build.xml
@@ -83,7 +83,6 @@
              access="package"
              packagenames="${USER_PKGS}"
              sourcefiles="${USER_CLASSES}"
-             notree="true"
              use="true"
              windowtitle="GWT Javadoc"
              doctitle="GWT API Reference"


### PR DESCRIPTION
This draft PR is to discuss updating the version of Java we use to produce GWT's Javadoc output, and to capture some of the changes that would make sense.

For a start, I've updated the two links to the JRE's own docs, so that we able to reference newer classes and methods as necessary. Note that this only affects the JRE Emulation at this time, as the source level for gwt-dev and gwt-user are still set to Java 8.

Next, for Java 13+'s search capability, I've re-enabled the `index` feature of Javadoc. It isn't clear to me why we had this disabled to begin with - perhaps we should also re-enable `tree`?

Finally, at least for Java >11 builds, I've removed the --frames flag. If we decide to go with a newer build of Java like this (to support search, etc), we will not be able to use this flag.

The advantage of an older Javadoc build is to keep the "familiar" frames layout, while the newer Javadoc builds give us client-side search.

| Java version | Frames? | Search? | Link |
|--|--|--|--|
|8|yes|no|https://www.gwtproject.org/javadoc/latest/|
|11|yes|no|https://www.colinalworth.com/gwt-javadoc/java11/javadoc/ or https://www.colinalworth.com/gwt-javadoc/java11/javadoc/overview-summary.html to have frames|
|17|no|yes|https://www.colinalworth.com/gwt-javadoc/java17/javadoc/|
|19|no|yes|https://www.colinalworth.com/gwt-javadoc/java19/javadoc/|

JRE Emulation is the same for all builds, but the links now point at Java 11. Example: https://www.colinalworth.com/gwt-javadoc/java17/emul-ezt/fragment.html

---

The only reason I would see to not update to Java 17+ would be to retain the frames view. Is there any reason we might want to keep the frames view, or should we just jump ahead here and assume the latest version going forward?