### PR TITLE
Relax naming rules to allow valid java bean properties as jsproperties

### DIFF
--- a/dev/core/src/com/google/gwt/dev/jjs/ast/HasJsInfo.java
+++ b/dev/core/src/com/google/gwt/dev/jjs/ast/HasJsInfo.java
@@ -117,7 +117,7 @@ public interface HasJsInfo extends HasJsName, CanBeJsNative {
 
     private static boolean startsWithCamelCase(String string, String prefix) {
       return string.length() > prefix.length() && string.startsWith(prefix)
-          && Character.isUpperCase(string.charAt(prefix.length()));
+          && !Character.isLowerCase(string.charAt(prefix.length()));
     }
   }
 

--- a/dev/core/src/com/google/gwt/dev/js/JsUtils.java
+++ b/dev/core/src/com/google/gwt/dev/js/JsUtils.java
@@ -480,7 +480,7 @@ public class JsUtils {
   /**
    * A JavaScript identifier contains only letters, numbers, _, $ and does not begin with a number.
    * There are actually other valid identifiers, such as ones that contain escaped Unicode
-   * characters but we disallow those for the time being.
+   * characters, but we disallow those for the time being.
    */
   public static boolean isValidJsIdentifier(String name) {
     return JAVASCRIPT_VALID_IDENTIFIER_PATTERN.matcher(name).matches();

--- a/dev/core/test/com/google/gwt/dev/jjs/impl/JsInteropRestrictionCheckerTest.java
+++ b/dev/core/test/com/google/gwt/dev/jjs/impl/JsInteropRestrictionCheckerTest.java
@@ -17,7 +17,6 @@ package com.google.gwt.dev.jjs.impl;
 
 import com.google.gwt.core.ext.TreeLogger;
 import com.google.gwt.dev.MinimalRebuildCache;
-import com.google.gwt.dev.javac.testing.impl.MockJavaResource;
 import com.google.gwt.dev.jjs.ast.JMethod;
 import com.google.gwt.dev.jjs.ast.JProgram;
 

--- a/dev/core/test/com/google/gwt/dev/jjs/impl/JsInteropRestrictionCheckerTest.java
+++ b/dev/core/test/com/google/gwt/dev/jjs/impl/JsInteropRestrictionCheckerTest.java
@@ -1268,6 +1268,77 @@ public class JsInteropRestrictionCheckerTest extends OptimizerTestBase {
     assertBuggySucceeds();
   }
 
+  public void testJsMethodWithDollarsign() throws Exception {
+    addSnippetImport("jsinterop.annotations.JsType");
+    addSnippetImport("jsinterop.annotations.JsMethod");
+    addSnippetImport("jsinterop.annotations.JsProperty");
+    addSnippetImport("jsinterop.annotations.JsPackage");
+    addSnippetClassDecl(
+            "@JsType public static class Buggy {",
+            "  public void $() {",
+            "  }",
+            "  public void $method(String l) {",
+            "  }",
+            "  public void method$(String l) {",
+            "  }",
+            "  public void method$name(String l) {",
+            "  }",
+            "}");
+    assertBuggySucceeds();
+  }
+
+  public void testJsFieldWithDollarsign() throws Exception {
+    addSnippetImport("jsinterop.annotations.JsType");
+    addSnippetImport("jsinterop.annotations.JsMethod");
+    addSnippetImport("jsinterop.annotations.JsProperty");
+    addSnippetImport("jsinterop.annotations.JsPackage");
+    addSnippetClassDecl(
+            "@JsType public static class Buggy {",
+            "  public String $;",
+            "  public String $field;",
+            "  public String field$;",
+            "  public String field$name;",
+            "}");
+    assertBuggySucceeds();
+  }
+
+  public void testJsPropertyWithDollarsign() throws Exception {
+    addSnippetImport("jsinterop.annotations.JsType");
+    addSnippetImport("jsinterop.annotations.JsProperty");
+    addSnippetClassDecl(
+            "@JsType public static class Buggy {",
+            "  @JsProperty",
+            "  public String get$() {",
+            "    return null;",
+            "  }",
+            "  @JsProperty",
+            "  public void set$(String value) {",
+            "  }",
+            "  @JsProperty",
+            "  public String get$1() {",
+            "    return null;",
+            "  }",
+            "  @JsProperty",
+            "  public void set$1(String value) {",
+            "  }",
+            "  @JsProperty",
+            "  public String getVal$() {",
+            "    return null;",
+            "  }",
+            "  @JsProperty",
+            "  public void setVal$(String value) {",
+            "  }",
+            "  @JsProperty",
+            "  public String getVal$1() {",
+            "    return null;",
+            "  }",
+            "  @JsProperty",
+            "  public void setVal$1(String value) {",
+            "  }",
+            "}");
+    assertBuggySucceeds();
+  }
+
   public void testSingleJsTypeSucceeds() throws Exception {
     addSnippetImport("jsinterop.annotations.JsType");
     addSnippetClassDecl(
@@ -2554,20 +2625,6 @@ public class JsInteropRestrictionCheckerTest extends OptimizerTestBase {
         "}");
     assertBuggySucceeds();
   }
-
-  private static final MockJavaResource jsFunctionInterface = new MockJavaResource(
-      "test.MyJsFunctionInterface") {
-    @Override
-    public CharSequence getContent() {
-      StringBuilder code = new StringBuilder();
-      code.append("package test;\n");
-      code.append("import jsinterop.annotations.JsFunction;\n");
-      code.append("@JsFunction public interface MyJsFunctionInterface {\n");
-      code.append("int foo(int x);\n");
-      code.append("}\n");
-      return code;
-    }
-  };
 
   public final void assertBuggySucceeds(String... expectedWarnings)
       throws Exception {


### PR DESCRIPTION
The old implementation only allowed a capital letter as the first character of a bean-like property, which isn't sufficient. Instead, we need to support cases where the first character is *not* lower case, so that non-letters that are valid for the first character are permitted.

Fixes #9554
