### PR TITLE
Disable rpc.enhancedClasses by default at runtime

### DIFF
--- a/user/src/com/google/gwt/user/rebind/rpc/SerializableTypeOracleBuilder.java
+++ b/user/src/com/google/gwt/user/rebind/rpc/SerializableTypeOracleBuilder.java
@@ -869,8 +869,8 @@ public class SerializableTypeOracleBuilder {
 
       if (tic.maybeEnhanced()
           || (enhancedClasses != null && enhancedClasses.contains(type.getQualifiedSourceName()))) {
-        logger.log(TreeLogger.WARN, "The class " + type.getQualifiedSourceName() + " has JPA " +
-                "annotations or is explicitly configured as an enhanced class using the " +
+        logger.log(TreeLogger.WARN, "The class " + type.getQualifiedSourceName() + " has " +
+                "JPA/JDO annotations or is explicitly configured as an enhanced class using the " +
                 "configuration property rpc.enhancedClasses. This makes the server vulnerable " +
                 "to an issue with deserialization of unsafe data. See " +
                 "https://github.com/gwtproject/gwt/issues/9709 for more information.");

--- a/user/src/com/google/gwt/user/rebind/rpc/SerializableTypeOracleBuilder.java
+++ b/user/src/com/google/gwt/user/rebind/rpc/SerializableTypeOracleBuilder.java
@@ -869,6 +869,10 @@ public class SerializableTypeOracleBuilder {
 
       if (tic.maybeEnhanced()
           || (enhancedClasses != null && enhancedClasses.contains(type.getQualifiedSourceName()))) {
+        logger.log(TreeLogger.WARN, "The class " + type.getQualifiedSourceName() + " is both " +
+                "referenced from configuration as rpc.enhancedClasses and has JPA annotations. " +
+                "This makes the server vulnerable to an issue with deserialization of unsafe " +
+                "data. See https://github.com/gwtproject/gwt/issues/9709 for more information.");
         type.setEnhanced();
       }
     }

--- a/user/src/com/google/gwt/user/rebind/rpc/SerializableTypeOracleBuilder.java
+++ b/user/src/com/google/gwt/user/rebind/rpc/SerializableTypeOracleBuilder.java
@@ -320,7 +320,7 @@ public class SerializableTypeOracleBuilder {
       JPA_ENTITY_ANNOTATION =
           Class.forName("javax.persistence.Entity").asSubclass(Annotation.class);
     } catch (ClassNotFoundException e) {
-      // Ignore, JPA_ENTITY_CAPABLE_ANNOTATION will be null
+      // Ignore, JPA_ENTITY_CAPABLE_ANNOTATION will be null
     }
   }
 
@@ -869,10 +869,11 @@ public class SerializableTypeOracleBuilder {
 
       if (tic.maybeEnhanced()
           || (enhancedClasses != null && enhancedClasses.contains(type.getQualifiedSourceName()))) {
-        logger.log(TreeLogger.WARN, "The class " + type.getQualifiedSourceName() + " is both " +
-                "referenced from configuration as rpc.enhancedClasses and has JPA annotations. " +
-                "This makes the server vulnerable to an issue with deserialization of unsafe " +
-                "data. See https://github.com/gwtproject/gwt/issues/9709 for more information.");
+        logger.log(TreeLogger.WARN, "The class " + type.getQualifiedSourceName() + " has JPA " +
+                "annotations or is explicitly configured as an enhanced class using the " +
+                "configuration property rpc.enhancedClasses. This makes the server vulnerable " +
+                "to an issue with deserialization of unsafe data. See " +
+                "https://github.com/gwtproject/gwt/issues/9709 for more information.");
         type.setEnhanced();
       }
     }

--- a/user/src/com/google/gwt/user/server/rpc/RemoteServiceServlet.java
+++ b/user/src/com/google/gwt/user/server/rpc/RemoteServiceServlet.java
@@ -16,6 +16,8 @@
 package com.google.gwt.user.server.rpc;
 
 import static com.google.gwt.user.client.rpc.RpcRequestBuilder.MODULE_BASE_HEADER;
+import static com.google.gwt.user.server.rpc.SerializationPolicyLoader.ENABLE_ENHANCED_CLASSES;
+import static com.google.gwt.user.server.rpc.SerializationPolicyLoader.ENABLE_GWT_ENHANCED_CLASSES_PROPERTY;
 
 import com.google.gwt.user.client.rpc.IncompatibleRemoteServiceException;
 import com.google.gwt.user.client.rpc.RpcTokenException;
@@ -94,6 +96,20 @@ public class RemoteServiceServlet extends AbstractRemoteServiceServlet
           try {
             serializationPolicy = SerializationPolicyLoader.loadFromStream(is,
                 null);
+            if (serializationPolicy.hasClientFields()) {
+              if (ENABLE_ENHANCED_CLASSES) {
+                servlet.log("WARNING: Enhanced JPA client fields are in use for this " +
+                        "application. See https://github.com/gwtproject/gwt/issues/9709 for " +
+                        "more detail. on the vulnerability that this presents.");
+              } else {
+                servlet.log("ERROR: Service uses enhanced classes, which are unsafe. Review " +
+                        "build logs to see where this can be fixed, or set " +
+                        ENABLE_GWT_ENHANCED_CLASSES_PROPERTY + " to true to allow using this " +
+                        "service. See https://github.com/gwtproject/gwt/issues/9709 for more " +
+                        "detail.");
+                serializationPolicy = null;
+              }
+            }
           } catch (ParseException e) {
             servlet.log("ERROR: Failed to parse the policy file '"
                 + serializationPolicyFilePath + "'", e);

--- a/user/src/com/google/gwt/user/server/rpc/RemoteServiceServlet.java
+++ b/user/src/com/google/gwt/user/server/rpc/RemoteServiceServlet.java
@@ -98,12 +98,12 @@ public class RemoteServiceServlet extends AbstractRemoteServiceServlet
                 null);
             if (serializationPolicy.hasClientFields()) {
               if (ENABLE_ENHANCED_CLASSES) {
-                servlet.log("WARNING: Enhanced JPA client fields are in use for this " +
-                        "application. See https://github.com/gwtproject/gwt/issues/9709 for " +
-                        "more detail. on the vulnerability that this presents.");
+                servlet.log("WARNING: Service deserializes enhanced JPA/JDO classes, which is " +
+                        "unsafe. See https://github.com/gwtproject/gwt/issues/9709 for more " +
+                        "detail on the vulnerability that this presents.");
               } else {
-                servlet.log("ERROR: Service uses enhanced classes, which are unsafe. Review " +
-                        "build logs to see where this can be fixed, or set " +
+                servlet.log("ERROR: Service deserializes enhanced JPA/JDO classes, which is " +
+                        "unsafe. Review build logs to see which classes are affected, or set " +
                         ENABLE_GWT_ENHANCED_CLASSES_PROPERTY + " to true to allow using this " +
                         "service. See https://github.com/gwtproject/gwt/issues/9709 for more " +
                         "detail.");

--- a/user/src/com/google/gwt/user/server/rpc/SerializationPolicy.java
+++ b/user/src/com/google/gwt/user/server/rpc/SerializationPolicy.java
@@ -82,4 +82,14 @@ public abstract class SerializationPolicy {
    */
   public abstract void validateSerialize(Class<?> clazz)
       throws SerializationException;
+
+  /**
+   * Returns true if there may be any unsafe client fields in the serialization policy. The default
+   * implementation returns true to ensure that custom implementations validate accordingly.
+   *
+   * @return true if the client may send unsafely serialized data, false otherwise
+   */
+  public boolean hasClientFields() {
+    return true;
+  }
 }

--- a/user/src/com/google/gwt/user/server/rpc/SerializationPolicyLoader.java
+++ b/user/src/com/google/gwt/user/server/rpc/SerializationPolicyLoader.java
@@ -51,6 +51,19 @@ public final class SerializationPolicyLoader {
    */
   public static final String SERIALIZATION_POLICY_FILE_ENCODING = "UTF-8";
 
+  /**
+   * System property to enable gwt-rpc enhanced classes. To use this, set the JVM system property
+   * with name {@value ENABLE_GWT_ENHANCED_CLASSES_PROPERTY} to {@code true}, any other value will
+   * leave this feature disabled in the server at runtime.
+   */
+  public static final String ENABLE_GWT_ENHANCED_CLASSES_PROPERTY = "gwt.enhancedClasses.enabled";
+
+  /**
+   * Flag to enable using enhanced classes, for applications that need them and are taking
+   * appropriate steps to secure them. Defaults to false.
+   */
+  public static final boolean ENABLE_ENHANCED_CLASSES = "true".equals(System.getProperty(ENABLE_GWT_ENHANCED_CLASSES_PROPERTY));
+
   private static final String FORMAT_ERROR_MESSAGE = "Expected: className, "
       + "[true | false], [true | false], [true | false], [true | false], typeId, signature";
   

--- a/user/src/com/google/gwt/user/server/rpc/impl/LegacySerializationPolicy.java
+++ b/user/src/com/google/gwt/user/server/rpc/impl/LegacySerializationPolicy.java
@@ -174,4 +174,9 @@ public class LegacySerializationPolicy extends SerializationPolicy implements
     }
     return SerializabilityUtil.hasCustomFieldSerializer(clazz) != null;
   }
+
+  @Override
+  public boolean hasClientFields() {
+    return false;
+  }
 }

--- a/user/src/com/google/gwt/user/server/rpc/impl/StandardSerializationPolicy.java
+++ b/user/src/com/google/gwt/user/server/rpc/impl/StandardSerializationPolicy.java
@@ -131,6 +131,11 @@ public class StandardSerializationPolicy extends SerializationPolicy implements
     return fieldNames == null ? null : Collections.unmodifiableSet(fieldNames);
   }
 
+  @Override
+  public boolean hasClientFields() {
+    return clientFields != null && !clientFields.isEmpty();
+  }
+
   public final String getTypeIdForClass(Class<?> clazz)
       throws SerializationException {
     return typeIds.get(clazz);


### PR DESCRIPTION
Logs warnings at compile time, indicating which classes need to be cleaned up to remove this feature.

Mitigation for #9709