### PR TITLE
Deprecate and remove references to RPCServletUtils.CHARSET_UTF8

### DIFF
--- a/user/src/com/google/gwt/user/server/rpc/RPCServletUtils.java
+++ b/user/src/com/google/gwt/user/server/rpc/RPCServletUtils.java
@@ -21,6 +21,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.lang.reflect.Method;
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.util.Locale;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.zip.GZIPOutputStream;
@@ -35,15 +36,16 @@ import javax.servlet.http.HttpServletResponse;
  * the RPC system.
  */
 public class RPCServletUtils {
-  
+
   public static final String CHARSET_UTF8_NAME = "UTF-8";
-  
+
   /**
-   * The UTF-8 Charset. Use this to avoid concurrency bottlenecks when
-   * converting between byte arrays and Strings.
-   * See http://code.google.com/p/google-web-toolkit/issues/detail?id=6398
+   * The UTF-8 Charset.
+   *
+   * Deprecated: please use {@link StandardCharsets#UTF_8} instead.
    */
-  public static final Charset CHARSET_UTF8 = Charset.forName(CHARSET_UTF8_NAME);
+  @Deprecated
+  public static final Charset CHARSET_UTF8 = StandardCharsets.UTF_8;
 
   /**
    * Package protected for use in tests.
@@ -73,17 +75,16 @@ public class RPCServletUtils {
   private static final int UNCOMPRESSED_BYTE_SIZE_LIMIT = 256;
 
   /**
-   * Contains cached mappings from character set name to Charset. The
-   * null key maps to the default UTF-8 character set.
+   * Contains cached mappings from character set name to Charset.
    */
   private static final ConcurrentHashMap<String, Charset> CHARSET_CACHE =
       new ConcurrentHashMap<String, Charset>();
 
-  /**
-   * Pre-populate the character set cache with UTF-8.
+  /*
+    Pre-populate the character set cache with UTF-8.
    */
   static {
-    CHARSET_CACHE.put(CHARSET_UTF8_NAME, CHARSET_UTF8);
+    CHARSET_CACHE.put(CHARSET_UTF8_NAME, StandardCharsets.UTF_8);
   }
 
   /**
@@ -131,7 +132,7 @@ public class RPCServletUtils {
   public static Charset getCharset(String encoding) {
         
     if (encoding == null) {
-      return CHARSET_UTF8;
+      return StandardCharsets.UTF_8;
     }
     
     Charset charset = CHARSET_CACHE.get(encoding);
@@ -335,7 +336,7 @@ public class RPCServletUtils {
       HttpServletResponse response, String responseContent, boolean gzipResponse)
       throws IOException {
 
-    byte[] responseBytes = responseContent.getBytes(CHARSET_UTF8);
+    byte[] responseBytes = responseContent.getBytes(StandardCharsets.UTF_8);
     if (gzipResponse) {
       // Compress the reply and adjust headers.
       //
@@ -396,7 +397,7 @@ public class RPCServletUtils {
       response.setContentType("text/plain");
       response.setStatus(HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
       try {
-        response.getOutputStream().write(GENERIC_FAILURE_MSG.getBytes(CHARSET_UTF8));
+        response.getOutputStream().write(GENERIC_FAILURE_MSG.getBytes(StandardCharsets.UTF_8));
       } catch (IllegalStateException e) {
         // Handle the (unexpected) case where getWriter() was previously used
         response.getWriter().write(GENERIC_FAILURE_MSG);

--- a/user/src/com/google/gwt/user/server/rpc/impl/SerializabilityUtil.java
+++ b/user/src/com/google/gwt/user/server/rpc/impl/SerializabilityUtil.java
@@ -21,7 +21,6 @@ import com.google.gwt.user.client.rpc.GwtTransient;
 import com.google.gwt.user.client.rpc.SerializationException;
 import com.google.gwt.user.client.rpc.SerializationStreamReader;
 import com.google.gwt.user.client.rpc.SerializationStreamWriter;
-import com.google.gwt.user.server.rpc.RPCServletUtils;
 import com.google.gwt.user.server.rpc.SerializationPolicy;
 import com.google.gwt.user.server.rpc.ServerCustomFieldSerializer;
 
@@ -34,6 +33,7 @@ import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
 import java.lang.reflect.TypeVariable;
 import java.lang.reflect.WildcardType;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Comparator;
@@ -896,7 +896,7 @@ public class SerializabilityUtil {
 
   private static void generateSerializationSignature(Class<?> instanceType, CRC32 crc,
       SerializationPolicy policy) throws UnsupportedEncodingException {
-    crc.update(getSerializedTypeName(instanceType).getBytes(RPCServletUtils.CHARSET_UTF8));
+    crc.update(getSerializedTypeName(instanceType).getBytes(StandardCharsets.UTF_8));
 
     if (excludeImplementationFromSerializationSignature(instanceType)) {
       return;
@@ -913,7 +913,7 @@ public class SerializabilityUtil {
       }
       Enum<?>[] constants = instanceType.asSubclass(Enum.class).getEnumConstants();
       for (Enum<?> constant : constants) {
-        crc.update(constant.name().getBytes(RPCServletUtils.CHARSET_UTF8));
+        crc.update(constant.name().getBytes(StandardCharsets.UTF_8));
       }
     } else if (!instanceType.isPrimitive()) {
       Field[] fields = applyFieldSerializationPolicy(instanceType, policy);
@@ -925,8 +925,8 @@ public class SerializabilityUtil {
          * generate the signature. Otherwise, use all known fields.
          */
         if ((clientFieldNames == null) || clientFieldNames.contains(field.getName())) {
-          crc.update(field.getName().getBytes(RPCServletUtils.CHARSET_UTF8));
-          crc.update(getSerializedTypeName(field.getType()).getBytes(RPCServletUtils.CHARSET_UTF8));
+          crc.update(field.getName().getBytes(StandardCharsets.UTF_8));
+          crc.update(getSerializedTypeName(field.getType()).getBytes(StandardCharsets.UTF_8));
         }
       }
 

--- a/user/test/com/google/gwt/user/server/rpc/RPCServletUtilsTest.java
+++ b/user/test/com/google/gwt/user/server/rpc/RPCServletUtilsTest.java
@@ -24,6 +24,7 @@ import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 
 import javax.servlet.ReadListener;
 import javax.servlet.ServletException;
@@ -200,8 +201,8 @@ public class RPCServletUtilsTest extends TestCase {
    * default UTF-8 character set when passed a null encoding value.
    */
   public void testGetDefaultCharset() {
-    assertEquals(Charset.forName("UTF-8"), RPCServletUtils.CHARSET_UTF8);
-    assertSame(RPCServletUtils.CHARSET_UTF8, RPCServletUtils.getCharset(null));
+    assertEquals(Charset.forName("UTF-8"), StandardCharsets.UTF_8);
+    assertSame(StandardCharsets.UTF_8, RPCServletUtils.getCharset(null));
   }
 
   /**


### PR DESCRIPTION
This was necessary pre-Java7 to avoid blocking on java.nio.charset.Charset operations, though this is unnecessary for our use case through the use of java.nio.charset.StandardCharsets for the default UTF8 charset.

Additionally, this removes a dependency on javax.servlet specific code from generic code that could be shared with a jakarta.servlet implementation.

See #6397
Partial #9727
