### PR TITLE
Remove dependency on servlet-specific RPC class

### DIFF
--- a/user/src/com/google/gwt/user/server/rpc/impl/ServerSerializationStreamReader.java
+++ b/user/src/com/google/gwt/user/server/rpc/impl/ServerSerializationStreamReader.java
@@ -21,7 +21,6 @@ import com.google.gwt.user.client.rpc.SerializationException;
 import com.google.gwt.user.client.rpc.SerializedTypeViolationException;
 import com.google.gwt.user.client.rpc.impl.AbstractSerializationStreamReader;
 import com.google.gwt.user.server.Base64Utils;
-import com.google.gwt.user.server.rpc.RPC;
 import com.google.gwt.user.server.rpc.SerializationPolicy;
 import com.google.gwt.user.server.rpc.SerializationPolicyProvider;
 import com.google.gwt.user.server.rpc.ServerCustomFieldSerializer;
@@ -367,7 +366,7 @@ public final class ServerSerializationStreamReader extends AbstractSerialization
 
   private final ClassLoader classLoader;
 
-  private SerializationPolicy serializationPolicy = RPC.getDefaultSerializationPolicy();
+  private SerializationPolicy serializationPolicy = LegacySerializationPolicy.getInstance();
 
   private final SerializationPolicyProvider serializationPolicyProvider;
 


### PR DESCRIPTION
As part of the upcoming jakarta-servlet artifact patch, we want to limit which types need to be copied and modified to be jakarta-specific.

Partial #9727