### PR TITLE
Avoid StackOverflowError in TypeUtils#resolveGenerics

### DIFF
--- a/user/src/com/google/web/bindery/autobean/vm/impl/TypeUtils.java
+++ b/user/src/com/google/web/bindery/autobean/vm/impl/TypeUtils.java
@@ -207,6 +207,9 @@ public class TypeUtils {
       Object genericDeclaration = variable.getGenericDeclaration();
       if (genericDeclaration instanceof Class<?>) {
         Class<?> declaration = (Class<?>) genericDeclaration;
+        if (declaration.equals(containingType)) {
+          return ensureBaseType(type);
+        }
         // could probably optimize, but would involve duplicating a bunch of
         // getParameterization's code
         Type[] types = getParameterization(declaration, containingType);


### PR DESCRIPTION
While the issue (#9855) is related to JDK21 and its new `getFirst` and `getLast` methods in the `List`/`SequencedCollection` interfaces, the current behaviour can in theory cause problems on JDK versions before 21 too. 

With this fix the `TypeUtils#resolveGenerics` method falls back to `TypeUtils#ensureBaseType` (already used method-level type variables) when a type variable is used in the same class where it has been defined.

This class for example, currently causes a `StackOverflowError`. With this PR the error is avoided, and the `T` is resolved as `java.lang.Object`
```java
class BrokenClass<T> {
    public T getT() {
        return null;
    }
}
```

Fixes #9855 