### PR TITLE
Additional JRE emulation types marked as Serializable

### DIFF
--- a/user/super/com/google/gwt/emul/java/util/AbstractMap.java
+++ b/user/super/com/google/gwt/emul/java/util/AbstractMap.java
@@ -19,6 +19,8 @@ import static javaemul.internal.InternalPreconditions.checkNotNull;
 
 import jsinterop.annotations.JsNonNull;
 
+import java.io.Serializable;
+
 /**
  * Skeletal implementation of the Map interface. <a
  * href="http://java.sun.com/j2se/1.5.0/docs/api/java/util/AbstractMap.html">[Sun
@@ -32,7 +34,7 @@ public abstract class AbstractMap<K, V> implements Map<K, V> {
   /**
    * A mutable {@link Map.Entry} shared by several {@link Map} implementations.
    */
-  public static class SimpleEntry<K, V> extends AbstractEntry<K, V> {
+  public static class SimpleEntry<K, V> extends AbstractEntry<K, V> implements Serializable {
     public SimpleEntry(K key, V value) {
       super(key, value);
     }
@@ -45,7 +47,8 @@ public abstract class AbstractMap<K, V> implements Map<K, V> {
   /**
    * An immutable {@link Map.Entry} shared by several {@link Map} implementations.
    */
-  public static class SimpleImmutableEntry<K, V> extends AbstractEntry<K, V> {
+  public static class SimpleImmutableEntry<K, V> extends AbstractEntry<K, V> implements
+      Serializable {
     public SimpleImmutableEntry(K key, V value) {
       super(key, value);
     }

--- a/user/super/com/google/gwt/emul/java/util/Collections.java
+++ b/user/super/com/google/gwt/emul/java/util/Collections.java
@@ -354,7 +354,7 @@ public class Collections {
    * TODO: make the unmodifiable collections serializable.
    */
 
-  static class UnmodifiableCollection<T> implements Collection<T> {
+  static class UnmodifiableCollection<T> implements Collection<T>, Serializable {
     protected final Collection<? extends T> coll;
 
     public UnmodifiableCollection(Collection<? extends T> coll) {
@@ -523,7 +523,7 @@ public class Collections {
     }
   }
 
-  static class UnmodifiableMap<K, V> implements Map<K, V> {
+  static class UnmodifiableMap<K, V> implements Map<K, V>, Serializable {
 
     static class UnmodifiableEntrySet<K, V> extends
         UnmodifiableSet<Map.Entry<K, V>> {

--- a/user/super/com/google/gwt/emul/java/util/Collections.java
+++ b/user/super/com/google/gwt/emul/java/util/Collections.java
@@ -350,10 +350,6 @@ public class Collections {
     return s;
   }
 
-  /*
-   * TODO: make the unmodifiable collections serializable.
-   */
-
   static class UnmodifiableCollection<T> implements Collection<T>, Serializable {
     protected final Collection<? extends T> coll;
 

--- a/user/test/com/google/gwt/user/client/rpc/CollectionsTest.java
+++ b/user/test/com/google/gwt/user/client/rpc/CollectionsTest.java
@@ -36,6 +36,7 @@ import com.google.gwt.user.client.rpc.TestSetFactory.MarkerTypeLinkedList;
 import com.google.gwt.user.client.rpc.TestSetFactory.MarkerTypeSingleton;
 import com.google.gwt.user.client.rpc.TestSetFactory.MarkerTypeTreeMap;
 import com.google.gwt.user.client.rpc.TestSetFactory.MarkerTypeTreeSet;
+import com.google.gwt.user.client.rpc.TestSetFactory.MarkerTypeUnmodifiable;
 import com.google.gwt.user.client.rpc.TestSetFactory.MarkerTypeVector;
 import com.google.gwt.user.client.rpc.core.java.util.LinkedHashMap_CustomFieldSerializer;
 
@@ -849,6 +850,25 @@ public class CollectionsTest extends RpcTestBase {
           public void onSuccess(List<MarkerTypeSingleton> result) {
             assertNotNull(result);
             assertTrue(TestSetValidator.isValidSingletonList(result));
+            finishTest();
+          }
+        });
+  }
+
+  public void testUnmodifiableList() {
+    CollectionsTestServiceAsync service = getServiceAsync();
+    delayTestFinishForRpc();
+    service.echoUnmodifiableList(TestSetFactory.createUnmodifiableList(),
+        new AsyncCallback<List<MarkerTypeUnmodifiable>>() {
+          @Override
+          public void onFailure(Throwable caught) {
+            TestSetValidator.rethrowException(caught);
+          }
+
+          @Override
+          public void onSuccess(List<MarkerTypeUnmodifiable> result) {
+            assertNotNull(result);
+            assertTrue(TestSetValidator.isValidUnmodifiableList(result));
             finishTest();
           }
         });

--- a/user/test/com/google/gwt/user/client/rpc/CollectionsTestService.java
+++ b/user/test/com/google/gwt/user/client/rpc/CollectionsTestService.java
@@ -35,6 +35,7 @@ import com.google.gwt.user.client.rpc.TestSetFactory.MarkerTypeLinkedList;
 import com.google.gwt.user.client.rpc.TestSetFactory.MarkerTypeSingleton;
 import com.google.gwt.user.client.rpc.TestSetFactory.MarkerTypeTreeMap;
 import com.google.gwt.user.client.rpc.TestSetFactory.MarkerTypeTreeSet;
+import com.google.gwt.user.client.rpc.TestSetFactory.MarkerTypeUnmodifiable;
 import com.google.gwt.user.client.rpc.TestSetFactory.MarkerTypeVector;
 
 import java.sql.Time;
@@ -192,5 +193,9 @@ public interface CollectionsTestService extends RemoteService {
 
   // For Collections.singletonList()
   List<MarkerTypeSingleton> echoSingletonList(List<MarkerTypeSingleton> value)
+      throws CollectionsTestServiceException;
+
+  // For Collections.unmodifiableList()
+  List<MarkerTypeUnmodifiable> echoUnmodifiableList(List<MarkerTypeUnmodifiable> value)
       throws CollectionsTestServiceException;
 }

--- a/user/test/com/google/gwt/user/client/rpc/CollectionsTestServiceAsync.java
+++ b/user/test/com/google/gwt/user/client/rpc/CollectionsTestServiceAsync.java
@@ -35,6 +35,7 @@ import com.google.gwt.user.client.rpc.TestSetFactory.MarkerTypeLinkedList;
 import com.google.gwt.user.client.rpc.TestSetFactory.MarkerTypeSingleton;
 import com.google.gwt.user.client.rpc.TestSetFactory.MarkerTypeTreeMap;
 import com.google.gwt.user.client.rpc.TestSetFactory.MarkerTypeTreeSet;
+import com.google.gwt.user.client.rpc.TestSetFactory.MarkerTypeUnmodifiable;
 import com.google.gwt.user.client.rpc.TestSetFactory.MarkerTypeVector;
 
 import java.sql.Time;
@@ -168,4 +169,8 @@ public interface CollectionsTestServiceAsync {
   // For Collections.singletonList()
   void echoSingletonList(List<MarkerTypeSingleton> value,
       AsyncCallback<List<MarkerTypeSingleton>> callback);
+
+  // For Collections.unmodifiableList()
+  void echoUnmodifiableList(List<MarkerTypeUnmodifiable> value,
+                         AsyncCallback<List<MarkerTypeUnmodifiable>> callback);
 }

--- a/user/test/com/google/gwt/user/client/rpc/TestSetFactory.java
+++ b/user/test/com/google/gwt/user/client/rpc/TestSetFactory.java
@@ -22,6 +22,7 @@ import java.sql.Time;
 import java.sql.Timestamp;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.Comparator;
 import java.util.Date;
 import java.util.EnumMap;
@@ -311,6 +312,15 @@ public class TestSetFactory {
   public static final class MarkerTypeSingleton extends MarkerBase {
     MarkerTypeSingleton() {
       super("singleton");
+    }
+  }
+  /**
+   * A single-use marker type to independently check type parameter exposure in
+   * unmodifiable collections.
+   */
+  public static final class MarkerTypeUnmodifiable extends MarkerBase {
+    MarkerTypeUnmodifiable() {
+      super("unmodifiable");
     }
   }
 
@@ -781,6 +791,10 @@ public class TestSetFactory {
 
   public static List<MarkerTypeSingleton> createSingletonList() {
     return java.util.Collections.singletonList(new MarkerTypeSingleton());
+  }
+
+  public static List<MarkerTypeUnmodifiable> createUnmodifiableList() {
+    return java.util.Collections.unmodifiableList(Collections.singletonList(new MarkerTypeUnmodifiable()));
   }
 
   public static java.sql.Date[] createSqlDateArray() {

--- a/user/test/com/google/gwt/user/client/rpc/TestSetValidator.java
+++ b/user/test/com/google/gwt/user/client/rpc/TestSetValidator.java
@@ -28,6 +28,7 @@ import com.google.gwt.user.client.rpc.TestSetFactory.MarkerTypeIdentityHashMapVa
 import com.google.gwt.user.client.rpc.TestSetFactory.MarkerTypeSingleton;
 import com.google.gwt.user.client.rpc.TestSetFactory.MarkerTypeTreeMap;
 import com.google.gwt.user.client.rpc.TestSetFactory.MarkerTypeTreeSet;
+import com.google.gwt.user.client.rpc.TestSetFactory.MarkerTypeUnmodifiable;
 import com.google.gwt.user.client.rpc.TestSetFactory.SerializableDoublyLinkedNode;
 import com.google.gwt.user.client.rpc.TestSetFactory.SerializableGraphWithCFS;
 import com.google.gwt.user.client.rpc.TestSetFactory.SerializablePrivateNoArg;
@@ -817,6 +818,28 @@ public class TestSetValidator {
     }
     MarkerTypeSingleton singleton = (MarkerTypeSingleton) value;
     if (!"singleton".equals(singleton.getValue())) {
+      return false;
+    }
+    return true;
+  }
+
+  public static boolean isValidUnmodifiableList(List<MarkerTypeUnmodifiable> list) {
+    if (list == null) {
+      return false;
+    }
+    try {
+      list.add(new MarkerTypeUnmodifiable());
+      return false;
+    } catch (UnsupportedOperationException ignored) {
+      // expected
+    }
+    Object value = list.get(0);
+    // Perform instanceof check in case RPC did the wrong thing
+    if (!(value instanceof MarkerTypeUnmodifiable)) {
+      return false;
+    }
+    MarkerTypeSingleton singleton = (MarkerTypeSingleton) value;
+    if (!"unmodifiable".equals(singleton.getValue())) {
       return false;
     }
     return true;

--- a/user/test/com/google/gwt/user/server/rpc/CollectionsTestServiceImpl.java
+++ b/user/test/com/google/gwt/user/server/rpc/CollectionsTestServiceImpl.java
@@ -37,6 +37,7 @@ import com.google.gwt.user.client.rpc.TestSetFactory.MarkerTypeLinkedList;
 import com.google.gwt.user.client.rpc.TestSetFactory.MarkerTypeSingleton;
 import com.google.gwt.user.client.rpc.TestSetFactory.MarkerTypeTreeMap;
 import com.google.gwt.user.client.rpc.TestSetFactory.MarkerTypeTreeSet;
+import com.google.gwt.user.client.rpc.TestSetFactory.MarkerTypeUnmodifiable;
 import com.google.gwt.user.client.rpc.TestSetFactory.MarkerTypeVector;
 import com.google.gwt.user.client.rpc.TestSetValidator;
 
@@ -561,6 +562,15 @@ public class CollectionsTestServiceImpl extends RemoteServiceServlet implements
   public List<MarkerTypeSingleton> echoSingletonList(
       List<MarkerTypeSingleton> value) throws CollectionsTestServiceException {
     if (!TestSetValidator.isValidSingletonList(value)) {
+      throw new CollectionsTestServiceException();
+    }
+
+    return value;
+  }
+  @Override
+  public List<MarkerTypeUnmodifiable> echoUnmodifiableList(
+      List<MarkerTypeUnmodifiable> value) throws CollectionsTestServiceException {
+    if (!TestSetValidator.isValidUnmodifiableList(value)) {
       throw new CollectionsTestServiceException();
     }
 


### PR DESCRIPTION
Nested types in java.util.Collections and java.util.AbstractMap should implement Serializable.

Fixes #9848