### PR TITLE
Remove unexpected sources from gwt-user by making valid servlet sources

### DIFF
--- a/distro-source/build.xml
+++ b/distro-source/build.xml
@@ -31,10 +31,8 @@
       <!-- jars -->
       <zipfileset file="${gwt.build.lib}/gwt-dev.jar" prefix="${project.distname}" />
       <zipfileset file="${gwt.build.lib}/gwt-user.jar" prefix="${project.distname}" />
-      <zipfileset file="${gwt.build.lib}/gwt-servlet.jar" prefix="${project.distname}" />
-      <zipfileset file="${gwt.build.lib}/gwt-servlet-jakarta.jar" prefix="${project.distname}" />
+      <zipfileset file="${gwt.build.lib}/gwt-servlet*.jar" prefix="${project.distname}" />
       <zipfileset file="${gwt.build.lib}/gwt-codeserver.jar" prefix="${project.distname}" />
-      <zipfileset file="${gwt.build.lib}/gwt-servlet-deps.jar" prefix="${project.distname}" />
       <zipfileset file="${gwt.build.lib}/gwt-api-checker.jar" prefix="${project.distname}" />
       <zipfileset file="${gwt.build.lib}/requestfactory*.jar" prefix="${project.distname}" />
 

--- a/maven/lib-gwt.sh
+++ b/maven/lib-gwt.sh
@@ -115,14 +115,10 @@ function maven-gwt() {
     gwtPomFile=$pomDir/gwt/gwt-$i/pom.xml
     SOURCES_FILE=gwt-${i}-sources.jar
     SOURCES_PATH_FILE=$GWT_EXTRACT_DIR/$SOURCES_FILE
-    # If there are no sources, use gwt-user sources.
-    # This is a bit hacky but Sonatype requires a
-    # source jar for Central, and lack of sources
-    # should only happen for gwt-servlet and
-    # gwt-servlet-jakarta, which are basically a
-    # subset of gwt-user.
+    # If there are no sources, fail, this is a requirement of maven central
     if [ ! -f $SOURCES_PATH_FILE ]; then
-      SOURCES_PATH_FILE=$GWT_EXTRACT_DIR/gwt-user-sources.jar
+      echo "ERROR: sources jar not found for $i"
+      exit 1
     fi
 
     maven-deploy-file $mavenRepoUrl $mavenRepoId "$CUR_FILE" $gwtPomFile "$JAVADOC_FILE_PATH" "$SOURCES_PATH_FILE" || die

--- a/servlet/build.xml
+++ b/servlet/build.xml
@@ -13,7 +13,7 @@
       location="${gwt.build.lib}/gwt-${ant.project.name}-deps.jar" />
 
   <target name="build" description="Packages this project into a jar"
-      depends="-servlet, -servlet-jakarta, -deps" />
+      depends="-servlet, -servlet-jakarta, -servlet-sources, -servlet-jakarta-sources, -deps" />
 
   <target name="clean" description="Cleans this project's intermediate and output files">
     <delete file="${project.lib}" />
@@ -30,7 +30,6 @@
       <zipfileset src="${gwt.tools.lib}/streamhtmlparser/streamhtmlparser-jsilver-r10/streamhtmlparser-jsilver-r10-1.5-rebased.jar" />
       <zipfileset src="${gwt.tools.lib}/protobuf/protobuf-2.5.0/protobuf-java-rebased-2.5.0.jar" />
       <fileset dir="${gwt.dev.bin}">
-        <include name="com/google/gwt/dev/asm/**" />
         <include name="com/google/gwt/dev/util/Name*.class" />
         <include name="com/google/gwt/dev/util/StringKey.class" />
         <include name="com/google/gwt/util/tools/shared/**" />
@@ -43,13 +42,28 @@
         <exclude name="com/google/gwt/json/**" />
         <exclude name="com/google/gwt/junit/*" />
         <exclude name="com/google/gwt/junit/client/GWTTestCase.*" />
-        <exclude name="com/google/gwt/junit/remote/**" />
         <exclude name="com/google/gwt/junit/server/**" />
-        <exclude name="com/google/gwt/benchmarks/*" />
-        <exclude name="**/*.gwtar" />
       </fileset>
-
-      <!-- additional dependencies (used by scripts). -->
+    </gwt.jar>
+  </target>
+  <target name="-servlet-sources" description="Packages sources found in gwt-servlet">
+    <mkdir dir="${gwt.build.lib}" />
+    <gwt.jar destfile="${gwt.build.lib}/gwt-servlet-sources.jar">
+      <fileset dir="${gwt.root}/dev/core/src">
+        <include name="com/google/gwt/dev/util/Name.java" />
+        <include name="com/google/gwt/dev/util/StringKey.java" />
+        <include name="com/google/gwt/util/tools/shared/**" />
+        <include name="com/google/gwt/core/shared/**" />
+      </fileset>
+      <fileset dir="${gwt.root}/user/src">
+        <exclude name="**/rebind/**" />
+        <exclude name="**/tools/**" />
+        <exclude name="**/super/**" />
+        <exclude name="com/google/gwt/json/**" />
+        <exclude name="com/google/gwt/junit/*" />
+        <exclude name="com/google/gwt/junit/client/GWTTestCase.*" />
+        <exclude name="com/google/gwt/junit/server/**" />
+      </fileset>
     </gwt.jar>
   </target>
   <target name="-servlet-jakarta" description="Packages this project into a jar for use with modern jakarta apis">
@@ -62,7 +76,6 @@
       <zipfileset src="${gwt.tools.lib}/streamhtmlparser/streamhtmlparser-jsilver-r10/streamhtmlparser-jsilver-r10-1.5-rebased.jar" />
       <zipfileset src="${gwt.tools.lib}/protobuf/protobuf-2.5.0/protobuf-java-rebased-2.5.0.jar" />
       <fileset dir="${gwt.dev.bin}">
-        <include name="com/google/gwt/dev/asm/**" />
         <include name="com/google/gwt/dev/util/Name*.class" />
         <include name="com/google/gwt/dev/util/StringKey.class" />
         <include name="com/google/gwt/util/tools/shared/**" />
@@ -75,12 +88,28 @@
         <exclude name="com/google/gwt/json/**" />
         <exclude name="com/google/gwt/junit/*" />
         <exclude name="com/google/gwt/junit/client/GWTTestCase.*" />
-        <exclude name="com/google/gwt/junit/remote/**" />
         <exclude name="com/google/gwt/junit/server/**" />
-        <exclude name="com/google/gwt/benchmarks/*" />
-        <exclude name="**/*.gwtar" />
       </fileset>
-      <!-- additional dependencies (used by scripts). -->
+    </gwt.jar>
+  </target>
+  <target name="-servlet-jakarta-sources" description="Packages sources found in gwt-servlet-jakarta">
+    <mkdir dir="${gwt.build.lib}" />
+    <gwt.jar destfile="${gwt.build.lib}/gwt-servlet-jakarta-sources.jar">
+      <fileset dir="${gwt.root}/dev/core/src">
+        <include name="com/google/gwt/dev/util/Name.java" />
+        <include name="com/google/gwt/dev/util/StringKey.java" />
+        <include name="com/google/gwt/util/tools/shared/**" />
+        <include name="com/google/gwt/core/shared/**" />
+      </fileset>
+      <fileset dir="${project.build}/../user/jakarta-src">
+        <exclude name="**/rebind/**" />
+        <exclude name="**/tools/**" />
+        <exclude name="**/super/**" />
+        <exclude name="com/google/gwt/json/**" />
+        <exclude name="com/google/gwt/junit/*" />
+        <exclude name="com/google/gwt/junit/client/GWTTestCase.*" />
+        <exclude name="com/google/gwt/junit/server/**" />
+      </fileset>
     </gwt.jar>
   </target>
 

--- a/user/build.xml
+++ b/user/build.xml
@@ -373,8 +373,6 @@
       <fileset dir="src" excludes="**/package.html"/>
       <fileset dir="super" excludes="**/package.html"/>
       <fileset dir="${javac.out}"/>
-      <!-- Copy jakarta-only sources as well, as gwt-user's sources are used for all other jars as well -->
-      <fileset dir="${project.build}/jakarta-src" />
       <zipfileset src="${gwt.tools.lib}/tomcat/tomcat-servlet-api-8.0.28.jar"
                   excludes="**/*.java"/>
       <zipfileset src="${gwt.tools.lib}/w3c/sac/sac-1.3.jar"/>


### PR DESCRIPTION
Removes an old hack which uses gwt-user's sources as if they were the correct sources for gwt-servlet by creating a real build artifact that contains the sources which correspond to the classes found in gwt-servlet and gwt-servlet-jakarta. This lets us avoid using gwt-user's own sources as if they were the sources for other jars, which in turn allows us to only package gwt-user sources in gwt-user.jar.

Fixes #9886