### PR TITLE
Add jaxb dependencies

### DIFF
--- a/samples/dynatablerf/pom.xml
+++ b/samples/dynatablerf/pom.xml
@@ -94,6 +94,18 @@
       </exclusions>
     </dependency>
 
+    <!-- added to work with GWT 2.11.0 and newer --> 
+    <dependency>
+      <groupId>javax.xml.bind</groupId>
+      <artifactId>jaxb-api</artifactId>
+      <version>2.4.0-b180830.0359</version>
+    </dependency>
+    <dependency>
+      <groupId>com.sun.xml.bind</groupId>
+      <artifactId>jaxb-impl</artifactId>
+      <version>4.0.4</version>
+    </dependency>
+    
     <!-- Required by Hibernate validator because slf4j-log4j is
          optional in the hibernate-validator POM  -->
     <dependency>


### PR DESCRIPTION
This PR fixes an issue with the dynatablerf example. Starting with GWT 2.11.0 the jabx dependencies are no longer available and need to be added.
