### PR TITLE
Use --release 8 to ensure bytecode runs on all support JVMs

### DIFF
--- a/build_tools/doctool/build.xml
+++ b/build_tools/doctool/build.xml
@@ -4,7 +4,11 @@
   <import file="${gwt.root}/common.ant.xml" />
 
   <target name="compile" description="Compiles this project">
-    <gwt.javac />
+    <!--
+    As guarded below in the build target, doctool can't be built on
+    Java 8. In theory release could be set to 9, but 9 and 10 are EOL.
+    -->
+    <gwt.javac release="11" />
   </target>
 
   <target name="build" depends="compile" description="Packages this project into a jar" unless="${isJava8}">

--- a/common.ant.xml
+++ b/common.ant.xml
@@ -62,8 +62,7 @@
   <property name="javac.debug" value="true"/>
   <property name="javac.debuglevel" value="lines,vars,source"/>
   <property name="javac.encoding" value="utf-8"/>
-  <property name="javac.source" value="8"/>
-  <property name="javac.target" value="8"/>
+  <property name="javac.release" value="8"/>
   <property name="javac.nowarn" value="true"/>
 
   <!-- javac and errorprone instructions from https://errorprone.info/docs/installation#ant -->
@@ -158,8 +157,7 @@
   <macrodef name="gwt.javac">
     <attribute name="srcdir" default="src" />
     <attribute name="destdir" default="${javac.out}" />
-    <attribute name="source" default="${javac.source}" />
-    <attribute name="target" default="${javac.target}" />
+    <attribute name="release" default="${javac.release}" />
     <attribute name="excludes" default="" />
     <attribute name="processorpath" default="" />
     <attribute name="errorprone.args" default="" />
@@ -172,7 +170,7 @@
       </path>
       <mkdir dir="@{destdir}"/>
       <javac srcdir="@{srcdir}" sourcepath="@{srcdir}" destdir="@{destdir}" debug="${javac.debug}"
-             debuglevel="${javac.debuglevel}" source="@{source}" target="@{target}"
+             debuglevel="${javac.debuglevel}" source="@{release}" target="@{release}" release="@{release}"
              nowarn="${javac.nowarn}" encoding="${javac.encoding}" includeantruntime="false"
              fork="true" compiler="modern" excludes="@{excludes}">
         <compilerarg value="-J-Xbootclasspath/p:${errorprone.javac.jar}" if:true="${isJava8}"/>

--- a/doc/build.xml
+++ b/doc/build.xml
@@ -78,7 +78,7 @@
     <property file="${gwt.root}/build/out/packages.properties" />
     <javadoc classpathref="DOC_PATH" failonerror="true" maxmemory="1g"
              destdir="${project.build}/javadoc"
-             source="${javac.source}"
+             source="${javac.release}"
              encoding="UTF-8"
              access="package"
              packagenames="${USER_PKGS}"
@@ -125,7 +125,7 @@
                  sourcepath="${gwt.root}/user/super/com/google/gwt/emul:${gwt.root}/dev/core/super/com/google/gwt/dev/jjs/intrinsic"
                  encoding="UTF-8"
                  access="public"
-                 source="${javac.source}"
+                 source="${javac.release}"
                  packagenames="${JAVA_PKGS}"
                  docletpath="${project.build}/../build_tools/doctool/bin"
                  doclet="com.google.doctool.custom.JavaEmulSummaryDoclet">


### PR DESCRIPTION
The ant task `java` is able to take source, target, and release flags and only set the appropriate ones given the version of javac being invoked.

The doctool package always sets this to 11, since the new doclet/taglet APIs require Java 9+.

Fixes #9850