### PR TITLE
Update Collections to support changes made in Java 9

### DIFF
--- a/user/build.xml
+++ b/user/build.xml
@@ -15,10 +15,9 @@
   <property name="emma.merged.out" value="${junit.out}/emma-coverage"/>
 
   <property name="gwt.junit.testcase.web.includes" value="${gwt.junit.testcase.includes}"/>
-  <!-- TODO once we compile with Java >8, update this to exclude tests based on running JDK version -->
   <condition property="gwt.junit.testcase.web.excludes"
-            value="**/*JreSuite.class,**/OptimizedOnly*,**/*Java8Suite.class"
-            else="**/*JreSuite.class,**/OptimizedOnly*,**/*Java8Suite.class">
+            value="**/*JreSuite.class,**/OptimizedOnly*"
+            else="**/*JreSuite.class,**/OptimizedOnly*,**/*Java9Suite.class">
     <isfalse value="${isJava8}" />
   </condition>
 
@@ -31,9 +30,8 @@
   </condition>
 
   <property name="gwt.junit.testcase.dev.includes" value="${gwt.junit.testcase.includes}"/>
-  <!-- TODO once we compile with Java >8, update this to exclude tests based on running JDK version -->
   <condition property="gwt.junit.testcase.dev.excludes"
-            value="**/EmulSuite.class,**/JSONSuite.class,**/RunAsyncSuite.class,**/*CompilerSuite.class,**/*JsInteropSuite.class,**/*JreSuite.class,**/OptimizedOnly*,**/*Java8Suite.class"
+            value="**/EmulSuite.class,**/JSONSuite.class,**/RunAsyncSuite.class,**/*CompilerSuite.class,**/*JsInteropSuite.class,**/*JreSuite.class,**/OptimizedOnly*"
             else="**/EmulSuite.class,**/JSONSuite.class,**/RunAsyncSuite.class,**/*CompilerSuite.class,**/*JsInteropSuite.class,**/*JreSuite.class,**/OptimizedOnly*,**/*Java8Suite.class">
     <isfalse value="${isJava8}" />
   </condition>
@@ -183,6 +181,7 @@
                  -Xep:ComparableType:OFF
                  -Xep:DoNotCall:OFF
                  -Xep:BadAnnotationImplementation:OFF
+                 -Xep:DuplicateMapKeys:OFF
                ">
       <classpath>
         <pathelement location="${javac.out}"/>

--- a/user/build.xml
+++ b/user/build.xml
@@ -17,7 +17,7 @@
   <property name="gwt.junit.testcase.web.includes" value="${gwt.junit.testcase.includes}"/>
   <condition property="gwt.junit.testcase.web.excludes"
             value="**/*JreSuite.class,**/OptimizedOnly*"
-            else="**/*JreSuite.class,**/OptimizedOnly*,**/*Java9Suite.class">
+            else="**/*JreSuite.class,**/OptimizedOnly*,**/*Java9Suite.class,**/*Java10Suite.class,**/*Java11Suite.class">
     <isfalse value="${isJava8}" />
   </condition>
 
@@ -32,7 +32,7 @@
   <property name="gwt.junit.testcase.dev.includes" value="${gwt.junit.testcase.includes}"/>
   <condition property="gwt.junit.testcase.dev.excludes"
             value="**/EmulSuite.class,**/JSONSuite.class,**/RunAsyncSuite.class,**/*CompilerSuite.class,**/*JsInteropSuite.class,**/*JreSuite.class,**/OptimizedOnly*"
-            else="**/EmulSuite.class,**/JSONSuite.class,**/RunAsyncSuite.class,**/*CompilerSuite.class,**/*JsInteropSuite.class,**/*JreSuite.class,**/OptimizedOnly*,**/*Java8Suite.class">
+            else="**/EmulSuite.class,**/JSONSuite.class,**/RunAsyncSuite.class,**/*CompilerSuite.class,**/*JsInteropSuite.class,**/*JreSuite.class,**/OptimizedOnly*,**/*Java9Suite.class,**/*Java10Suite.class,**/*Java11Suite.class">
     <isfalse value="${isJava8}" />
   </condition>
 
@@ -156,13 +156,13 @@
       Compiles the test code for this project
   -->
   <target name="compile.tests"
-          depends="-compile.tests.java8"
+          depends="-compile.tests.java8,-compile.tests.java11"
           unless="compile.tests.complete">
   </target>
 
   <target name="-compile.tests.java8" depends="compile.dev.tests, compile.emma.if.enabled">
     <gwt.javac srcdir="test" destdir="${javac.junit.out}"
-               excludes="com/google/gwt/langtest/**,**/super/**"
+               excludes="com/google/gwt/langtest/**,**/super/**,**/java9/**,**/*Java9*.java,**/java10/**,**/*Java10*.java,**/java11/**,**/*Java11*.java"
                processorpath="test.extraclasspath"
                errorprone.args="
                  -Xep:SelfAssignment:OFF
@@ -192,6 +192,39 @@
       <compilerarg value="-processor"/>
       <compilerarg value="com.google.web.bindery.requestfactory.apt.RfValidator"/>
     </gwt.javac>
+  </target>
+  <target name="-compile.tests.java11" unless="isJava8" depends="-compile.tests.java8">
+    <gwt.javac srcdir="test" destdir="${javac.junit.out}"
+               excludes="com/google/gwt/langtest/**,**/super/**"
+               processorpath="test.extraclasspath"
+               errorprone.args="
+                 -Xep:SelfAssignment:OFF
+                 -Xep:MissingCasesInEnumSwitch:OFF
+                 -Xep:SelfComparison:OFF
+                 -Xep:SelfEquals:OFF
+                 -Xep:FallThrough:OFF
+                 -Xep:ReturnValueIgnored:OFF
+                 -Xep:EqualsIncompatibleType:OFF
+                 -Xep:IdentityBinaryExpression:OFF
+                 -Xep:LoopConditionChecker:OFF
+                 -Xep:JUnitAssertSameCheck:OFF
+                 -Xep:CollectionIncompatibleType:OFF
+                 -Xep:DeadThread:OFF
+                 -Xep:ComplexBooleanConstant:OFF
+                 -Xep:ComparableType:OFF
+                 -Xep:DoNotCall:OFF
+                 -Xep:BadAnnotationImplementation:OFF
+                 -Xep:DuplicateMapKeys:OFF
+               ">
+      <classpath>
+        <pathelement location="${javac.junit.out}"/>
+        <pathelement location="${javac.out}"/>
+        <pathelement location="${gwt.tools.lib}/junit/junit-4.8.2.jar"/>
+        <pathelement location="${gwt.tools.lib}/selenium/selenium-java-client-driver.jar"/>
+        <path refid="test.extraclasspath"/>
+      </classpath>
+    </gwt.javac>
+
   </target>
 
   <target name="build" depends="compile"

--- a/user/build.xml
+++ b/user/build.xml
@@ -181,7 +181,6 @@
                  -Xep:ComparableType:OFF
                  -Xep:DoNotCall:OFF
                  -Xep:BadAnnotationImplementation:OFF
-                 -Xep:DuplicateMapKeys:OFF
                ">
       <classpath>
         <pathelement location="${javac.out}"/>
@@ -214,7 +213,6 @@
                  -Xep:ComparableType:OFF
                  -Xep:DoNotCall:OFF
                  -Xep:BadAnnotationImplementation:OFF
-                 -Xep:DuplicateMapKeys:OFF
                ">
       <classpath>
         <pathelement location="${javac.junit.out}"/>

--- a/user/super/com/google/gwt/emul/java/util/AbstractMap.java
+++ b/user/super/com/google/gwt/emul/java/util/AbstractMap.java
@@ -61,6 +61,15 @@ public abstract class AbstractMap<K, V> implements Map<K, V> {
   }
 
   /**
+   * Internal implementation for immutable entries with non-null keys and values.
+   */
+  static final class NonNullableImmutableEntry<K, V> extends AbstractMap.SimpleImmutableEntry<K, V> {
+    public NonNullableImmutableEntry(K key, V value) {
+      super(checkNotNull(key), checkNotNull(value));
+    }
+  }
+
+  /**
    * Basic {@link Map.Entry} implementation used by {@link SimpleEntry}
    * and {@link SimpleImmutableEntry}.
    */

--- a/user/super/com/google/gwt/emul/java/util/AbstractMap.java
+++ b/user/super/com/google/gwt/emul/java/util/AbstractMap.java
@@ -63,7 +63,8 @@ public abstract class AbstractMap<K, V> implements Map<K, V> {
   /**
    * Internal implementation for immutable entries with non-null keys and values.
    */
-  static final class NonNullableImmutableEntry<K, V> extends AbstractMap.SimpleImmutableEntry<K, V> {
+  static final class NonNullableImmutableEntry<K, V> extends
+          AbstractMap.SimpleImmutableEntry<K, V> {
     public NonNullableImmutableEntry(K key, V value) {
       super(checkNotNull(key), checkNotNull(value));
     }

--- a/user/super/com/google/gwt/emul/java/util/AbstractMap.java
+++ b/user/super/com/google/gwt/emul/java/util/AbstractMap.java
@@ -61,16 +61,6 @@ public abstract class AbstractMap<K, V> implements Map<K, V> {
   }
 
   /**
-   * Internal implementation for immutable entries with non-null keys and values.
-   */
-  static final class NonNullableImmutableEntry<K, V> extends
-          AbstractMap.SimpleImmutableEntry<K, V> {
-    public NonNullableImmutableEntry(K key, V value) {
-      super(checkNotNull(key), checkNotNull(value));
-    }
-  }
-
-  /**
    * Basic {@link Map.Entry} implementation used by {@link SimpleEntry}
    * and {@link SimpleImmutableEntry}.
    */

--- a/user/super/com/google/gwt/emul/java/util/List.java
+++ b/user/super/com/google/gwt/emul/java/util/List.java
@@ -18,6 +18,7 @@ package java.util;
 import static javaemul.internal.InternalPreconditions.checkNotNull;
 
 import java.util.function.UnaryOperator;
+import javaemul.internal.ArrayHelper;
 
 import jsinterop.annotations.JsIgnore;
 import jsinterop.annotations.JsMethod;
@@ -33,6 +34,69 @@ import jsinterop.annotations.JsType;
  */
 @JsType
 public interface List<E> extends Collection<E> {
+
+  @JsIgnore
+  static <E> List<E> of() {
+    return Collections.emptyList();
+  }
+
+  @JsIgnore
+  static <E> List<E> of(E e1) {
+    return of((E[]) new Object[] {e1});
+  }
+
+  @JsIgnore
+  static <E> List<E> of(E e1, E e2) {
+    return of((E[]) new Object[] {e1, e2});
+  }
+
+  @JsIgnore
+  static <E> List<E> of(E e1, E e2, E e3) {
+    return of((E[]) new Object[] {e1, e2, e3});
+  }
+
+  @JsIgnore
+  static <E> List<E> of(E e1, E e2, E e3, E e4) {
+    return of((E[]) new Object[] {e1, e2, e3, e4});
+  }
+
+  @JsIgnore
+  static <E> List<E> of(E e1, E e2, E e3, E e4, E e5) {
+    return of((E[]) new Object[] {e1, e2, e3, e4, e5});
+  }
+
+  @JsIgnore
+  static <E> List<E> of(E e1, E e2, E e3, E e4, E e5, E e6) {
+    return of((E[]) new Object[] {e1, e2, e3, e4, e5, e6});
+  }
+
+  @JsIgnore
+  static <E> List<E> of(E e1, E e2, E e3, E e4, E e5, E e6, E e7) {
+    return of((E[]) new Object[] {e1, e2, e3, e4, e5, e6, e7});
+  }
+
+  @JsIgnore
+  static <E> List<E> of(E e1, E e2, E e3, E e4, E e5, E e6, E e7, E e8) {
+    return of((E[]) new Object[] {e1, e2, e3, e4, e5, e6, e7, e8});
+  }
+
+  @JsIgnore
+  static <E> List<E> of(E e1, E e2, E e3, E e4, E e5, E e6, E e7, E e8, E e9) {
+    return of((E[]) new Object[] {e1, e2, e3, e4, e5, e6, e7, e8, e9});
+  }
+
+  @JsIgnore
+  static <E> List<E> of(E e1, E e2, E e3, E e4, E e5, E e6, E e7, E e8, E e9, E e10) {
+    return of((E[]) new Object[] {e1, e2, e3, e4, e5, e6, e7, e8, e9, e10});
+  }
+
+  @JsIgnore
+  static <E> List<E> of(E... elements) {
+    for (int i = 0; i < elements.length; i++) {
+      checkNotNull(elements[i]);
+    }
+    return Collections.unmodifiableList(Arrays.asList((E[]) ArrayHelper.unsafeClone(elements, 0, elements.length)));
+  }
 
   @JsMethod(name = "addAtIndex")
   void add(int index, E element);

--- a/user/super/com/google/gwt/emul/java/util/List.java
+++ b/user/super/com/google/gwt/emul/java/util/List.java
@@ -37,7 +37,7 @@ public interface List<E> extends Collection<E> {
 
   @JsIgnore
   static <E> List<E> of() {
-    return Collections.emptyList();
+    return Collections.unmodifiableList(Collections.emptyList());
   }
 
   @JsIgnore

--- a/user/super/com/google/gwt/emul/java/util/List.java
+++ b/user/super/com/google/gwt/emul/java/util/List.java
@@ -42,53 +42,67 @@ public interface List<E> extends Collection<E> {
 
   @JsIgnore
   static <E> List<E> of(E e1) {
-    return of((E[]) new Object[] {e1});
+    return __ofInternal((E[]) new Object[] {e1});
   }
 
   @JsIgnore
   static <E> List<E> of(E e1, E e2) {
-    return of((E[]) new Object[] {e1, e2});
+    return __ofInternal((E[]) new Object[] {e1, e2});
   }
 
   @JsIgnore
   static <E> List<E> of(E e1, E e2, E e3) {
-    return of((E[]) new Object[] {e1, e2, e3});
+    return __ofInternal((E[]) new Object[] {e1, e2, e3});
   }
 
   @JsIgnore
   static <E> List<E> of(E e1, E e2, E e3, E e4) {
-    return of((E[]) new Object[] {e1, e2, e3, e4});
+    return __ofInternal((E[]) new Object[] {e1, e2, e3, e4});
   }
 
   @JsIgnore
   static <E> List<E> of(E e1, E e2, E e3, E e4, E e5) {
-    return of((E[]) new Object[] {e1, e2, e3, e4, e5});
+    return __ofInternal((E[]) new Object[] {e1, e2, e3, e4, e5});
   }
 
   @JsIgnore
   static <E> List<E> of(E e1, E e2, E e3, E e4, E e5, E e6) {
-    return of((E[]) new Object[] {e1, e2, e3, e4, e5, e6});
+    return __ofInternal((E[]) new Object[] {e1, e2, e3, e4, e5, e6});
   }
 
   @JsIgnore
   static <E> List<E> of(E e1, E e2, E e3, E e4, E e5, E e6, E e7) {
-    return of((E[]) new Object[] {e1, e2, e3, e4, e5, e6, e7});
+    return __ofInternal((E[]) new Object[] {e1, e2, e3, e4, e5, e6, e7});
   }
 
   @JsIgnore
   static <E> List<E> of(E e1, E e2, E e3, E e4, E e5, E e6, E e7, E e8) {
-    return of((E[]) new Object[] {e1, e2, e3, e4, e5, e6, e7, e8});
+    return __ofInternal((E[]) new Object[] {e1, e2, e3, e4, e5, e6, e7, e8});
   }
 
   @JsIgnore
   static <E> List<E> of(E e1, E e2, E e3, E e4, E e5, E e6, E e7, E e8, E e9) {
-    return of((E[]) new Object[] {e1, e2, e3, e4, e5, e6, e7, e8, e9});
+    return __ofInternal((E[]) new Object[] {e1, e2, e3, e4, e5, e6, e7, e8, e9});
   }
 
   @JsIgnore
   static <E> List<E> of(E e1, E e2, E e3, E e4, E e5, E e6, E e7, E e8, E e9, E e10) {
-    return of((E[]) new Object[] {e1, e2, e3, e4, e5, e6, e7, e8, e9, e10});
+    return __ofInternal((E[]) new Object[] {e1, e2, e3, e4, e5, e6, e7, e8, e9, e10});
   }
+
+  // CHECKSTYLE_OFF: Internal only method that cannot collide with future JRE changes
+  /**
+   * Internal-only helper to avoid copying the incoming array, and instead just wrap it with an
+   * immutable List after checking there are no nulls.
+   */
+  @JsIgnore
+  static <E> List<E> __ofInternal(E[] elements) {
+    for (int i = 0; i < elements.length; i++) {
+      checkNotNull(elements[i]);
+    }
+    return Collections.unmodifiableList(Arrays.asList(elements));
+  }
+  // CHECKSTYLE_ON
 
   @JsIgnore
   static <E> List<E> of(E... elements) {

--- a/user/super/com/google/gwt/emul/java/util/List.java
+++ b/user/super/com/google/gwt/emul/java/util/List.java
@@ -95,7 +95,9 @@ public interface List<E> extends Collection<E> {
     for (int i = 0; i < elements.length; i++) {
       checkNotNull(elements[i]);
     }
-    return Collections.unmodifiableList(Arrays.asList((E[]) ArrayHelper.unsafeClone(elements, 0, elements.length)));
+    return Collections.unmodifiableList(
+            Arrays.asList((E[]) ArrayHelper.unsafeClone(elements, 0, elements.length))
+    );
   }
 
   @JsMethod(name = "addAtIndex")

--- a/user/super/com/google/gwt/emul/java/util/Map.java
+++ b/user/super/com/google/gwt/emul/java/util/Map.java
@@ -15,6 +15,7 @@
  */
 package java.util;
 
+import static javaemul.internal.InternalPreconditions.checkArgument;
 import static javaemul.internal.InternalPreconditions.checkNotNull;
 
 import java.io.Serializable;
@@ -34,6 +35,211 @@ import jsinterop.annotations.JsType;
  */
 @JsType
 public interface Map<K, V> {
+
+  @JsIgnore
+  static <K, V> Map<K, V> of() {
+    return Collections.emptyMap();
+  }
+
+  @JsIgnore
+  static <K, V> Map<K, V> of(K key, V value) {
+    return ofEntries(
+            entry(key, value)
+    );
+  }
+
+  @JsIgnore
+  static <K, V> Map<K, V> of(K k1, V v1, K k2, V v2) {
+    return ofEntries(
+            entry(k1, v1),
+            entry(k2, v2)
+    );
+  }
+
+  @JsIgnore
+  static <K, V> Map<K, V> of(
+      K k1, V v1,
+      K k2, V v2,
+      K k3, V v3
+  ) {
+    return ofEntries(
+            entry(k1, v1),
+            entry(k2, v2),
+            entry(k3, v3)
+    );
+  }
+
+  @JsIgnore
+  static <K, V> Map<K, V> of(
+      K k1, V v1,
+      K k2, V v2,
+      K k3, V v3,
+      K k4, V v4
+  ) {
+    return ofEntries(
+            entry(k1, v1),
+            entry(k2, v2),
+            entry(k3, v3),
+            entry(k4, v4)
+    );
+  }
+
+  @JsIgnore
+  static <K, V> Map<K, V> of(
+      K k1, V v1,
+      K k2, V v2,
+      K k3, V v3,
+      K k4, V v4,
+      K k5, V v5
+  ) {
+    return ofEntries(
+            entry(k1, v1),
+            entry(k2, v2),
+            entry(k3, v3),
+            entry(k4, v4),
+            entry(k5, v5)
+    );
+  }
+
+  @JsIgnore
+  static <K, V> Map<K, V> of(
+      K k1, V v1,
+      K k2, V v2,
+      K k3, V v3,
+      K k4, V v4,
+      K k5, V v5,
+      K k6, V v6
+  ) {
+    return ofEntries(
+            entry(k1, v1),
+            entry(k2, v2),
+            entry(k3, v3),
+            entry(k4, v4),
+            entry(k5, v5),
+            entry(k6, v6)
+    );
+  }
+
+  @JsIgnore
+  static <K, V> Map<K, V> of(
+      K k1, V v1,
+      K k2, V v2,
+      K k3, V v3,
+      K k4, V v4,
+      K k5, V v5,
+      K k6, V v6,
+      K k7, V v7
+  ) {
+    return ofEntries(
+            entry(k1, v1),
+            entry(k2, v2),
+            entry(k3, v3),
+            entry(k4, v4),
+            entry(k5, v5),
+            entry(k6, v6),
+            entry(k7, v7)
+    );
+  }
+
+  @JsIgnore
+  static <K, V> Map<K, V> of(
+      K k1, V v1,
+      K k2, V v2,
+      K k3, V v3,
+      K k4, V v4,
+      K k5, V v5,
+      K k6, V v6,
+      K k7, V v7,
+      K k8, V v8
+  ) {
+    return ofEntries(
+            entry(k1, v1),
+            entry(k2, v2),
+            entry(k3, v3),
+            entry(k4, v4),
+            entry(k5, v5),
+            entry(k6, v6),
+            entry(k7, v7),
+            entry(k8, v8)
+    );
+  }
+
+  @JsIgnore
+  static <K, V> Map<K, V> of(
+      K k1, V v1,
+      K k2, V v2,
+      K k3, V v3,
+      K k4, V v4,
+      K k5, V v5,
+      K k6, V v6,
+      K k7, V v7,
+      K k8, V v8,
+      K k9, V v9
+  ) {
+    return ofEntries(
+            entry(k1, v1),
+            entry(k2, v2),
+            entry(k3, v3),
+            entry(k4, v4),
+            entry(k5, v5),
+            entry(k6, v6),
+            entry(k7, v7),
+            entry(k8, v8),
+            entry(k9, v9)
+    );
+  }
+
+  @JsIgnore
+  static <K, V> Map<K, V> of(
+      K k1, V v1,
+      K k2, V v2,
+      K k3, V v3,
+      K k4, V v4,
+      K k5, V v5,
+      K k6, V v6,
+      K k7, V v7,
+      K k8, V v8,
+      K k9, V v9,
+      K k10, V v10
+  ) {
+    return ofEntries(
+            entry(k1, v1),
+            entry(k2, v2),
+            entry(k3, v3),
+            entry(k4, v4),
+            entry(k5, v5),
+            entry(k6, v6),
+            entry(k7, v7),
+            entry(k8, v8),
+            entry(k9, v9),
+            entry(k10, v10)
+    );
+  }
+
+  @JsIgnore
+  static <K, V> Entry<K, V> entry(K key, V value) {
+    // This isn't quite consistent with the javadoc, since this is serializable, while entry()
+    // need not be serializable.
+    return new AbstractMap.SimpleImmutableEntry(
+        checkNotNull(key),
+        checkNotNull(value)
+    );
+  }
+
+  @JsIgnore
+  static <K, V> Map<K, V> ofEntries(Entry<? extends K,? extends V>... entries) {
+    Map<K, V> map = new HashMap<>();
+
+    for (int i = 0; i < entries.length; i++) {
+      // TODO this perhaps can be optimized if we know the entry is an instance of
+      //  AbstractMap.SimpleImmutableEntry, or something more specialized?
+      Entry<? extends K, ? extends V> entry = entries[i];
+      checkArgument(map.put(checkNotNull(entry.getKey()), checkNotNull(entry.getValue())) == null,
+          "Duplicate key " + entry.getKey());
+    }
+
+    return Collections.unmodifiableMap(map);
+  }
 
   /**
    * Represents an individual map entry.

--- a/user/super/com/google/gwt/emul/java/util/Map.java
+++ b/user/super/com/google/gwt/emul/java/util/Map.java
@@ -38,7 +38,7 @@ public interface Map<K, V> {
 
   @JsIgnore
   static <K, V> Map<K, V> of() {
-    return Collections.emptyMap();
+    return Collections.unmodifiableMap(Collections.emptyMap());
   }
 
   @JsIgnore
@@ -235,9 +235,15 @@ public interface Map<K, V> {
       K key = entry.getKey();
       if (entry instanceof AbstractMap.NonNullableImmutableEntry) {
         // key/value cannot be null for this type, still need to check for collisions
-        checkArgument(map.put(key, entry.getValue()) == null, "Can't add multiple entries with the same key");
+        checkArgument(
+                map.put(key, entry.getValue()) == null,
+                "Can't add multiple entries with the same key"
+        );
       } else {
-        checkArgument(map.put(checkNotNull(key), checkNotNull(entry.getValue())) == null, "Can't add multiple entries with the same key");
+        checkArgument(
+                map.put(checkNotNull(key), checkNotNull(entry.getValue())) == null,
+                "Can't add multiple entries with the same key"
+        );
       }
     }
 

--- a/user/super/com/google/gwt/emul/java/util/Map.java
+++ b/user/super/com/google/gwt/emul/java/util/Map.java
@@ -220,9 +220,9 @@ public interface Map<K, V> {
   static <K, V> Entry<K, V> entry(K key, V value) {
     // This isn't quite consistent with the javadoc, since this is serializable, while entry()
     // need not be serializable.
-    return new AbstractMap.NonNullableImmutableEntry<>(
-        key,
-        value
+    return new AbstractMap.SimpleImmutableEntry<>(
+        checkNotNull(key),
+        checkNotNull(value)
     );
   }
 
@@ -231,20 +231,11 @@ public interface Map<K, V> {
     Map<K, V> map = new HashMap<>();
 
     for (int i = 0; i < entries.length; i++) {
+      // TODO this perhaps can be optimized if we know the entry is an instance of
+      //  AbstractMap.SimpleImmutableEntry, or something more specialized?
       Entry<? extends K, ? extends V> entry = checkNotNull(entries[i]);
-      K key = entry.getKey();
-      if (entry instanceof AbstractMap.NonNullableImmutableEntry) {
-        // key/value cannot be null for this type, still need to check for collisions
-        checkArgument(
-                map.put(key, entry.getValue()) == null,
-                "Can't add multiple entries with the same key"
-        );
-      } else {
-        checkArgument(
-                map.put(checkNotNull(key), checkNotNull(entry.getValue())) == null,
-                "Can't add multiple entries with the same key"
-        );
-      }
+      checkArgument(map.put(checkNotNull(entry.getKey()), checkNotNull(entry.getValue())) == null,
+              "Can't add multiple entries with the same key");
     }
 
     return Collections.unmodifiableMap(map);

--- a/user/super/com/google/gwt/emul/java/util/Set.java
+++ b/user/super/com/google/gwt/emul/java/util/Set.java
@@ -15,6 +15,9 @@
  */
 package java.util;
 
+import static javaemul.internal.InternalPreconditions.checkArgument;
+import static javaemul.internal.InternalPreconditions.checkNotNull;
+
 import jsinterop.annotations.JsIgnore;
 import jsinterop.annotations.JsType;
 
@@ -26,6 +29,70 @@ import jsinterop.annotations.JsType;
  */
 @JsType
 public interface Set<E> extends Collection<E> {
+  @JsIgnore
+  static <E> Set<E> of() {
+    return Collections.emptySet();
+  }
+
+  @JsIgnore
+  static <E> Set<E> of(E e1) {
+    return of((E[]) new Object[] {e1});
+  }
+
+  @JsIgnore
+  static <E> Set<E> of(E e1, E e2) {
+    return of((E[]) new Object[] {e1, e2});
+  }
+
+  @JsIgnore
+  static <E> Set<E> of(E e1, E e2, E e3) {
+    return of((E[]) new Object[] {e1, e2, e3});
+  }
+
+  @JsIgnore
+  static <E> Set<E> of(E e1, E e2, E e3, E e4) {
+    return of((E[]) new Object[] {e1, e2, e3, e4});
+  }
+
+  @JsIgnore
+  static <E> Set<E> of(E e1, E e2, E e3, E e4, E e5) {
+    return of((E[]) new Object[] {e1, e2, e3, e4, e5});
+  }
+
+  @JsIgnore
+  static <E> Set<E> of(E e1, E e2, E e3, E e4, E e5, E e6) {
+    return of((E[]) new Object[] {e1, e2, e3, e4, e5, e6});
+  }
+
+  @JsIgnore
+  static <E> Set<E> of(E e1, E e2, E e3, E e4, E e5, E e6, E e7) {
+    return of((E[]) new Object[] {e1, e2, e3, e4, e5, e6, e7});
+  }
+
+  @JsIgnore
+  static <E> Set<E> of(E e1, E e2, E e3, E e4, E e5, E e6, E e7, E e8) {
+    return of((E[]) new Object[] {e1, e2, e3, e4, e5, e6, e7, e8});
+  }
+
+  @JsIgnore
+  static <E> Set<E> of(E e1, E e2, E e3, E e4, E e5, E e6, E e7, E e8, E e9) {
+    return of((E[]) new Object[] {e1, e2, e3, e4, e5, e6, e7, e8, e9});
+  }
+
+  @JsIgnore
+  static <E> Set<E> of(E e1, E e2, E e3, E e4, E e5, E e6, E e7, E e8, E e9, E e10) {
+    return of((E[]) new Object[] {e1, e2, e3, e4, e5, e6, e7, e8, e9, e10});
+  }
+
+  @JsIgnore
+  static <E> Set<E> of(E... elements) {
+    HashSet<E> set = new HashSet<>();
+    for (int i = 0; i < elements.length; i++) {
+      checkArgument(set.add(checkNotNull(elements[i])));
+    }
+    return Collections.unmodifiableSet(set);
+  }
+
   @JsIgnore
   @Override
   default Spliterator<E> spliterator() {

--- a/user/super/com/google/gwt/emul/java/util/Set.java
+++ b/user/super/com/google/gwt/emul/java/util/Set.java
@@ -31,7 +31,7 @@ import jsinterop.annotations.JsType;
 public interface Set<E> extends Collection<E> {
   @JsIgnore
   static <E> Set<E> of() {
-    return Collections.emptySet();
+    return Collections.unmodifiableSet(Collections.emptySet());
   }
 
   @JsIgnore
@@ -88,7 +88,7 @@ public interface Set<E> extends Collection<E> {
   static <E> Set<E> of(E... elements) {
     HashSet<E> set = new HashSet<>();
     for (int i = 0; i < elements.length; i++) {
-      checkArgument(set.add(checkNotNull(elements[i])));
+      checkArgument(set.add(checkNotNull(elements[i])), "Can't add the same item multiple times");
     }
     return Collections.unmodifiableSet(set);
   }

--- a/user/test/com/google/gwt/emultest/EmulJava9Suite.java
+++ b/user/test/com/google/gwt/emultest/EmulJava9Suite.java
@@ -1,0 +1,18 @@
+package com.google.gwt.emultest;
+
+import com.google.gwt.emultest.java9.util.ListTest;
+import com.google.gwt.emultest.java9.util.MapTest;
+import com.google.gwt.emultest.java9.util.SetTest;
+import org.junit.runner.RunWith;
+import org.junit.runners.Suite;
+import org.junit.runners.Suite.SuiteClasses;
+
+/** Test JRE emulations. */
+@RunWith(Suite.class)
+@SuiteClasses({
+        ListTest.class,
+        SetTest.class,
+        MapTest.class
+})
+public class EmulJava9Suite {
+}

--- a/user/test/com/google/gwt/emultest/EmulJava9Suite.java
+++ b/user/test/com/google/gwt/emultest/EmulJava9Suite.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
 package com.google.gwt.emultest;
 
 import com.google.gwt.emultest.java9.util.ListTest;

--- a/user/test/com/google/gwt/emultest/EmulSuite.gwt.xml
+++ b/user/test/com/google/gwt/emultest/EmulSuite.gwt.xml
@@ -17,6 +17,7 @@
   <inherits name='com.google.gwt.testing.TestUtils' />
   <source path='java' />
   <source path='java8' />
+  <source path='java9' />
 
   <define-configuration-property name="someConfigurationProperty" is-multi-valued='false'/>
   <set-configuration-property name="someConfigurationProperty" value="conf"/>

--- a/user/test/com/google/gwt/emultest/EmulSuite.gwt.xml
+++ b/user/test/com/google/gwt/emultest/EmulSuite.gwt.xml
@@ -18,6 +18,8 @@
   <source path='java' />
   <source path='java8' />
   <source path='java9' />
+  <source path='java10' />
+  <source path='java11' />
 
   <define-configuration-property name="someConfigurationProperty" is-multi-valued='false'/>
   <set-configuration-property name="someConfigurationProperty" value="conf"/>

--- a/user/test/com/google/gwt/emultest/java/util/EmulTestBase.java
+++ b/user/test/com/google/gwt/emultest/java/util/EmulTestBase.java
@@ -57,6 +57,24 @@ public class EmulTestBase extends GWTTestCase {
         Arrays.equals(expected, actual));
   }
 
+  public static void assertNPE(String methodName, Runnable runnable) {
+    try {
+      runnable.run();
+      fail("Expected NPE from calling " + methodName);
+    } catch (NullPointerException ignored) {
+      // expected
+    }
+  }
+
+  public static void assertIAE(String methodName, Runnable runnable) {
+    try {
+      runnable.run();
+      fail("Expected IAE from calling " + methodName);
+    } catch (IllegalArgumentException ignored) {
+      // expected
+    }
+  }
+
   @Override
   public String getModuleName() {
     return "com.google.gwt.emultest.EmulSuite";

--- a/user/test/com/google/gwt/emultest/java9/util/ListTest.java
+++ b/user/test/com/google/gwt/emultest/java9/util/ListTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Google Inc.
+ * Copyright 2023 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -128,7 +128,7 @@ public class ListTest extends EmulTestBase {
       list.remove("not present");
       fail("List should be unmodifiable: remove(T)");
     } catch (UnsupportedOperationException ignored) {
-      //success
+      // success
     }
 
     try {

--- a/user/test/com/google/gwt/emultest/java9/util/ListTest.java
+++ b/user/test/com/google/gwt/emultest/java9/util/ListTest.java
@@ -1,0 +1,135 @@
+/*
+ * Copyright 2020 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.gwt.emultest.java9.util;
+
+import com.google.gwt.emultest.java.util.EmulTestBase;
+
+import java.util.Iterator;
+import java.util.List;
+
+/**
+ * Tests for java.util.List Java 9 API emulation.
+ */
+public class ListTest extends EmulTestBase {
+
+  public void testOf() {
+    assertIsImmutableListOf(List.of());
+    assertIsImmutableListOf(List.of("a"), "a");
+    assertIsImmutableListOf(
+        List.of("a", "b"),
+        "a", "b"
+    );
+    assertIsImmutableListOf(
+        List.of("a", "b", "c"),
+        "a", "b", "c"
+    );
+    assertIsImmutableListOf(
+        List.of("a", "b", "c", "d"),
+        "a", "b", "c", "d"
+    );
+    assertIsImmutableListOf(
+        List.of("a", "b", "c", "d", "e"),
+        "a", "b", "c", "d", "e"
+    );
+    assertIsImmutableListOf(
+        List.of("a", "b", "c", "d", "e", "f"),
+        "a", "b", "c", "d", "e", "f"
+    );
+    assertIsImmutableListOf(
+        List.of("a", "b", "c", "d", "e", "f", "g"),
+        "a", "b", "c", "d", "e", "f", "g"
+    );
+    assertIsImmutableListOf(
+        List.of("a", "b", "c", "d", "e", "f", "g", "h"),
+        "a", "b", "c", "d", "e", "f", "g", "h"
+    );
+    assertIsImmutableListOf(
+        List.of("a", "b", "c", "d", "e", "f", "g", "h", "i"),
+        "a", "b", "c", "d", "e", "f", "g", "h", "i"
+    );
+    assertIsImmutableListOf(
+        List.of("a", "b", "c", "d", "e", "f", "g", "h", "i", "j"),
+        "a", "b", "c", "d", "e", "f", "g", "h", "i", "j"
+    );
+    assertIsImmutableListOf(
+        List.of("a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k"),
+        "a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k"
+    );
+
+    // ensure that NPE is thrown if a value is null
+    assertNPE("of", () -> List.of((String) null));
+    assertNPE("of", () -> List.of("a", null));
+    assertNPE("of", () -> List.of("a", "b", null));
+    assertNPE("of", () -> List.of("a", "b", "c", null));
+    assertNPE("of", () -> List.of("a", "b", "c", "d", null));
+    assertNPE("of", () -> List.of("a", "b", "c", "d", "e", null));
+    assertNPE("of", () -> List.of("a", "b", "c", "d", "e", "f", null));
+    assertNPE("of", () -> List.of("a", "b", "c", "d", "e", "f", "g", "h", null));
+    assertNPE("of", () -> List.of("a", "b", "c", "d", "e", "f", "g", "h", "i", null));
+    assertNPE("of", () -> List.of("a", "b", "c", "d", "e", "f", "g", "h", "i", "j", null));
+  }
+
+  protected static void assertIsImmutableListOf(List<String> list, String... contents) {
+    assertEquals(contents, list);
+
+    // quick test that the list impl is sane
+    if (contents.length == 0) {
+      assertFalse(list.iterator().hasNext());
+    } else {
+      Iterator<String> itr = list.iterator();
+      assertTrue(itr.hasNext());
+      assertEquals(contents[0], itr.next());
+      assertEquals(contents.length > 1, itr.hasNext());
+    }
+
+    // quick check that the list is immutable
+    try {
+      list.add("another item");
+      fail("List should be unmodifiable: add(T)");
+    } catch (UnsupportedOperationException ignored) {
+      // success
+    }
+
+    try {
+      list.remove(0);
+      fail("List should be unmodifiable: remove(int)");
+    } catch (UnsupportedOperationException ignored) {
+      // success
+    }
+
+    if (contents.length > 0) {
+      // Without any items, remove(T) defaults to iterating items present, so we only test from
+      // present items
+      try {
+        list.remove(contents[0]);
+        fail("List should be unmodifiable: remove(T)");
+      } catch (UnsupportedOperationException ignored) {
+        // success
+      }
+
+      // This will actually succeed if the collection is empty, since the base implementation
+      // invokes the iterator and removes each item - an empty collection does no iteration,
+      // so the operation trivially passes
+      try {
+        list.clear();
+        fail("List should be unmodifiable: clear()");
+      } catch (UnsupportedOperationException ignored) {
+        // success
+      }
+    }
+  }
+
+}

--- a/user/test/com/google/gwt/emultest/java9/util/ListTest.java
+++ b/user/test/com/google/gwt/emultest/java9/util/ListTest.java
@@ -77,6 +77,7 @@ public class ListTest extends EmulTestBase {
     assertNPE("of", () -> List.of("a", "b", "c", "d", null));
     assertNPE("of", () -> List.of("a", "b", "c", "d", "e", null));
     assertNPE("of", () -> List.of("a", "b", "c", "d", "e", "f", null));
+    assertNPE("of", () -> List.of("a", "b", "c", "d", "e", "f", "g", null));
     assertNPE("of", () -> List.of("a", "b", "c", "d", "e", "f", "g", "h", null));
     assertNPE("of", () -> List.of("a", "b", "c", "d", "e", "f", "g", "h", "i", null));
     assertNPE("of", () -> List.of("a", "b", "c", "d", "e", "f", "g", "h", "i", "j", null));
@@ -110,6 +111,7 @@ public class ListTest extends EmulTestBase {
       // success
     }
 
+    // if any, remove an item actually in the list
     if (contents.length > 0) {
       // Without any items, remove(T) defaults to iterating items present, so we only test from
       // present items
@@ -119,16 +121,21 @@ public class ListTest extends EmulTestBase {
       } catch (UnsupportedOperationException ignored) {
         // success
       }
+    }
 
-      // This will actually succeed if the collection is empty, since the base implementation
-      // invokes the iterator and removes each item - an empty collection does no iteration,
-      // so the operation trivially passes
-      try {
-        list.clear();
-        fail("List should be unmodifiable: clear()");
-      } catch (UnsupportedOperationException ignored) {
-        // success
-      }
+    // Remove an item that will not be in the list
+    try {
+      list.remove("not present");
+      fail("List should be unmodifiable: remove(T)");
+    } catch (UnsupportedOperationException ignored) {
+      //success
+    }
+
+    try {
+      list.clear();
+      fail("List should be unmodifiable: clear()");
+    } catch (UnsupportedOperationException ignored) {
+      // success
     }
   }
 

--- a/user/test/com/google/gwt/emultest/java9/util/ListTest.java
+++ b/user/test/com/google/gwt/emultest/java9/util/ListTest.java
@@ -138,5 +138,4 @@ public class ListTest extends EmulTestBase {
       // success
     }
   }
-
 }

--- a/user/test/com/google/gwt/emultest/java9/util/MapTest.java
+++ b/user/test/com/google/gwt/emultest/java9/util/MapTest.java
@@ -17,6 +17,9 @@ package com.google.gwt.emultest.java9.util;
 
 import com.google.gwt.emultest.java.util.EmulTestBase;
 
+import java.util.AbstractMap;
+import java.util.Collections;
+import java.util.HashMap;
 import java.util.Map;
 
 /**
@@ -156,6 +159,13 @@ public class MapTest extends EmulTestBase {
     } catch (UnsupportedOperationException ignore) {
       // expected
     }
+
+    assertNPE("Map.entry", () -> {
+      Map.entry(null, "value");
+    });
+    assertNPE("Map.entry", () -> {
+      Map.entry("key", null);
+    });
   }
 
   public void testOfEntries() {

--- a/user/test/com/google/gwt/emultest/java9/util/MapTest.java
+++ b/user/test/com/google/gwt/emultest/java9/util/MapTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Google Inc.
+ * Copyright 2023 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -17,9 +17,6 @@ package com.google.gwt.emultest.java9.util;
 
 import com.google.gwt.emultest.java.util.EmulTestBase;
 
-import java.util.AbstractMap;
-import java.util.Collections;
-import java.util.HashMap;
 import java.util.Map;
 
 /**

--- a/user/test/com/google/gwt/emultest/java9/util/MapTest.java
+++ b/user/test/com/google/gwt/emultest/java9/util/MapTest.java
@@ -1,0 +1,203 @@
+/*
+ * Copyright 2020 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.gwt.emultest.java9.util;
+
+import com.google.gwt.emultest.java.util.EmulTestBase;
+
+import java.util.Map;
+
+/**
+ * Tests for java.util.Map Java 9 API emulation.
+ */
+public class MapTest extends EmulTestBase {
+
+  public void testOf() {
+    assertIsImmutableMapOf(Map.of());
+    assertIsImmutableMapOf(Map.of("a", 1), "a");
+    assertIsImmutableMapOf(
+        Map.of("a", 1, "b", 2),
+        "a", "b"
+    );
+    assertIsImmutableMapOf(
+        Map.of("a", 1, "b", 2, "c", 3),
+        "a", "b", "c"
+    );
+    assertIsImmutableMapOf(
+        Map.of("a", 1, "b", 2, "c", 3, "d", 4),
+        "a", "b", "c", "d"
+    );
+    assertIsImmutableMapOf(
+        Map.of("a", 1, "b", 2, "c", 3, "d", 4, "e", 5),
+        "a", "b", "c", "d", "e"
+    );
+    assertIsImmutableMapOf(
+        Map.of("a", 1, "b", 2, "c", 3, "d", 4, "e", 5, "f", 6),
+        "a", "b", "c", "d", "e", "f"
+    );
+    assertIsImmutableMapOf(
+        Map.of("a", 1, "b", 2, "c", 3, "d", 4, "e", 5, "f", 6, "g", 7),
+        "a", "b", "c", "d", "e", "f", "g"
+    );
+    assertIsImmutableMapOf(
+        Map.of("a", 1, "b", 2, "c", 3, "d", 4, "e", 5, "f", 6, "g", 7, "h", 8),
+        "a", "b", "c", "d", "e", "f", "g", "h"
+    );
+    assertIsImmutableMapOf(
+        Map.of("a", 1, "b", 2, "c", 3, "d", 4, "e", 5, "f", 6, "g", 7, "h", 8, "i", 9),
+        "a", "b", "c", "d", "e", "f", "g", "h", "i"
+    );
+    assertIsImmutableMapOf(
+        Map.of("a", 1, "b", 2, "c", 3, "d", 4, "e", 5, "f", 6, "g", 7, "h", 8, "i", 9, "j", 10),
+        "a", "b", "c", "d", "e", "f", "g", "h", "i", "j"
+    );
+
+    // ensure NullPointerException if either key or value are null for any param
+    assertNPE("Map.of(1)", () -> Map.of(null, 1));
+    assertNPE("Map.of(1)", () -> Map.of("a", null));
+    assertNPE("Map.of(2)", () -> Map.of("a", 1, null, 2));
+    assertNPE("Map.of(2)", () -> Map.of("a", 1, "b", null));
+    assertNPE("Map.of(3)", () -> Map.of("a", 1, "b", 2, null, 3));
+    assertNPE("Map.of(3)", () -> Map.of("a", 1, "b", 2, "c", null));
+    assertNPE("Map.of(4)", () -> Map.of("a", 1, "b", 2, "c", 3, null, 4));
+    assertNPE("Map.of(4)", () -> Map.of("a", 1, "b", 2, "c", 3, "d", null));
+    assertNPE("Map.of(5)", () -> Map.of("a", 1, "b", 2, "c", 3, "d", 4, null, 5));
+    assertNPE("Map.of(5)", () -> Map.of("a", 1, "b", 2, "c", 3, "d", 4, "e", null));
+    assertNPE("Map.of(6)", () -> Map.of("a", 1, "b", 2, "c", 3, "d", 4, "e", 5, null, 6));
+    assertNPE("Map.of(6)", () -> Map.of("a", 1, "b", 2, "c", 3, "d", 4, "e", 5, "f", null));
+    assertNPE("Map.of(7)", () -> Map.of("a", 1, "b", 2, "c", 3, "d", 4, "e", 5, "f", 6,
+        null, 7));
+    assertNPE("Map.of(7)", () -> Map.of("a", 1, "b", 2, "c", 3, "d", 4, "e", 5, "f", 6,
+        "g", null));
+    assertNPE("Map.of(8)", () -> Map.of("a", 1, "b", 2, "c", 3, "d", 4, "e", 5, "f", 6,
+        "g", 7, null, 8));
+    assertNPE("Map.of(8)", () -> Map.of("a", 1, "b", 2, "c", 3, "d", 4, "e", 5, "f", 6,
+        "g", 7, "h", null));
+    assertNPE("Map.of(9)", () -> Map.of("a", 1, "b", 2, "c", 3, "d", 4, "e", 5, "f", 6,
+        "g", 7, "h", 8, null, 9));
+    assertNPE("Map.of(9)", () -> Map.of("a", 1, "b", 2, "c", 3, "d", 4, "e", 5, "f", 6,
+        "g", 7, "h", 8, "i", null));
+    assertNPE("Map.of(10)", () -> Map.of("a", 1, "b", 2, "c", 3, "d", 4, "e", 5, "f", 6,
+        "g", 7, "h", 8, "i", 9, null, 10));
+    assertNPE("Map.of(10)", () -> Map.of("a", 1, "b", 2, "c", 3, "d", 4, "e", 5, "f", 6,
+        "g", 7, "h", 8, "i", 9, "j", null));
+
+    // ensure IllegalArgumentException if any key is repeated
+    assertIAE("Map.of(2)", () -> Map.of("a", 1, "a", 2));
+    assertIAE("Map.of(3)", () -> Map.of("a", 1, "b", 2, "a", 3));
+    assertIAE("Map.of(4)", () -> Map.of("a", 1, "b", 2, "c", 3, "a", 4));
+    assertIAE("Map.of(5)", () -> Map.of("a", 1, "b", 2, "c", 3, "d", 4, "a", 5));
+    assertIAE("Map.of(6)", () -> Map.of("a", 1, "b", 2, "c", 3, "d", 4, "e", 5, "a", 6));
+    assertIAE("Map.of(7)", () -> Map.of("a", 1, "b", 2, "c", 3, "d", 4, "e", 5, "f", 6, "a", 7));
+    assertIAE("Map.of(8)", () -> Map.of("a", 1, "b", 2, "c", 3, "d", 4, "e", 5, "f", 6, "g", 7,
+        "a", 8));
+    assertIAE("Map.of(9)", () -> Map.of("a", 1, "b", 2, "c", 3, "d", 4, "e", 5, "f", 6, "g", 7,
+        "h", 8, "a", 9));
+    assertIAE("Map.of(10)", () -> Map.of("a", 1, "b", 2, "c", 3, "d", 4, "e", 5, "f", 6, "g", 7,
+        "h", 8, "i", 9, "a", 10));
+  }
+
+  protected static void assertIsImmutableMapOf(Map<String, Integer> map, String... contents) {
+    assertEquals(contents.length, map.size());
+    for (int i = 0; i < contents.length; i++) {
+      assertTrue(map.containsKey(contents[i]));
+      assertFalse(map.containsKey(contents[i] + "nope"));
+      assertEquals(i + 1, (int) map.get(contents[i]));
+    }
+
+    // quick check that the map is immutable
+    try {
+      map.put("another item", 1);
+      fail("Set should be unmodifiable: add(T)");
+    } catch (UnsupportedOperationException ignored) {
+      // success
+    }
+
+    if (contents.length > 1) {
+      // Without any items, remove(T) defaults to iterating items present, so we only test from
+      // present items
+      try {
+        map.remove(contents[0]);
+        fail("Map should be unmodifiable: remove(T)");
+      } catch (UnsupportedOperationException ignored) {
+        // success
+      }
+
+      try {
+        map.clear();
+        fail("Set should be unmodifiable: clear()");
+      } catch (UnsupportedOperationException ignored) {
+        // expected
+      }
+    }
+  }
+
+  public void testEntry() {
+    Map.Entry<String, String> entry = Map.entry("a", "b");
+
+    assertEquals("a", entry.getKey());
+    assertEquals("b", entry.getValue());
+
+    try {
+      entry.setValue("z");
+      fail("Entry should be immutable: setValue");
+    } catch (UnsupportedOperationException ignore) {
+      // expected
+    }
+  }
+
+  public void testOfEntries() {
+    Map<String, Integer> map = Map.ofEntries(
+        Map.entry("a", 1),
+        Map.entry("b", 2)
+    );
+
+    assertIsImmutableMapOf(map, "a", "b");
+
+    // ensure NullPointerException if any entry is null, if any key is null, or value is null
+    assertNPE("Map.ofEntries", () -> {
+      Map.ofEntries(
+          Map.entry("a", "b"),
+          null
+      );
+    });
+    assertNPE("Map.ofEntries", () -> {
+      Map.ofEntries(
+          Map.entry("a", "b"),
+          Map.entry("c", null)
+      );
+    });
+    assertNPE("Map.ofEntries", () -> {
+      Map.ofEntries(
+          Map.entry("a", "b"),
+          Map.entry(null, "d")
+      );
+    });
+
+    // ensure IllegalArgumentException if any pair has the same key (same or different value)
+    assertIAE("Map.ofEntries", () -> {
+      Map.ofEntries(
+          Map.entry("a", "b"),
+          Map.entry("a", "b")
+      );
+    });
+    assertIAE("Map.ofEntries", () -> {
+      Map.ofEntries(
+          Map.entry("a", "b"),
+          Map.entry("a", "c")
+      );
+    });
+  }
+}

--- a/user/test/com/google/gwt/emultest/java9/util/MapTest.java
+++ b/user/test/com/google/gwt/emultest/java9/util/MapTest.java
@@ -172,6 +172,7 @@ public class MapTest extends EmulTestBase {
     });
   }
 
+  @SuppressWarnings("DuplicateMapKeys")
   public void testOfEntries() {
     Map<String, Integer> map = Map.ofEntries(
         Map.entry("a", 1),

--- a/user/test/com/google/gwt/emultest/java9/util/MapTest.java
+++ b/user/test/com/google/gwt/emultest/java9/util/MapTest.java
@@ -134,13 +134,20 @@ public class MapTest extends EmulTestBase {
       } catch (UnsupportedOperationException ignored) {
         // success
       }
+    }
 
-      try {
-        map.clear();
-        fail("Set should be unmodifiable: clear()");
-      } catch (UnsupportedOperationException ignored) {
-        // expected
-      }
+    try {
+      map.remove("not found");
+      fail("Map should be unmodifiable: remove(T)");
+    } catch (UnsupportedOperationException ignored) {
+      // success
+    }
+
+    try {
+      map.clear();
+      fail("Set should be unmodifiable: clear()");
+    } catch (UnsupportedOperationException ignored) {
+      // expected
     }
   }
 

--- a/user/test/com/google/gwt/emultest/java9/util/SetTest.java
+++ b/user/test/com/google/gwt/emultest/java9/util/SetTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Google Inc.
+ * Copyright 2023 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/user/test/com/google/gwt/emultest/java9/util/SetTest.java
+++ b/user/test/com/google/gwt/emultest/java9/util/SetTest.java
@@ -1,0 +1,156 @@
+/*
+ * Copyright 2020 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.gwt.emultest.java9.util;
+
+import com.google.gwt.emultest.java.util.EmulTestBase;
+
+import java.util.Arrays;
+import java.util.Iterator;
+import java.util.Set;
+
+/**
+ * Tests for java.util.Set Java 9 API emulation.
+ */
+public class SetTest extends EmulTestBase {
+
+  public void testOf() {
+    assertIsImmutableSetOf(Set.of());
+    assertIsImmutableSetOf(Set.of("a"), "a");
+    assertIsImmutableSetOf(
+        Set.of("a", "b"),
+        "a", "b"
+    );
+    assertIsImmutableSetOf(
+        Set.of("a", "b", "c"),
+        "a", "b", "c"
+    );
+    assertIsImmutableSetOf(
+        Set.of("a", "b", "c", "d"),
+        "a", "b", "c", "d"
+    );
+    assertIsImmutableSetOf(
+        Set.of("a", "b", "c", "d", "e"),
+        "a", "b", "c", "d", "e"
+    );
+    assertIsImmutableSetOf(
+        Set.of("a", "b", "c", "d", "e", "f"),
+        "a", "b", "c", "d", "e", "f"
+    );
+    assertIsImmutableSetOf(
+        Set.of("a", "b", "c", "d", "e", "f", "g"),
+        "a", "b", "c", "d", "e", "f", "g"
+    );
+    assertIsImmutableSetOf(
+        Set.of("a", "b", "c", "d", "e", "f", "g", "h"),
+        "a", "b", "c", "d", "e", "f", "g", "h"
+    );
+    assertIsImmutableSetOf(
+        Set.of("a", "b", "c", "d", "e", "f", "g", "h", "i"),
+        "a", "b", "c", "d", "e", "f", "g", "h", "i"
+    );
+    assertIsImmutableSetOf(
+        Set.of("a", "b", "c", "d", "e", "f", "g", "h", "i", "j"),
+        "a", "b", "c", "d", "e", "f", "g", "h", "i", "j"
+    );
+    assertIsImmutableSetOf(
+        Set.of("a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k"),
+        "a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k"
+    );
+
+    // ensure NPE if any element is null
+    assertNPE("Set.of(1)", () -> Set.of((String) null));
+    assertNPE("Set.of(2)", () -> Set.of("a", null));
+    assertNPE("Set.of(3)", () -> Set.of("a", "b", null));
+    assertNPE("Set.of(4)", () -> Set.of("a", "b", "c", null));
+    assertNPE("Set.of(5)", () -> Set.of("a", "b", "c", "d", null));
+    assertNPE("Set.of(6)", () -> Set.of("a", "b", "c", "d", "e", null));
+    assertNPE("Set.of(7)", () -> Set.of("a", "b", "c", "d", "e", "f", null));
+    assertNPE("Set.of(8)", () -> Set.of("a", "b", "c", "d", "e", "f", "g", null));
+    assertNPE("Set.of(9)", () -> Set.of("a", "b", "c", "d", "e", "f", "g", "h", null));
+    assertNPE("Set.of(10)", () -> Set.of("a", "b", "c", "d", "e", "f", "g", "h", "i", null));
+    assertNPE("Set.of(...)", () -> Set.of("a", "b", "c", "d", "e", "f", "g", "h", "i", "j", null));
+
+    // ensure IAE if any element is duplicated
+    assertIAE("Set.of(2)", () -> Set.of("a", "a"));
+    assertIAE("Set.of(3)", () -> Set.of("a", "b", "a"));
+    assertIAE("Set.of(4)", () -> Set.of("a", "b", "c", "a"));
+    assertIAE("Set.of(5)", () -> Set.of("a", "b", "c", "d", "a"));
+    assertIAE("Set.of(6)", () -> Set.of("a", "b", "c", "d", "e", "a"));
+    assertIAE("Set.of(7)", () -> Set.of("a", "b", "c", "d", "e", "f", "a"));
+    assertIAE("Set.of(8)", () -> Set.of("a", "b", "c", "d", "e", "f", "g", "a"));
+    assertIAE("Set.of(9)", () -> Set.of("a", "b", "c", "d", "e", "f", "g", "h", "a"));
+    assertIAE("Set.of(10)", () -> Set.of("a", "b", "c", "d", "e", "f", "g", "h", "i", "a"));
+    assertIAE("Set.of(...)", () -> Set.of("a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "a"));
+  }
+
+  protected static void assertIsImmutableSetOf(Set<String> set, String... contents) {
+    assertEquals(contents.length, set.size());
+    for (int i = 0; i < contents.length; i++) {
+      assertTrue(set.contains(contents[i]));
+      assertFalse(set.contains(contents[i] + "nope"));
+    }
+
+    // quick test that the set impl is sane, aside from the above
+    if (contents.length == 0) {
+      assertFalse(set.iterator().hasNext());
+    } else {
+      Iterator<String> itr = set.iterator();
+      assertTrue(itr.hasNext());
+
+      assertContains(contents, itr.next());
+
+      assertEquals(contents.length > 1, itr.hasNext());
+    }
+
+    // quick check that the set is immutable
+    try {
+      set.add("another item");
+      fail("Set should be unmodifiable: add(T)");
+    } catch (UnsupportedOperationException ignored) {
+      // success
+    }
+
+    if (contents.length > 1) {
+      // Without any items, remove(T) defaults to iterating items present, so we only test from
+      // present items
+      try {
+        set.remove(contents[0]);
+        fail("Set should be unmodifiable: remove(T)");
+      } catch (UnsupportedOperationException ignored) {
+        // success
+      }
+
+      // This will actually succeed if the collection is empty, since the base implementation
+      // invokes the iterator and removes each item - an empty collection does no iteration,
+      // so the operation trivially passes
+      try {
+        set.clear();
+        fail("Set should be unmodifiable: clear()");
+      } catch (UnsupportedOperationException ignored) {
+        // success
+      }
+    }
+  }
+
+  private static void assertContains(String[] contents, String value) {
+    for (String item : contents) {
+      if (item.equals(value)) {
+        return;
+      }
+    }
+    fail("Failed to find '" + value + "' in " + Arrays.toString(contents));
+  }
+}

--- a/user/test/com/google/gwt/emultest/java9/util/SetTest.java
+++ b/user/test/com/google/gwt/emultest/java9/util/SetTest.java
@@ -123,6 +123,7 @@ public class SetTest extends EmulTestBase {
       // success
     }
 
+    // if any, remove an item actually in the set
     if (contents.length > 1) {
       // Without any items, remove(T) defaults to iterating items present, so we only test from
       // present items
@@ -132,16 +133,21 @@ public class SetTest extends EmulTestBase {
       } catch (UnsupportedOperationException ignored) {
         // success
       }
+    }
 
-      // This will actually succeed if the collection is empty, since the base implementation
-      // invokes the iterator and removes each item - an empty collection does no iteration,
-      // so the operation trivially passes
-      try {
-        set.clear();
-        fail("Set should be unmodifiable: clear()");
-      } catch (UnsupportedOperationException ignored) {
-        // success
-      }
+    // Remove an item that will not be in the set
+    try {
+      set.remove("not present");
+      fail("Set should be unmodifiable: remove(T)");
+    } catch (UnsupportedOperationException ignored) {
+      // success
+    }
+
+    try {
+      set.clear();
+      fail("Set should be unmodifiable: clear()");
+    } catch (UnsupportedOperationException ignored) {
+      // success
     }
   }
 


### PR DESCRIPTION
See earlier review at https://gwt-review.googlesource.com/c/gwt/+/21501.

Build changes get us ready for missing Java 10 and 11 emulation as well.

Fixes #9547