### PR TITLE
Deprecate webAppCreator, encourage using the getting started guide

### DIFF
--- a/user/src/com/google/gwt/user/tools/WebAppCreator.java
+++ b/user/src/com/google/gwt/user/tools/WebAppCreator.java
@@ -456,6 +456,10 @@ public final class WebAppCreator {
   }
 
   public static void main(String[] args) {
+    System.err.println("WebAppCreator is deprecated - please refer to " +
+            "https://www.gwtproject.org/gettingstarted.html for other ways to create a new " +
+            "application with GWT, including with Maven archetypes. These encourage better " +
+            "separation of classpaths, and do not need IDE-specific setup.");
     System.exit(doMain(args) ? 0 : 1);
   }
 


### PR DESCRIPTION
This encourages a few bad practices that we'd like to avoid, most notably mixing server and client classpaths, and encouraging using DevMode's built-in server as an application server.

Partial #9863