### PR TITLE
Run build, tests in Java 17

### DIFF
--- a/.github/workflows/full-check.yml
+++ b/.github/workflows/full-check.yml
@@ -1,7 +1,7 @@
-# Run all tests and builds all aspects of GWT using Java 8 and 11. Runs nightly
-# (plus or minus timzeones) on the main branch, and will also run right away on
-# a push to a release branch. Release zips are uploaded as part of the build,
-# though maven snapshots are not yet deployed.
+# Run all tests and builds all aspects of GWT using Java 8, 11, and 17. Runs
+# nightly (plus or minus timzeones) on the main branch, and will also run right
+# away on a push to a release branch. Release zips are uploaded as part of the
+# build, though maven snapshots are not yet deployed.
 name: Full build
 on:
   schedule:
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        java-version: [ '8', '11' ]
+        java-version: [ '8', '11', '17' ]
     steps:
       - name: Checkout GWT itself into one directory
         uses: actions/checkout@v2
@@ -83,7 +83,7 @@ jobs:
       - name: Set up sonatype credentials
         # Using the same java version as above, set up a settings.xml file
         uses: actions/setup-java@v3
-        if: ${{ github.event_name == 'schedule' && github.repository_owner == 'gwtproject' && matrix.java-version == '11' }}
+        if: ${{ github.event_name == 'schedule' && github.repository_owner == 'gwtproject' && matrix.java-version == '17' }}
         with:
           java-version: ${{ matrix.java-version }}
           distribution: 'temurin'
@@ -93,7 +93,7 @@ jobs:
           server-password: SONATYPE_PASSWORD
 
       - name: Nightly builds should be deployed as snapshots to sonatype
-        if: ${{ github.event_name == 'schedule' && github.repository_owner == 'gwtproject' && matrix.java-version == '11' }}
+        if: ${{ github.event_name == 'schedule' && github.repository_owner == 'gwtproject' && matrix.java-version == '17' }}
         env:
           SONATYPE_USERNAME: ${{ secrets.SONATYPE_USERNAME }}
           SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}

--- a/.github/workflows/quick-check.yml
+++ b/.github/workflows/quick-check.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        java-version: ['8', '11']
+        java-version: ['8', '11', '17']
     steps:
       - name: Checkout GWT itself into one directory
         uses: actions/checkout@v2
@@ -22,7 +22,7 @@ jobs:
           repository: 'gwtproject/tools'
           path: 'tools'
       - name: Set up JDK ${{ matrix.java-version }}
-        # GWT presently requires Java8 to build just the SDK and some tests, or 11 to build everything, but can run on newer Java versions
+        # GWT presently requires Java8 to build just the SDK and some tests, or 11+ to build everything, and can run on newer Java versions
         uses: actions/setup-java@v3
         with:
           java-version: ${{ matrix.java-version }}
@@ -44,8 +44,8 @@ jobs:
             ANT_OPTS=-Xmx2g
           ant clean dist doc checkstyle apicheck
 
-      - name: Create pull request comments/annotations for checkstyle from the java 11 build, even on failure
-        if: ${{ always() && github.event_name == 'pull_request' && matrix.java-version == '11' }}
+      - name: Create pull request comments/annotations for checkstyle from the java 17 build, even on failure
+        if: ${{ always() && github.event_name == 'pull_request' && matrix.java-version == '17' }}
         env:
           REVIEWDOG_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
@@ -58,7 +58,7 @@ jobs:
           done
       - name: Upload checkstyle xml for manual review
         uses: actions/upload-artifact@v2
-        if: ${{ matrix.java-version == '11' }}
+        if: ${{ matrix.java-version == '17' }}
         with:
           name: checkstyle-reports-java${{ matrix.java-version }}
           path: 'gwt/build/out/**/checkstyle*.xml'

--- a/build_tools/doctool/src/com/google/doctool/custom/JavaEmulSummaryDoclet.java
+++ b/build_tools/doctool/src/com/google/doctool/custom/JavaEmulSummaryDoclet.java
@@ -53,7 +53,7 @@ import java.util.stream.Stream;
 public class JavaEmulSummaryDoclet implements Doclet {
 
     public static final String OPT_OUTFILE = "-outfile";
-    private static final String JAVADOC_URL = "https://docs.oracle.com/javase/8/docs/api/";
+    private static final String JAVADOC_URL = "https://docs.oracle.com/en/java/javase/11/docs/api/";
 
     private Reporter reporter;
     private String outputFile;

--- a/common.ant.xml
+++ b/common.ant.xml
@@ -251,6 +251,7 @@
         <jvmarg value="-Demma.coverage.out.merge=true"/>
         <jvmarg value="-Dcom.google.gwt.junit.reportPath=reports"/>
         <jvmarg line="@{test.jvmargs}"/>
+        <jvmarg line="--add-opens=java.base/java.lang=ALL-UNNAMED" unless:true="${isJava8}"/>
         <sysproperty key="gwt.args" value="@{test.args}"/>
         <sysproperty key="java.awt.headless" value="true"/>
         <classpath>

--- a/dev/core/src/com/google/gwt/dev/javac/BytecodeSignatureMaker.java
+++ b/dev/core/src/com/google/gwt/dev/javac/BytecodeSignatureMaker.java
@@ -56,7 +56,7 @@ public class BytecodeSignatureMaker {
     private Map<String, String> methods = new HashMap<String, String>();
 
     public CompileDependencyVisitor() {
-      super(Opcodes.ASM7);
+      super(Opcodes.ASM9);
     }
 
     public String getSignature() {

--- a/dev/core/src/com/google/gwt/dev/javac/CompilationUnit.java
+++ b/dev/core/src/com/google/gwt/dev/javac/CompilationUnit.java
@@ -66,7 +66,7 @@ public abstract class CompilationUnit implements Serializable {
 
       public AnonymousClassVisitor() {
 
-        this.mv = new org.objectweb.asm.MethodVisitor(Opcodes.ASM7, this.mv) {
+        this.mv = new org.objectweb.asm.MethodVisitor(Opcodes.ASM9, this.mv) {
           @Override
           public void visitCode() {
             ++sawCode;

--- a/dev/core/src/com/google/gwt/dev/javac/asm/CollectAnnotationData.java
+++ b/dev/core/src/com/google/gwt/dev/javac/asm/CollectAnnotationData.java
@@ -79,7 +79,7 @@ public class CollectAnnotationData extends AnnotationVisitor {
     private final List<Object> values = new ArrayList<Object>();
 
     public MyAnnotationArrayVisitor(Callback<Object> callback) {
-      super(Opcodes.ASM7);
+      super(Opcodes.ASM9);
       this.callback = callback;
     }
 
@@ -158,7 +158,7 @@ public class CollectAnnotationData extends AnnotationVisitor {
    */
   CollectAnnotationData(String desc, boolean visible,
       Callback<CollectAnnotationData.AnnotationData> callback) {
-    super(Opcodes.ASM7);
+    super(Opcodes.ASM9);
     annotation = new AnnotationData(desc, visible);
     this.callback = callback;
   }

--- a/dev/core/src/com/google/gwt/dev/javac/asm/CollectFieldData.java
+++ b/dev/core/src/com/google/gwt/dev/javac/asm/CollectFieldData.java
@@ -36,7 +36,7 @@ public class CollectFieldData extends FieldVisitor {
 
   public CollectFieldData(int access, String name, String desc,
       String signature, Object value) {
-    super(Opcodes.ASM7);
+    super(Opcodes.ASM9);
     this.access = access;
     this.name = name;
     this.desc = desc;

--- a/dev/core/src/com/google/gwt/dev/javac/asm/CollectMethodData.java
+++ b/dev/core/src/com/google/gwt/dev/javac/asm/CollectMethodData.java
@@ -58,7 +58,7 @@ public class CollectMethodData extends MethodVisitor {
   // for new List[]
   public CollectMethodData(CollectClassData.ClassType classType, int access,
       String name, String desc, String signature, String[] exceptions) {
-    super(Opcodes.ASM7);
+    super(Opcodes.ASM9);
     this.access = access;
     this.name = name;
     this.desc = desc;

--- a/dev/core/src/com/google/gwt/dev/javac/asm/CollectReferencesVisitor.java
+++ b/dev/core/src/com/google/gwt/dev/javac/asm/CollectReferencesVisitor.java
@@ -42,7 +42,7 @@ public class CollectReferencesVisitor extends EmptyVisitor {
   private class CollectGenericTypes extends SignatureVisitor {
 
     public CollectGenericTypes() {
-      super(Opcodes.ASM7);
+      super(Opcodes.ASM9);
     }
 
     @Override
@@ -121,7 +121,7 @@ public class CollectReferencesVisitor extends EmptyVisitor {
   }
 
   CollectReferencesVisitor() {
-    this.av = new AnnotationVisitor(Opcodes.ASM7, this.av) {
+    this.av = new AnnotationVisitor(Opcodes.ASM9, this.av) {
       @Override
       public void visitEnum(String name, String desc, String value) {
         addTypeIfClass(desc);

--- a/dev/core/src/com/google/gwt/dev/javac/asm/EmptySignatureVisitor.java
+++ b/dev/core/src/com/google/gwt/dev/javac/asm/EmptySignatureVisitor.java
@@ -34,7 +34,7 @@ public class EmptySignatureVisitor extends SignatureVisitor {
   protected static EmptySignatureVisitor ignore = new EmptySignatureVisitor();
 
   public EmptySignatureVisitor() {
-    super(Opcodes.ASM7);
+    super(Opcodes.ASM9);
   }
 
   /**

--- a/dev/core/src/com/google/gwt/dev/javac/asmbridge/EmptyVisitor.java
+++ b/dev/core/src/com/google/gwt/dev/javac/asmbridge/EmptyVisitor.java
@@ -27,7 +27,7 @@ import org.objectweb.asm.Opcodes;
  */
 public class EmptyVisitor extends ClassVisitor {
 
-  protected AnnotationVisitor av = new AnnotationVisitor(Opcodes.ASM7) {
+  protected AnnotationVisitor av = new AnnotationVisitor(Opcodes.ASM9) {
 
     @Override
     public AnnotationVisitor visitAnnotation(String name, String desc) {
@@ -41,10 +41,10 @@ public class EmptyVisitor extends ClassVisitor {
   };
 
   public EmptyVisitor() {
-    super(Opcodes.ASM7);
+    super(Opcodes.ASM9);
   }
 
-  protected MethodVisitor mv = new MethodVisitor(Opcodes.ASM7) {
+  protected MethodVisitor mv = new MethodVisitor(Opcodes.ASM9) {
 
     @Override
     public AnnotationVisitor visitAnnotationDefault() {
@@ -63,7 +63,7 @@ public class EmptyVisitor extends ClassVisitor {
     }
   };
 
-  protected FieldVisitor fv = new FieldVisitor(Opcodes.ASM7) {
+  protected FieldVisitor fv = new FieldVisitor(Opcodes.ASM9) {
 
     @Override
     public AnnotationVisitor visitAnnotation(String desc, boolean visible) {

--- a/dev/core/src/com/google/gwt/dev/shell/rewrite/ForceClassVersion15.java
+++ b/dev/core/src/com/google/gwt/dev/shell/rewrite/ForceClassVersion15.java
@@ -25,7 +25,7 @@ import org.objectweb.asm.Opcodes;
 class ForceClassVersion15 extends ClassVisitor {
 
   public ForceClassVersion15(ClassVisitor v) {
-    super(Opcodes.ASM7, v);
+    super(Opcodes.ASM9, v);
   }
 
   @Override

--- a/dev/core/src/com/google/gwt/dev/shell/rewrite/HasAnnotation.java
+++ b/dev/core/src/com/google/gwt/dev/shell/rewrite/HasAnnotation.java
@@ -54,7 +54,7 @@ public class HasAnnotation extends ClassVisitor {
   private final String targetDesc;
 
   public HasAnnotation(ClassVisitor v, Class<? extends Annotation> annotation) {
-    super(Opcodes.ASM7, v);
+    super(Opcodes.ASM9, v);
     targetDesc = Type.getDescriptor(annotation);
   }
 

--- a/dev/core/src/com/google/gwt/dev/shell/rewrite/RewriteJsniMethods.java
+++ b/dev/core/src/com/google/gwt/dev/shell/rewrite/RewriteJsniMethods.java
@@ -206,7 +206,7 @@ public class RewriteJsniMethods extends ClassVisitor {
 
     public MyMethodAdapter(MethodVisitor mv, int access, String name,
         String desc) {
-      super(Opcodes.ASM7, mv, access, name, desc);
+      super(Opcodes.ASM9, mv, access, name, desc);
       this.descriptor = desc;
       this.name = name;
       isStatic = (access & Opcodes.ACC_STATIC) != 0;
@@ -329,7 +329,7 @@ public class RewriteJsniMethods extends ClassVisitor {
 
   public RewriteJsniMethods(ClassVisitor v,
       Map<String, String> anonymousClassMap) {
-    super(Opcodes.ASM7, v);
+    super(Opcodes.ASM9, v);
     this.anonymousClassMap = anonymousClassMap;
   }
 

--- a/dev/core/src/com/google/gwt/dev/shell/rewrite/RewriteRefsToJsoClasses.java
+++ b/dev/core/src/com/google/gwt/dev/shell/rewrite/RewriteRefsToJsoClasses.java
@@ -54,7 +54,7 @@ class RewriteRefsToJsoClasses extends ClassVisitor {
     };
 
     public MyMethodAdapter(MethodVisitor mv) {
-      super(Opcodes.ASM7, mv);
+      super(Opcodes.ASM9, mv);
     }
 
     @Override
@@ -132,7 +132,7 @@ class RewriteRefsToJsoClasses extends ClassVisitor {
    */
   public RewriteRefsToJsoClasses(ClassVisitor cv, Set<String> jsoDescriptors,
       InstanceMethodOracle mapper) {
-    super(Opcodes.ASM7, cv);
+    super(Opcodes.ASM9, cv);
     this.jsoDescriptors = jsoDescriptors;
     this.mapper = mapper;
   }

--- a/dev/core/src/com/google/gwt/dev/shell/rewrite/RewriteSingleJsoImplDispatches.java
+++ b/dev/core/src/com/google/gwt/dev/shell/rewrite/RewriteSingleJsoImplDispatches.java
@@ -57,7 +57,7 @@ import java.util.TreeSet;
 public class RewriteSingleJsoImplDispatches extends ClassVisitor {
   private class MyMethodVisitor extends MethodVisitor {
     public MyMethodVisitor(MethodVisitor mv) {
-      super(Opcodes.ASM7, mv);
+      super(Opcodes.ASM9, mv);
     }
 
     /*
@@ -133,7 +133,7 @@ public class RewriteSingleJsoImplDispatches extends ClassVisitor {
 
   public RewriteSingleJsoImplDispatches(ClassVisitor v, TypeOracle typeOracle,
       SingleJsoImplData jsoData) {
-    super(Opcodes.ASM7, v);
+    super(Opcodes.ASM9, v);
     this.typeOracle = typeOracle;
     this.jsoData = jsoData;
   }

--- a/dev/core/src/com/google/gwt/dev/shell/rewrite/UseMirroredClasses.java
+++ b/dev/core/src/com/google/gwt/dev/shell/rewrite/UseMirroredClasses.java
@@ -72,7 +72,7 @@ public class UseMirroredClasses extends ClassVisitor {
     private String className;
 
     protected MethodInterceptor(MethodVisitor mv, String className) {
-      super(Opcodes.ASM7, mv);
+      super(Opcodes.ASM9, mv);
       this.className = className;
     }
 
@@ -144,7 +144,7 @@ public class UseMirroredClasses extends ClassVisitor {
   private String className;
 
   public UseMirroredClasses(ClassVisitor cv, String className) {
-    super(Opcodes.ASM7, cv);
+    super(Opcodes.ASM9, cv);
     this.className = className;
   }
 

--- a/dev/core/src/com/google/gwt/dev/shell/rewrite/WriteJsoImpl.java
+++ b/dev/core/src/com/google/gwt/dev/shell/rewrite/WriteJsoImpl.java
@@ -264,7 +264,7 @@ abstract class WriteJsoImpl extends ClassVisitor {
    * @param mapper maps methods to the class in which they are declared
    */
   private WriteJsoImpl(ClassVisitor cv, InstanceMethodOracle mapper) {
-    super(Opcodes.ASM7, cv);
+    super(Opcodes.ASM9, cv);
     this.mapper = mapper;
   }
 

--- a/doc/build.xml
+++ b/doc/build.xml
@@ -83,17 +83,14 @@
              access="package"
              packagenames="${USER_PKGS}"
              sourcefiles="${USER_CLASSES}"
-             noindex="true"
              notree="true"
              use="true"
              windowtitle="GWT Javadoc"
              doctitle="GWT API Reference"
              header="GWT ${gwt.version}"
-             linkoffline="http://download.oracle.com/javaee/6/api/ validation-package-list">
+             linkoffline="https://docs.oracle.com/en/java/javase/11/docs/api/ validation-package-list">
       <!-- suppress errors that don't break the output, we should refine this to just suppress things we haven't fixed yet -->
       <arg value="-Xdoclint:none" />
-      <!-- re-enable frames for now, until we get to >=13 and have search -->
-      <arg value="--frames" />
       <classpath refid="USER_CLASS_PATH" />
       <sourcepath refid="USER_SOURCE_PATH" />
 

--- a/doc/build.xml
+++ b/doc/build.xml
@@ -83,7 +83,6 @@
              access="package"
              packagenames="${USER_PKGS}"
              sourcefiles="${USER_CLASSES}"
-             notree="true"
              use="true"
              windowtitle="GWT Javadoc"
              doctitle="GWT API Reference"

--- a/user/build.xml
+++ b/user/build.xml
@@ -75,8 +75,8 @@
     <pathelement location="${gwt.tools.lib}/cglib/cglib-3.1.jar"/>
     <pathelement location="${gwt.tools.lib}/mockito/1.9.5/mockito-all-1.9.5.jar"/>
     <pathelement location="${gwt.tools.lib}/objenesis/objenesis-1.2.jar"/>
-    <pathelement location="${gwt.tools.lib}/objectweb/asm-7.1/asm-7.1.jar"/>
-    <pathelement location="${gwt.tools.lib}/objectweb/asm-7.1/asm-commons-7.1.jar"/>
+    <pathelement location="${gwt.tools.lib}/objectweb/asm-9.2/asm-9.2.jar"/>
+    <pathelement location="${gwt.tools.lib}/objectweb/asm-9.2/asm-commons-9.2.jar"/>
     <pathelement location="${gwt.tools.lib}/javax/validation/validation-api-1.0.0.GA.jar"/>
     <pathelement location="${gwt.tools.lib}/javax/validation/validation-api-1.0.0.GA-sources.jar"/>
     <pathelement

--- a/user/src/com/google/web/bindery/requestfactory/server/RequestFactoryJarExtractor.java
+++ b/user/src/com/google/web/bindery/requestfactory/server/RequestFactoryJarExtractor.java
@@ -386,7 +386,7 @@ public class RequestFactoryJarExtractor {
     private String sourceType;
 
     public ClassProcessor(String sourceType, ClassVisitor cv, State state) {
-      super(Opcodes.ASM7, cv);
+      super(Opcodes.ASM9, cv);
       this.sourceType = sourceType;
       this.state = state;
     }
@@ -630,7 +630,7 @@ public class RequestFactoryJarExtractor {
    */
   private class NativeMethodDefanger extends ClassVisitor {
     public NativeMethodDefanger(ClassVisitor cv) {
-      super(Opcodes.ASM7, cv);
+      super(Opcodes.ASM9, cv);
     }
 
     @Override

--- a/user/src/com/google/web/bindery/requestfactory/server/RequestFactoryJarExtractor.java
+++ b/user/src/com/google/web/bindery/requestfactory/server/RequestFactoryJarExtractor.java
@@ -352,7 +352,7 @@ public class RequestFactoryJarExtractor {
 
     public AnnotationProcessor(String sourceType, AnnotationVisitor av) {
       // TODO(rluble): should we chain av to super here?
-      super(Opcodes.ASM7);
+      super(Opcodes.ASM9);
       this.sourceType = sourceType;
       this.av = av;
     }
@@ -519,7 +519,7 @@ public class RequestFactoryJarExtractor {
 
     public FieldProcessor(String sourceType, FieldVisitor fv) {
       // TODO(rluble): Should we chain fv to super here?
-      super(Opcodes.ASM7);
+      super(Opcodes.ASM9);
       this.sourceType = sourceType;
       this.fv = fv;
     }
@@ -541,7 +541,7 @@ public class RequestFactoryJarExtractor {
     private final String sourceType;
 
     public MethodProcessor(String sourceType, MethodVisitor mv) {
-      super(Opcodes.ASM7, mv);
+      super(Opcodes.ASM9, mv);
       this.sourceType = sourceType;
     }
 


### PR DESCRIPTION
Full build with Java 8, 11, 17 was run https://github.com/niloc132/gwt/actions/runs/5007780467/jobs/8974836774.

With Javadoc now able to run on Java 17, we can make Java 17 the default going forward for builds. This patch enables running tests in 17, and fixes a few gotchas discovered - an old asm jar was being used for tests, and when we updated to the latest asm for GWT 2.10, we didn't update ClassVisitors to use the newer version.