### PR TITLE
Do not set crossOrigin for file protocol

### DIFF
--- a/dev/core/src/com/google/gwt/core/ext/linker/impl/installScriptDirect.js
+++ b/dev/core/src/com/google/gwt/core/ext/linker/impl/installScriptDirect.js
@@ -9,7 +9,9 @@ function installScript(filename) {
     var docbody = doc.body;
     var script = doc.createElement('script');
     script.language='javascript';
-    script.crossOrigin='';
+    if (location.host) {
+      script.crossOrigin='';
+    }
     script.src = code;
     if (__MODULE_FUNC__.__errFn) {
       script.onerror = function() {


### PR DESCRIPTION
This allows using GWT compiled code with `installCode=false` also with `file://` protocol.

See https://github.com/gwtproject/gwt/issues/9734#issuecomment-1729695795 for the relevant Chrome error message.