### PR TITLE
Remove redundant readme instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,10 +28,6 @@
 
    `$ ant clean dist-dev`
 
-   or if you don't have `python` and `g++` just run
-
-   `$ ant clean dist-dev`
-
    Then you will get all `.jar` files in the folder `build/lib` and
    the redistributable file will be: `build/dist/gwt-0.0.0.zip`
 


### PR DESCRIPTION
Since elemental was removed from this repo, thementions of python and c++ seem redundant.