### PR TITLE
Log deprecation warning when using built-in JettyLauncher

### DIFF
--- a/dev/core/src/com/google/gwt/dev/shell/StaticResourceServer.java
+++ b/dev/core/src/com/google/gwt/dev/shell/StaticResourceServer.java
@@ -1,0 +1,190 @@
+/*
+ * Copyright 2023 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.gwt.dev.shell;
+
+import com.google.gwt.core.ext.ServletContainer;
+import com.google.gwt.core.ext.ServletContainerLauncher;
+import com.google.gwt.core.ext.TreeLogger;
+import com.google.gwt.core.ext.UnableToCompleteException;
+import com.google.gwt.dev.shell.jetty.ClientAuthType;
+import com.google.gwt.dev.shell.jetty.JettyLauncherUtils;
+import com.google.gwt.dev.shell.jetty.JettyTreeLogger;
+import com.google.gwt.dev.shell.jetty.SslConfiguration;
+import org.eclipse.jetty.security.ConstraintSecurityHandler;
+import org.eclipse.jetty.server.Server;
+import org.eclipse.jetty.server.ServerConnector;
+import org.eclipse.jetty.servlet.ErrorPageErrorHandler;
+import org.eclipse.jetty.servlet.ServletContextHandler;
+import org.eclipse.jetty.util.log.Log;
+import org.eclipse.jetty.webapp.WebAppContext;
+
+import java.io.File;
+import java.util.Optional;
+
+/**
+ * Simple webserver that only hosts static resources. Intended to be the replacement
+ * for JettyLauncher.
+ */
+public class StaticResourceServer extends ServletContainerLauncher {
+
+  private String bindAddress = null;
+
+  private SslConfiguration sslConfig = new SslConfiguration(ClientAuthType.NONE, null, null, false);
+
+  @Override
+  public String getName() {
+    return "StaticResourceServer";
+  }
+
+  @Override
+  public void setBindAddress(String bindAddress) {
+    this.bindAddress = bindAddress;
+  }
+
+  @Override
+  public boolean isSecure() {
+    return sslConfig.isUseSsl();
+  }
+
+  private void checkStartParams(TreeLogger logger, int port, File appRootDir) {
+    if (logger == null) {
+      throw new NullPointerException("logger cannot be null");
+    }
+
+    if (port < 0 || port > 65535) {
+      throw new IllegalArgumentException(
+              "port must be either 0 (for auto) or less than 65536");
+    }
+
+    if (appRootDir == null) {
+      throw new NullPointerException("app root directory cannot be null");
+    }
+  }
+
+  @Override
+  public boolean processArguments(TreeLogger logger, String arguments) {
+    if (arguments != null && arguments.length() > 0) {
+      Optional<SslConfiguration> parsed = SslConfiguration.parseArgs(arguments.split(","), logger);
+      if (parsed.isPresent()) {
+        sslConfig = parsed.get();
+      } else {
+        return false;
+      }
+    }
+    return true;
+  }
+
+
+  @Override
+  public ServletContainer start(TreeLogger logger, int port, File appRootDir) throws Exception {
+    TreeLogger branch = logger.branch(TreeLogger.TRACE,
+            "Starting StaticResourceServer on port " + port, null);
+
+    checkStartParams(branch, port, appRootDir);
+
+    // During startup, use the branch logger, we'll reset this later to the root logger
+    Log.setLog(new JettyTreeLogger(branch));
+
+    Server server = new Server();
+
+    ServerConnector connector = JettyLauncherUtils.getConnector(server, sslConfig, branch);
+    JettyLauncherUtils.setupConnector(connector, bindAddress, port);
+    server.addConnector(connector);
+
+    WebAppContext webAppContext = new WebAppContext(null, "/", null, null, null,
+            new ErrorPageErrorHandler(), ServletContextHandler.NO_SECURITY);
+    webAppContext.setWar(appRootDir.getAbsolutePath());
+    webAppContext.setSecurityHandler(new ConstraintSecurityHandler());
+
+    server.setHandler(webAppContext);
+
+    server.start();
+    server.setStopAtShutdown(true);
+
+    // Now that we're started, log to the top level logger.
+    Log.setLog(new JettyTreeLogger(logger));
+
+    // DevMode#doStartUpServer() fails from time to time (rarely) due
+    // to an unknown error. Adding some logging to pinpoint the problem.
+    int connectorPort = connector.getLocalPort();
+    if (connector.getLocalPort() < 0) {
+      branch.log(TreeLogger.ERROR, String.format(
+              "Failed to connect to open channel with port %d (return value %d)",
+              port, connectorPort));
+    }
+
+    return new StaticServerImpl(connectorPort, appRootDir, branch, server);
+  }
+
+  private static final class StaticServerImpl extends ServletContainer {
+    private final int port;
+    private final File appRootDir;
+    private final TreeLogger logger;
+    private final Server server;
+
+    private StaticServerImpl(int port, File appRootDir, TreeLogger logger, Server server) {
+      this.port = port;
+      this.appRootDir = appRootDir;
+      this.logger = logger;
+      this.server = server;
+    }
+
+    @Override
+    public int getPort() {
+      return port;
+    }
+
+    @Override
+    public void refresh() throws UnableToCompleteException {
+      String msg = "Reloading web app to reflect changes in "
+              + appRootDir.getAbsolutePath();
+      TreeLogger branch = logger.branch(TreeLogger.INFO, msg);
+      // Temporarily log Jetty on the branch.
+      Log.setLog(new JettyTreeLogger(branch));
+      try {
+        server.stop();
+        server.start();
+        branch.log(TreeLogger.INFO, "Reload completed successfully");
+      } catch (Exception e) {
+        branch.log(TreeLogger.ERROR, "Unable to restart StaticResourceServer server",
+                e);
+        throw new UnableToCompleteException();
+      } finally {
+        // Reset the top-level logger.
+        Log.setLog(new JettyTreeLogger(logger));
+      }
+    }
+
+    @Override
+    public void stop() throws UnableToCompleteException {
+      TreeLogger branch = logger.branch(TreeLogger.INFO,
+              "Stopping StaticResourceServer server");
+      // Temporarily log Jetty on the branch.
+      Log.setLog(new JettyTreeLogger(branch));
+      try {
+        server.stop();
+        server.setStopAtShutdown(false);
+        branch.log(TreeLogger.TRACE, "Stopped successfully");
+      } catch (Exception e) {
+        branch.log(TreeLogger.ERROR, "Unable to stop embedded StaticResourceServer server", e);
+        throw new UnableToCompleteException();
+      } finally {
+        // Reset the top-level logger.
+        Log.setLog(new JettyTreeLogger(logger));
+      }
+    }
+  }
+}

--- a/dev/core/src/com/google/gwt/dev/shell/jetty/ClientAuthType.java
+++ b/dev/core/src/com/google/gwt/dev/shell/jetty/ClientAuthType.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2023 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.gwt.dev.shell.jetty;
+
+/**
+ * Represents the type of SSL client certificate authentication desired.
+ */
+public enum ClientAuthType {
+  NONE,
+  WANT,
+  REQUIRE,
+}

--- a/dev/core/src/com/google/gwt/dev/shell/jetty/JettyLauncherUtils.java
+++ b/dev/core/src/com/google/gwt/dev/shell/jetty/JettyLauncherUtils.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright 2023 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.gwt.dev.shell.jetty;
+
+import com.google.gwt.core.ext.TreeLogger;
+import org.eclipse.jetty.server.HttpConfiguration;
+import org.eclipse.jetty.server.HttpConnectionFactory;
+import org.eclipse.jetty.server.SecureRequestCustomizer;
+import org.eclipse.jetty.server.Server;
+import org.eclipse.jetty.server.ServerConnector;
+import org.eclipse.jetty.server.SslConnectionFactory;
+import org.eclipse.jetty.util.ssl.SslContextFactory;
+
+/**
+ * Shared static methods for both JettyLauncher and StaticResourceServer, useful for
+ * any Jetty-based implementation of a ServletContainerLauncher.
+ */
+public class JettyLauncherUtils {
+
+  private JettyLauncherUtils() {
+    // non-instantiable
+  }
+
+  /**
+   * Setup a connector for the bind address/port.
+   *
+   * @param connector
+   * @param bindAddress
+   * @param port
+   */
+  public static void setupConnector(ServerConnector connector,
+                                    String bindAddress, int port) {
+    if (bindAddress != null) {
+      connector.setHost(bindAddress);
+    }
+    connector.setPort(port);
+
+    // Allow binding to a port even if it's still in state TIME_WAIT.
+    connector.setReuseAddress(true);
+  }
+
+  public static ServerConnector getConnector(Server server, SslConfiguration sslConfig, TreeLogger logger) {
+    HttpConfiguration config = defaultConfig();
+    if (sslConfig.isUseSsl()) {
+      TreeLogger sslLogger = logger.branch(TreeLogger.INFO,
+          "Listening for SSL connections");
+      if (sslLogger.isLoggable(TreeLogger.TRACE)) {
+        sslLogger.log(TreeLogger.TRACE, "Using keystore " + sslConfig.getKeyStore());
+      }
+      SslContextFactory ssl = new SslContextFactory();
+      if (sslConfig.getClientAuth() != null) {
+        switch (sslConfig.getClientAuth()) {
+          case NONE:
+            ssl.setWantClientAuth(false);
+            ssl.setNeedClientAuth(false);
+            break;
+          case WANT:
+            sslLogger.log(TreeLogger.TRACE, "Requesting client certificates");
+            ssl.setWantClientAuth(true);
+            ssl.setNeedClientAuth(false);
+            break;
+          case REQUIRE:
+            sslLogger.log(TreeLogger.TRACE, "Requiring client certificates");
+            ssl.setWantClientAuth(true);
+            ssl.setNeedClientAuth(true);
+            break;
+        }
+      }
+      ssl.setKeyStorePath(sslConfig.getKeyStore());
+      ssl.setTrustStorePath(sslConfig.getKeyStore());
+      ssl.setKeyStorePassword(sslConfig.getKeyStorePassword());
+      ssl.setTrustStorePassword(sslConfig.getKeyStorePassword());
+      config.addCustomizer(new SecureRequestCustomizer());
+      return new ServerConnector(server,
+          null, null, null, 0, 2,
+          new SslConnectionFactory(ssl, "http/1.1"),
+          new HttpConnectionFactory(config));
+    }
+    return new ServerConnector(server, new HttpConnectionFactory(config));
+  }
+
+  private static HttpConfiguration defaultConfig() {
+     HttpConfiguration config = new HttpConfiguration();
+     config.setRequestHeaderSize(16386);
+     config.setSendServerVersion(false);
+     config.setSendDateHeader(true);
+     return config;
+  }
+}

--- a/dev/core/src/com/google/gwt/dev/shell/jetty/JettyTreeLogger.java
+++ b/dev/core/src/com/google/gwt/dev/shell/jetty/JettyTreeLogger.java
@@ -1,0 +1,134 @@
+/*
+ * Copyright 2023 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.gwt.dev.shell.jetty;
+
+import com.google.gwt.core.ext.TreeLogger;
+import org.eclipse.jetty.util.log.Logger;
+
+/**
+ * An adapter for the Jetty logging system to GWT's TreeLogger. This implementation class is only
+ * public to allow {@link org.eclipse.jetty.util.log.Log} to instantiate it.
+ * <p>
+ * The weird static data / default construction setup is a game we play with
+ * {@link org.eclipse.jetty.util.log.Log}'s static initializer to prevent the initial log message
+ * from going to stderr.
+ */
+public class JettyTreeLogger implements Logger {
+  private final TreeLogger logger;
+
+  public JettyTreeLogger(TreeLogger logger) {
+    if (logger == null) {
+      throw new NullPointerException();
+    }
+    this.logger = logger;
+  }
+
+  public void debug(String msg, long arg) {
+    logger.log(TreeLogger.SPAM, format(msg, arg));
+  }
+
+  public void debug(String msg, Object... args) {
+    if (logger.isLoggable(TreeLogger.SPAM)) {
+      logger.log(TreeLogger.SPAM, format(msg, args));
+    }
+  }
+
+  public void debug(String msg, Throwable th) {
+    logger.log(TreeLogger.SPAM, msg, th);
+  }
+
+  public void debug(Throwable th) {
+    logger.log(TreeLogger.SPAM, "", th);
+  }
+
+  public Logger getLogger(String name) {
+    return this;
+  }
+
+  public String getName() {
+    return "";
+  }
+
+  public void info(String msg, Object... args) {
+    if (logger.isLoggable(TreeLogger.TRACE)) {
+      logger.log(TreeLogger.TRACE, format(msg, args));
+    }
+  }
+
+  public void info(String msg, Throwable th) {
+    logger.log(TreeLogger.TRACE, msg, th);
+  }
+
+  public void info(Throwable th) {
+    logger.log(TreeLogger.TRACE, "", th);
+  }
+
+  public boolean isDebugEnabled() {
+    return logger.isLoggable(TreeLogger.SPAM);
+  }
+
+  public void setDebugEnabled(boolean enabled) {
+    // ignored
+  }
+
+  public void warn(String msg, Object... args) {
+    if (logger.isLoggable(TreeLogger.WARN)) {
+      logger.log(TreeLogger.WARN, format(msg, args));
+    }
+  }
+
+  public void warn(String msg, Throwable th) {
+    logger.log(TreeLogger.WARN, msg, th);
+  }
+
+  public void warn(Throwable th) {
+    logger.log(TreeLogger.WARN, "", th);
+  }
+
+  public void ignore(Throwable th) {
+    logger.log(TreeLogger.SPAM, "IGNORE", th);
+  }
+
+  /**
+   * Copied from org.eclipse.log.StdErrLog.
+   */
+  private String format(String msg, Object... args) {
+    if (msg == null) {
+      msg = "";
+      for (int i = 0; i < args.length; i++) {
+        msg += "{} ";
+      }
+    }
+    String braces = "{}";
+    int start = 0;
+    StringBuilder builder = new StringBuilder();
+    for (Object arg : args) {
+      int bracesIndex = msg.indexOf(braces, start);
+      if (bracesIndex < 0) {
+        builder.append(msg.substring(start));
+        builder.append(" ");
+        builder.append(arg);
+        start = msg.length();
+      } else {
+        builder.append(msg.substring(start, bracesIndex));
+        builder.append(String.valueOf(arg));
+        start = bracesIndex + braces.length();
+      }
+    }
+    builder.append(msg.substring(start));
+    return builder.toString();
+  }
+}

--- a/dev/core/src/com/google/gwt/dev/shell/jetty/SslConfiguration.java
+++ b/dev/core/src/com/google/gwt/dev/shell/jetty/SslConfiguration.java
@@ -1,0 +1,129 @@
+/*
+ * Copyright 2023 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.gwt.dev.shell.jetty;
+
+import com.google.gwt.core.ext.TreeLogger;
+import com.google.gwt.dev.util.Util;
+
+import java.io.File;
+import java.net.URL;
+import java.util.Optional;
+
+/**
+ * Configuration object to parse selected command line args, store SSL options for use by in the
+ * server.
+ */
+public class SslConfiguration {
+  private final ClientAuthType clientAuth;
+
+  private final String keyStore;
+
+  private final String keyStorePassword;
+
+  private final boolean useSsl;
+
+  public static Optional<SslConfiguration> parseArgs(String[] args, TreeLogger logger) {
+    boolean useSsl = false;
+    String keyStore = null;
+    String keyStorePassword = null;
+    ClientAuthType clientAuth = ClientAuthType.NONE;
+
+    // TODO(jat): better parsing of the args
+    for (String arg : args) {
+      int equals = arg.indexOf('=');
+      String tag;
+      String value = null;
+      if (equals < 0) {
+        tag = arg;
+      } else {
+        tag = arg.substring(0, equals);
+        value = arg.substring(equals + 1);
+      }
+      if ("ssl".equals(tag)) {
+        useSsl = true;
+        URL keyStoreUrl = JettyLauncher.class.getResource("localhost.keystore");
+        if (keyStoreUrl == null) {
+          logger.log(TreeLogger.ERROR, "Default GWT keystore not found");
+          return Optional.empty();
+        }
+        keyStore = keyStoreUrl.toExternalForm();
+        keyStorePassword = "localhost";
+      } else if ("keystore".equals(tag)) {
+        useSsl = true;
+        keyStore = value;
+      } else if ("password".equals(tag)) {
+        useSsl = true;
+        keyStorePassword = value;
+      } else if ("pwfile".equals(tag)) {
+        useSsl = true;
+        keyStorePassword = Util.readFileAsString(new File(value));
+        if (keyStorePassword == null) {
+          logger.log(TreeLogger.ERROR,
+                  "Unable to read keystore password from '" + value + "'");
+          return Optional.empty();
+        }
+        keyStorePassword = keyStorePassword.trim();
+      } else if ("clientAuth".equals(tag)) {
+        useSsl = true;
+        try {
+          clientAuth = ClientAuthType.valueOf(value);
+        } catch (IllegalArgumentException e) {
+          logger.log(TreeLogger.WARN, "Ignoring invalid clientAuth of '"
+                  + value + "'");
+        }
+      } else {
+        logger.log(TreeLogger.ERROR, "Unexpected argument to "
+                + JettyLauncher.class.getSimpleName() + ": " + arg);
+        return Optional.empty();
+      }
+    }
+    if (useSsl) {
+      if (keyStore == null) {
+        logger.log(TreeLogger.ERROR, "A keystore is required to use SSL");
+        return Optional.empty();
+      }
+      if (keyStorePassword == null) {
+        logger.log(TreeLogger.ERROR,
+                "A keystore password is required to use SSL");
+        return Optional.empty();
+      }
+    }
+    return Optional.of(new SslConfiguration(clientAuth, keyStore, keyStorePassword, useSsl));
+  }
+
+  public SslConfiguration(ClientAuthType clientAuth, String keyStore, String keyStorePassword, boolean useSsl) {
+    this.clientAuth = clientAuth;
+    this.keyStore = keyStore;
+    this.keyStorePassword = keyStorePassword;
+    this.useSsl = useSsl;
+  }
+
+  public ClientAuthType getClientAuth() {
+    return clientAuth;
+  }
+
+  public String getKeyStore() {
+    return keyStore;
+  }
+
+  public String getKeyStorePassword() {
+    return keyStorePassword;
+  }
+
+  public boolean isUseSsl() {
+    return useSsl;
+  }
+}

--- a/user/src/com/google/gwt/junit/JUnitShell.java
+++ b/user/src/com/google/gwt/junit/JUnitShell.java
@@ -249,6 +249,7 @@ public class JUnitShell extends DevMode {
        * ----- Options from DevMode -------
        */
       // Hard code the server.
+      JettyLauncher.suppressDeprecationWarningForTests();
       options.setServletContainerLauncher(shell.new MyJettyLauncher());
       // DISABLE: ArgHandlerStartupURLs
       registerHandler(new ArgHandlerWarDir(options) {


### PR DESCRIPTION
This patch has two approaches to check if the JettyLauncher is being used, it checks for any configured filters/servlets (other than the defaults provided by Jetty) in order to log a warning on startup, and it checks for non-404 responses to catch other resources loaded after startup.

No warning is logged for tests.

Fixes #9863