### PR TITLE
Avoid document.write in Chrome with iframe linker

### DIFF
--- a/dev/core/src/com/google/gwt/core/ext/linker/impl/installLocationIframe.js
+++ b/dev/core/src/com/google/gwt/core/ext/linker/impl/installLocationIframe.js
@@ -46,8 +46,10 @@ function setupInstallLocation() {
   // throwing away the current document.
   //
   // In IE, it ensures that the <body> element is immediately available.
-  frameDoc.open();
-  var doctype = (document.compatMode == 'CSS1Compat') ? '<!doctype html>' : '';
-  frameDoc.write(doctype + '<html><head></head><body></body></html>');
-  frameDoc.close();
+  if (navigator.userAgent.indexOf("Chrome") == -1) {
+    frameDoc.open();
+    var doctype = (document.compatMode == 'CSS1Compat') ? '<!doctype html>' : '';
+    frameDoc.write(doctype + '<html><head></head><body></body></html>');
+    frameDoc.close();
+  }
 }


### PR DESCRIPTION
This PR avoids `document.write` in Chrome browser. It cannot be simply removed for all browsers for reasons mentioned in the code comment (I verified it's still valid in Firefox, didn't check Safari or IE).

*Motivation*
Same as https://github.com/gwtproject/gwt/pull/9814 -- `document.write` is considered bad for perfomance (flagged by Lighthouse performance audits) and completely forbidden in some contexts (chrome extensions, packaged chrome apps).

*Testing*
This is part of GeoGebra codebase for a few months (via https://github.com/geogebra/geogebra/commit/ac5c880d235e24ef5ff0715e8613eb27a692ac23) and we didn't notice any problems.