### PR TITLE
Update ErrorProne to run on Java 21, drop Java 8 support

### DIFF
--- a/.github/workflows/full-check.yml
+++ b/.github/workflows/full-check.yml
@@ -29,7 +29,8 @@ jobs:
       - name: Checkout GWT tools into a sibling directory
         uses: actions/checkout@v4
         with:
-          repository: 'gwtproject/tools'
+          repository: 'Vertispan/tools'
+          ref: 'errorprone-2.23'
           path: 'tools'
       - name: Set up JDK ${{ matrix.java-version }}
         # GWT requires Java 11+ to build

--- a/.github/workflows/full-check.yml
+++ b/.github/workflows/full-check.yml
@@ -52,7 +52,7 @@ jobs:
             GWT_VERSION=HEAD-SNAPSHOT
           # Run the ant tasks, disabling watchFileChanges to work around a github actions limitation
           ant clean test dist doc \
-            -Dtest.jvmargs='-ea -Dgwt.watchFileChanges=false' \
+            -Dtest.jvmargs='-ea -noverify -Dgwt.watchFileChanges=false' \
             -Dtest.web.htmlunit.disable=true \
             -Dtest.nometa.htmlunit.disable=true \
             -Dtest.emma.htmlunit.disable=true

--- a/.github/workflows/full-check.yml
+++ b/.github/workflows/full-check.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        java-version: [ '11', '17', '21' ]
+        java-version: [ '11', '17' ]
     steps:
       - name: Checkout GWT itself into one directory
         uses: actions/checkout@v4

--- a/.github/workflows/full-check.yml
+++ b/.github/workflows/full-check.yml
@@ -1,4 +1,4 @@
-# Run all tests and builds all aspects of GWT using Java 8, 11, and 17. Runs
+# Run all tests and builds all aspects of GWT using Java 17, 11, and 21. Runs
 # nightly (plus or minus timzeones) on the main branch, and will also run right
 # away on a push to a release branch. Release zips are uploaded as part of the
 # build, though maven snapshots are not yet deployed.
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        java-version: [ '8', '11', '17' ]
+        java-version: [ '11', '17', '21' ]
     steps:
       - name: Checkout GWT itself into one directory
         uses: actions/checkout@v4
@@ -32,7 +32,7 @@ jobs:
           repository: 'gwtproject/tools'
           path: 'tools'
       - name: Set up JDK ${{ matrix.java-version }}
-        # GWT presently requires Java8 to build just the SDK and some tests, or 11 to build everything, but can run on newer Java versions
+        # GWT requires Java 11+ to build
         uses: actions/setup-java@v4
         with:
           java-version: ${{ matrix.java-version }}
@@ -83,7 +83,7 @@ jobs:
       - name: Set up sonatype credentials
         # Using the same java version as above, set up a settings.xml file
         uses: actions/setup-java@v4
-        if: ${{ github.event_name == 'schedule' && github.repository_owner == 'gwtproject' && matrix.java-version == '17' }}
+        if: ${{ github.event_name == 'schedule' && github.repository_owner == 'gwtproject' && matrix.java-version == '21' }}
         with:
           java-version: ${{ matrix.java-version }}
           distribution: 'temurin'
@@ -93,7 +93,7 @@ jobs:
           server-password: SONATYPE_PASSWORD
 
       - name: Nightly builds should be deployed as snapshots to sonatype
-        if: ${{ github.event_name == 'schedule' && github.repository_owner == 'gwtproject' && matrix.java-version == '17' }}
+        if: ${{ github.event_name == 'schedule' && github.repository_owner == 'gwtproject' && matrix.java-version == '21' }}
         env:
           SONATYPE_USERNAME: ${{ secrets.SONATYPE_USERNAME }}
           SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}

--- a/.github/workflows/full-check.yml
+++ b/.github/workflows/full-check.yml
@@ -1,4 +1,4 @@
-# Run all tests and builds all aspects of GWT using Java 17, 11, and 21. Runs
+# Run all tests and builds all aspects of GWT using Java 11 and 17. Runs
 # nightly (plus or minus timzeones) on the main branch, and will also run right
 # away on a push to a release branch. Release zips are uploaded as part of the
 # build, though maven snapshots are not yet deployed.
@@ -52,7 +52,7 @@ jobs:
             GWT_VERSION=HEAD-SNAPSHOT
           # Run the ant tasks, disabling watchFileChanges to work around a github actions limitation
           ant clean test dist doc \
-            -Dtest.jvmargs='-ea -noverify -Dgwt.watchFileChanges=false' \
+            -Dtest.jvmargs='-ea -Dgwt.watchFileChanges=false' \
             -Dtest.web.htmlunit.disable=true \
             -Dtest.nometa.htmlunit.disable=true \
             -Dtest.emma.htmlunit.disable=true
@@ -84,7 +84,7 @@ jobs:
       - name: Set up sonatype credentials
         # Using the same java version as above, set up a settings.xml file
         uses: actions/setup-java@v4
-        if: ${{ github.event_name == 'schedule' && github.repository_owner == 'gwtproject' && matrix.java-version == '21' }}
+        if: ${{ github.event_name == 'schedule' && github.repository_owner == 'gwtproject' && matrix.java-version == '17' }}
         with:
           java-version: ${{ matrix.java-version }}
           distribution: 'temurin'
@@ -94,7 +94,7 @@ jobs:
           server-password: SONATYPE_PASSWORD
 
       - name: Nightly builds should be deployed as snapshots to sonatype
-        if: ${{ github.event_name == 'schedule' && github.repository_owner == 'gwtproject' && matrix.java-version == '21' }}
+        if: ${{ github.event_name == 'schedule' && github.repository_owner == 'gwtproject' && matrix.java-version == '17' }}
         env:
           SONATYPE_USERNAME: ${{ secrets.SONATYPE_USERNAME }}
           SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}

--- a/.github/workflows/full-check.yml
+++ b/.github/workflows/full-check.yml
@@ -29,8 +29,7 @@ jobs:
       - name: Checkout GWT tools into a sibling directory
         uses: actions/checkout@v4
         with:
-          repository: 'Vertispan/tools'
-          ref: 'errorprone-2.23'
+          repository: 'gwtproject/tools'
           path: 'tools'
       - name: Set up JDK ${{ matrix.java-version }}
         # GWT requires Java 11+ to build

--- a/.github/workflows/quick-check.yml
+++ b/.github/workflows/quick-check.yml
@@ -19,7 +19,8 @@ jobs:
       - name: Checkout GWT tools into a sibling directory
         uses: actions/checkout@v4
         with:
-          repository: 'gwtproject/tools'
+          repository: 'Vertispan/tools'
+          ref: 'errorprone-2.23'
           path: 'tools'
       - name: Set up JDK ${{ matrix.java-version }}
         # GWT presently requires Java 11+ to build

--- a/.github/workflows/quick-check.yml
+++ b/.github/workflows/quick-check.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        java-version: ['11', '17', '21']
+        java-version: ['11', '17']
     steps:
       - name: Checkout GWT itself into one directory
         uses: actions/checkout@v4

--- a/.github/workflows/quick-check.yml
+++ b/.github/workflows/quick-check.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        java-version: ['8', '11', '17']
+        java-version: ['11', '17', '21']
     steps:
       - name: Checkout GWT itself into one directory
         uses: actions/checkout@v4
@@ -22,7 +22,7 @@ jobs:
           repository: 'gwtproject/tools'
           path: 'tools'
       - name: Set up JDK ${{ matrix.java-version }}
-        # GWT presently requires Java8 to build just the SDK and some tests, or 11+ to build everything, and can run on newer Java versions
+        # GWT presently requires Java 11+ to build
         uses: actions/setup-java@v4
         with:
           java-version: ${{ matrix.java-version }}
@@ -44,8 +44,8 @@ jobs:
             ANT_OPTS=-Xmx2g
           ant clean dist doc checkstyle apicheck
 
-      - name: Create pull request comments/annotations for checkstyle from the java 17 build, even on failure
-        if: ${{ always() && github.event_name == 'pull_request' && matrix.java-version == '17' }}
+      - name: Create pull request comments/annotations for checkstyle from the java 21 build, even on failure
+        if: ${{ always() && github.event_name == 'pull_request' && matrix.java-version == '21' }}
         env:
           REVIEWDOG_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
@@ -58,7 +58,7 @@ jobs:
           done
       - name: Upload checkstyle xml for manual review
         uses: actions/upload-artifact@v4
-        if: ${{ matrix.java-version == '17' }}
+        if: ${{ matrix.java-version == '21' }}
         with:
           name: checkstyle-reports-java${{ matrix.java-version }}
           path: 'gwt/build/out/**/checkstyle*.xml'

--- a/.github/workflows/quick-check.yml
+++ b/.github/workflows/quick-check.yml
@@ -19,8 +19,7 @@ jobs:
       - name: Checkout GWT tools into a sibling directory
         uses: actions/checkout@v4
         with:
-          repository: 'Vertispan/tools'
-          ref: 'errorprone-2.23'
+          repository: 'gwtproject/tools'
           path: 'tools'
       - name: Set up JDK ${{ matrix.java-version }}
         # GWT presently requires Java 11+ to build

--- a/.github/workflows/quick-check.yml
+++ b/.github/workflows/quick-check.yml
@@ -45,8 +45,8 @@ jobs:
             ANT_OPTS=-Xmx2g
           ant clean dist doc checkstyle apicheck
 
-      - name: Create pull request comments/annotations for checkstyle from the java 21 build, even on failure
-        if: ${{ always() && github.event_name == 'pull_request' && matrix.java-version == '21' }}
+      - name: Create pull request comments/annotations for checkstyle from the java 17 build, even on failure
+        if: ${{ always() && github.event_name == 'pull_request' && matrix.java-version == '17' }}
         env:
           REVIEWDOG_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
@@ -59,7 +59,7 @@ jobs:
           done
       - name: Upload checkstyle xml for manual review
         uses: actions/upload-artifact@v4
-        if: ${{ matrix.java-version == '21' }}
+        if: ${{ matrix.java-version == '17' }}
         with:
           name: checkstyle-reports-java${{ matrix.java-version }}
           path: 'gwt/build/out/**/checkstyle*.xml'

--- a/build.xml
+++ b/build.xml
@@ -98,7 +98,7 @@
     <gwt.ant dir="samples"/>
   </target>
 
-  <target name="buildtools" description="[subdir] Build (or runs ${target} if set) the build tools" unless="isJava8">
+  <target name="buildtools" description="[subdir] Build (or runs ${target} if set) the build tools">
     <gwt.ant dir="build_tools"/>
   </target>
 

--- a/build_tools/doctool/build.xml
+++ b/build_tools/doctool/build.xml
@@ -11,7 +11,7 @@
     <gwt.javac release="11" />
   </target>
 
-  <target name="build" depends="compile" description="Packages this project into a jar" unless="${isJava8}">
+  <target name="build" depends="compile" description="Packages this project into a jar">
     <mkdir dir="${gwt.build.lib}" />
     <gwt.jar>
       <fileset dir="src" />

--- a/common.ant.xml
+++ b/common.ant.xml
@@ -27,12 +27,6 @@
         message="This build file is in an inconsistent state (${ant.file} != ${test.ant.file})."/>
 
   <!-- Global Properties -->
-  <!--
-  Indicate if we are running in Java8, and so cannot run java9+ tests or generate Javadoc.
-  -->
-  <condition property="isJava8">
-    <equals arg1="${ant.java.version}" arg2="1.8" />
-  </condition>
   <property environment="env"/>
   <condition property="gwt.version" value="${env.GWT_VERSION}" else="0.0.0">
     <isset property="env.GWT_VERSION"/>
@@ -66,11 +60,9 @@
   <property name="javac.nowarn" value="true"/>
 
   <!-- javac and errorprone instructions from https://errorprone.info/docs/installation#ant -->
-  <property name="errorprone.javac.jar" location="${gwt.tools.lib}/errorprone/javac-9+181-r4173-1.jar"/>
   <path id="errorprone.processorpath.ref">
-    <pathelement location="${gwt.tools.lib}/errorprone/error_prone_core-2.9.0-with-dependencies.jar"/>
-    <pathelement location="${gwt.tools.lib}/errorprone/jFormatString-3.0.0.jar"/>
-    <pathelement location="${gwt.tools.lib}/errorprone/dataflow-errorprone-3.15.0.jar"/>
+    <pathelement location="${gwt.tools.lib}/errorprone/error_prone_core-2.23.0-with-dependencies.jar"/>
+    <pathelement location="${gwt.tools.lib}/errorprone/dataflow-errorprone-3.34.0-eisop1.jar"/>
   </path>
 
   <property name="junit.out" location="${project.build}/test"/>
@@ -170,20 +162,19 @@
       </path>
       <mkdir dir="@{destdir}"/>
       <javac srcdir="@{srcdir}" sourcepath="@{srcdir}" destdir="@{destdir}" debug="${javac.debug}"
-             debuglevel="${javac.debuglevel}" source="@{release}" target="@{release}" release="@{release}"
+             debuglevel="${javac.debuglevel}" release="@{release}"
              nowarn="${javac.nowarn}" encoding="${javac.encoding}" includeantruntime="false"
-             fork="true" compiler="modern" excludes="@{excludes}">
-        <compilerarg value="-J-Xbootclasspath/p:${errorprone.javac.jar}" if:true="${isJava8}"/>
-        <compilerarg value="-J--add-exports=jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED" unless:true="${isJava8}"/>
-        <compilerarg value="-J--add-exports=jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED" unless:true="${isJava8}"/>
-        <compilerarg value="-J--add-exports=jdk.compiler/com.sun.tools.javac.main=ALL-UNNAMED" unless:true="${isJava8}"/>
-        <compilerarg value="-J--add-exports=jdk.compiler/com.sun.tools.javac.model=ALL-UNNAMED" unless:true="${isJava8}"/>
-        <compilerarg value="-J--add-exports=jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED" unless:true="${isJava8}"/>
-        <compilerarg value="-J--add-exports=jdk.compiler/com.sun.tools.javac.processing=ALL-UNNAMED" unless:true="${isJava8}"/>
-        <compilerarg value="-J--add-exports=jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED" unless:true="${isJava8}"/>
-        <compilerarg value="-J--add-exports=jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED" unless:true="${isJava8}"/>
-        <compilerarg value="-J--add-opens=jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED" unless:true="${isJava8}"/>
-        <compilerarg value="-J--add-opens=jdk.compiler/com.sun.tools.javac.comp=ALL-UNNAMED" unless:true="${isJava8}"/>
+             fork="true" excludes="@{excludes}">
+        <compilerarg value="-J--add-exports=jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED" />
+        <compilerarg value="-J--add-exports=jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED" />
+        <compilerarg value="-J--add-exports=jdk.compiler/com.sun.tools.javac.main=ALL-UNNAMED" />
+        <compilerarg value="-J--add-exports=jdk.compiler/com.sun.tools.javac.model=ALL-UNNAMED" />
+        <compilerarg value="-J--add-exports=jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED" />
+        <compilerarg value="-J--add-exports=jdk.compiler/com.sun.tools.javac.processing=ALL-UNNAMED" />
+        <compilerarg value="-J--add-exports=jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED" />
+        <compilerarg value="-J--add-exports=jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED" />
+        <compilerarg value="-J--add-opens=jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED" />
+        <compilerarg value="-J--add-opens=jdk.compiler/com.sun.tools.javac.comp=ALL-UNNAMED" />
         <compilerarg value="-XDcompilePolicy=simple"/>
         <compilerarg value="-processorpath"/>
         <compilerarg pathref="mergedprocessorpath.ref"/>
@@ -249,7 +240,7 @@
         <jvmarg value="-Demma.coverage.out.merge=true"/>
         <jvmarg value="-Dcom.google.gwt.junit.reportPath=reports"/>
         <jvmarg line="@{test.jvmargs}"/>
-        <jvmarg line="--add-opens=java.base/java.lang=ALL-UNNAMED" unless:true="${isJava8}"/>
+        <jvmarg line="--add-opens=java.base/java.lang=ALL-UNNAMED" />
         <sysproperty key="gwt.args" value="@{test.args}"/>
         <sysproperty key="java.awt.headless" value="true"/>
         <classpath>

--- a/dev/build.xml
+++ b/dev/build.xml
@@ -216,6 +216,7 @@
                                     -Xep:FallThrough:OFF
                                     -Xep:ReturnValueIgnored:OFF
                                     -Xep:EqualsIncompatibleType:OFF
+                                    -Xep:ReturnValueIgnored:OFF
                                   ">
       <include name="com/google/gwt/core/ext/**"/>
       <include name="com/google/gwt/core/linker/**"/>

--- a/dev/build.xml
+++ b/dev/build.xml
@@ -22,15 +22,7 @@
 
   <target name="compile.tests" depends="build, compile.emma.if.enabled, build.alldeps.jar"
           description="Compiles the test code for this project">
-    <gwt.javac srcdir="" destdir="${javac.junit.out}" errorprone.args="
-                                                         -Xep:MissingCasesInEnumSwitch:OFF
-                                                         -Xep:FallThrough:OFF
-                                                         -Xep:ReturnValueIgnored:OFF
-                                                         -Xep:EqualsIncompatibleType:OFF
-                                                         -Xep:SelfComparison:OFF
-                                                         -Xep:SelfEquals:OFF
-                                                         -Xep:ComparableType:OFF
-                                                       ">
+    <gwt.javac srcdir="" destdir="${javac.junit.out}">
         <src path="core/src"/>
         <src path="core/test"/>
       <classpath>
@@ -40,13 +32,7 @@
       </classpath>
     </gwt.javac>
     <gwt.javac srcdir="" destdir="${javac.junit.out}"
-               excludes="**/EmulatedCharset.java,**/HashCodes.java,**/ConsoleLogger.java,**/NativeRegExp.java,**/SuperDevModeLogger.java"
-               errorprone.args="
-                 -Xep:MissingCasesInEnumSwitch:OFF
-                 -Xep:FallThrough:OFF
-                 -Xep:ReturnValueIgnored:OFF
-                 -Xep:EqualsIncompatibleType:OFF
-               ">
+               excludes="**/EmulatedCharset.java,**/HashCodes.java,**/ConsoleLogger.java,**/NativeRegExp.java,**/SuperDevModeLogger.java">
       <src path="${gwt.root}/user/src" />
       <src path="${gwt.root}/user/super/com/google/gwt/emul/javaemul/internal"/>
       <classpath>
@@ -211,13 +197,7 @@
           description="Validates that the standalone gwt-compiler project can build.">
     <mkdir dir="${javac.out}"/>
     <gwt.javac srcdir="core/super" excludes="com/google/gwt/dev/jjs/intrinsic/"/>
-    <gwt.javac srcdir="core/src" errorprone.args="
-                                    -Xep:MissingCasesInEnumSwitch:OFF
-                                    -Xep:FallThrough:OFF
-                                    -Xep:ReturnValueIgnored:OFF
-                                    -Xep:EqualsIncompatibleType:OFF
-                                    -Xep:ReturnValueIgnored:OFF
-                                  ">
+    <gwt.javac srcdir="core/src">
       <include name="com/google/gwt/core/ext/**"/>
       <include name="com/google/gwt/core/linker/**"/>
       <include name="com/google/gwt/dev/About.java"/>
@@ -260,12 +240,7 @@
 
   <target name="compile" depends="compiler.standalone, build.alldeps.jar"
           description="Compiles this project">
-    <gwt.javac srcdir="core/src" excludes="${filter.pattern}" errorprone.args="
-                                                                 -Xep:MissingCasesInEnumSwitch:OFF
-                                                                 -Xep:FallThrough:OFF
-                                                                 -Xep:ReturnValueIgnored:OFF
-                                                                 -Xep:EqualsIncompatibleType:OFF
-                                                               ">
+    <gwt.javac srcdir="core/src" excludes="${filter.pattern}">
       <classpath>
         <pathelement location="${alldeps.jar}"/>
       </classpath>

--- a/dev/core/src/com/google/gwt/core/ext/Linker.java
+++ b/dev/core/src/com/google/gwt/core/ext/Linker.java
@@ -62,6 +62,7 @@ public abstract class Linker {
    * intended to support linkers that must compile against older versions of
    * GWT.
    */
+  @SuppressWarnings("ReturnValueIgnored")
   public final boolean isShardable() {
     if (getClass().isAnnotationPresent(Shardable.class)) {
       return true;

--- a/dev/core/test/com/google/gwt/core/ext/linker/ArtifactSetTest.java
+++ b/dev/core/test/com/google/gwt/core/ext/linker/ArtifactSetTest.java
@@ -27,6 +27,7 @@ import java.util.SortedSet;
  */
 public class ArtifactSetTest extends TestCase {
 
+  @SuppressWarnings("SelfComparison")
   public void testScriptOrder() {
     StandardScriptReference fooScript = new StandardScriptReference("foo", 0);
     StandardScriptReference barScript = new StandardScriptReference("bar", 1);
@@ -65,6 +66,7 @@ public class ArtifactSetTest extends TestCase {
     }
   }
 
+  @SuppressWarnings("SelfComparison")
   public void testStyleOrder() {
     StandardStylesheetReference fooStyle = new StandardStylesheetReference(
         "foo", 0);

--- a/dev/core/test/com/google/gwt/core/ext/linker/TypeIndexedSetTest.java
+++ b/dev/core/test/com/google/gwt/core/ext/linker/TypeIndexedSetTest.java
@@ -52,6 +52,7 @@ public class TypeIndexedSetTest extends TestCase {
     }
 
     @Override
+    @SuppressWarnings("BoxedPrimitiveEquality")
     public boolean equals(Object o) {
       return (o instanceof RootComparable) && (((RootComparable) o).value == this.value);
     }

--- a/dev/core/test/com/google/gwt/dev/GwtVersionTest.java
+++ b/dev/core/test/com/google/gwt/dev/GwtVersionTest.java
@@ -39,6 +39,7 @@ public class GwtVersionTest extends TestCase {
   /**
    * Test that GwtVersion.compareTo produced expected results.
    */
+  @SuppressWarnings("SelfComparison")
   public void testCompareTo() {
     GwtVersion v1 = new GwtVersion("0.0.0");
     assertEquals(0, v1.compareTo(v1));

--- a/dev/core/test/com/google/gwt/dev/javac/GeneratedClassnameFinderTest.java
+++ b/dev/core/test/com/google/gwt/dev/javac/GeneratedClassnameFinderTest.java
@@ -260,6 +260,7 @@ class JavacWeirdnessTester {
     assertEquals(g, a);
   }
 
+  @SuppressWarnings("ReturnValueIgnored")
   private void testDeadTypes() {
     if (false) {
       new Object() {

--- a/dev/core/test/com/google/gwt/dev/javac/typemodel/test/GenericClass.java
+++ b/dev/core/test/com/google/gwt/dev/javac/typemodel/test/GenericClass.java
@@ -28,6 +28,7 @@ import java.util.List;
  * follows: class GenericClass<T extends Serializable & Comparable<T>>
  * implements Comparable<T> { ... }
  */
+@SuppressWarnings("ComparableType")
 public class GenericClass<T extends Serializable> implements Comparable<T>,
     Serializable {
   /**

--- a/dev/core/test/org/apache/commons/collections/AbstractTestObject.java
+++ b/dev/core/test/org/apache/commons/collections/AbstractTestObject.java
@@ -120,6 +120,7 @@ public abstract class AbstractTestObject extends BulkTest {
         assertEquals("hashCode should be repeatable", obj.hashCode(), obj.hashCode());
     }
 
+    @SuppressWarnings("SelfEquals")
     public void testObjectHashCodeEqualsContract() {
         Object obj1 = makeObject();
         if (obj1.equals(obj1)) {

--- a/dev/core/test/org/apache/commons/collections/collection/AbstractTestCollection.java
+++ b/dev/core/test/org/apache/commons/collections/collection/AbstractTestCollection.java
@@ -805,6 +805,7 @@ public abstract class AbstractTestCollection extends AbstractTestObject {
     /**
      *  Tests removals from {@link Collection#iterator()}.
      */
+    @SuppressWarnings("ReturnValueIgnored")
     public void testCollectionIteratorRemove() {
         if (!isRemoveSupported()) return;
 

--- a/doc/build.xml
+++ b/doc/build.xml
@@ -90,7 +90,7 @@
   </target>
 
   <!-- Really rebuild the javadoc -->
-  <target name="makeJavadoc" unless="isJava8">
+  <target name="makeJavadoc">
     <java classpathref="DOC_PATH" classname="com.google.doctool.custom.FindPackages" fork="yes" failonerror="true">
       <arg value="${gwt.root}" />
     </java>
@@ -124,7 +124,7 @@
     </javadoc>
   </target>
 
-  <target name="emul-doc" unless="isJava8">
+  <target name="emul-doc">
     <outofdate>
       <sourcefiles>
         <fileset dir="${gwt.root}/user/super/com/google/gwt/emul">

--- a/user/build.xml
+++ b/user/build.xml
@@ -2,7 +2,7 @@
   <property name="gwt.root" location=".."/>
   <property name="project.tail" value="user"/>
   <property name="test.args" value="-ea -sourceLevel auto"/>
-  <property name="test.jvmargs" value="-ea -noverify"/>
+  <property name="test.jvmargs" value="-ea"/>
 
   <!-- support old variables names -->
   <condition property="gwt.hosts.web.selenium" value="${gwt.selenium.hosts}">

--- a/user/build.xml
+++ b/user/build.xml
@@ -2,7 +2,11 @@
   <property name="gwt.root" location=".."/>
   <property name="project.tail" value="user"/>
   <property name="test.args" value="-ea -sourceLevel auto"/>
-  <property name="test.jvmargs" value="-ea"/>
+  <!--
+  Adding "-noverify" is a workaround for https://bugs.openjdk.org/browse/JDK-8323657
+  so that tests can be compiled under Java9+.
+  -->
+  <property name="test.jvmargs" value="-ea -noverify"/>
 
   <!-- support old variables names -->
   <condition property="gwt.hosts.web.selenium" value="${gwt.selenium.hosts}">

--- a/user/build.xml
+++ b/user/build.xml
@@ -14,27 +14,16 @@
   <property name="test.timeout" value="5"/>
   <property name="emma.merged.out" value="${junit.out}/emma-coverage"/>
 
-  <property name="gwt.junit.testcase.web.includes" value="${gwt.junit.testcase.includes}"/>
-  <condition property="gwt.junit.testcase.web.excludes"
-            value="**/*JreSuite.class,**/OptimizedOnly*"
-            else="**/*JreSuite.class,**/OptimizedOnly*,**/*Java9Suite.class,**/*Java10Suite.class,**/*Java11Suite.class">
-    <isfalse value="${isJava8}" />
-  </condition>
+  <property name="gwt.junit.testcase.web.includes" value="${gwt.junit.testcase.includes}" />
+  <property name="gwt.junit.testcase.web.excludes" value="**/*JreSuite.class,**/OptimizedOnly*" />
 
   <!-- Disable legacy dev mode test on Java 9 and above -->
-  <condition property="test.dev.htmlunit.disable" value="true">
-    <isfalse value="${isJava8}" />
-  </condition>
-  <condition property="test.dev.selenium.disable" value="true">
-    <isfalse value="${isJava8}" />
-  </condition>
+  <property name="test.dev.htmlunit.disable" value="true" />
+  <property name="test.dev.selenium.disable" value="true "/>
 
   <property name="gwt.junit.testcase.dev.includes" value="${gwt.junit.testcase.includes}"/>
-  <condition property="gwt.junit.testcase.dev.excludes"
-            value="**/EmulSuite.class,**/JSONSuite.class,**/RunAsyncSuite.class,**/*CompilerSuite.class,**/*JsInteropSuite.class,**/*JreSuite.class,**/OptimizedOnly*"
-            else="**/EmulSuite.class,**/JSONSuite.class,**/RunAsyncSuite.class,**/*CompilerSuite.class,**/*JsInteropSuite.class,**/*JreSuite.class,**/OptimizedOnly*,**/*Java9Suite.class,**/*Java10Suite.class,**/*Java11Suite.class">
-    <isfalse value="${isJava8}" />
-  </condition>
+  <property name="gwt.junit.testcase.dev.excludes"
+            value="**/EmulSuite.class,**/JSONSuite.class,**/RunAsyncSuite.class,**/*CompilerSuite.class,**/*JsInteropSuite.class,**/*JreSuite.class,**/OptimizedOnly*" />
 
   <property name="gwt.tck.testcase.dev.includes"
             value="com/google/gwt/validation/tck/**/*GwtSuite.class"/>
@@ -59,7 +48,6 @@
    -->
   <property name="gwt.i18n.test.InnerClassChar" value="dollar"/>
 
-  <!-- Platform shouldn't matter here, just picking one -->
   <property.ensure name="gwt.dev.jar" location="${gwt.build.lib}/gwt-dev.jar"/>
 
   <!--
@@ -116,6 +104,8 @@
               -Xep:FallThrough:OFF
               -Xep:ReturnValueIgnored:OFF
               -Xep:EqualsIncompatibleType:OFF
+              -Xep:BoxedPrimitiveEquality:OFF
+              -Xep:DoubleBraceInitialization:OFF
             ">
       <src path="super/com/google/gwt/emul/javaemul/internal" />
       <classpath>
@@ -254,6 +244,8 @@
               -Xep:FallThrough:OFF
               -Xep:ReturnValueIgnored:OFF
               -Xep:EqualsIncompatibleType:OFF
+              -Xep:BoxedPrimitiveEquality:OFF
+              -Xep:DoubleBraceInitialization:OFF
             ">
         <src path="${project.build}/no-servlet-src" />
         <src path="super/com/google/gwt/emul/javaemul/internal" />
@@ -296,13 +288,10 @@
       Compiles the test code for this project
   -->
   <target name="compile.tests"
-          depends="-compile.tests.java8,-compile.tests.java11"
+          depends="compile.dev.tests, compile.emma.if.enabled"
           unless="compile.tests.complete">
-  </target>
-
-  <target name="-compile.tests.java8" depends="compile.dev.tests, compile.emma.if.enabled">
     <gwt.javac srcdir="test" destdir="${javac.junit.out}"
-               excludes="com/google/gwt/langtest/**,**/super/**,**/java9/**,**/*Java9*.java,**/java10/**,**/*Java10*.java,**/java11/**,**/*Java11*.java"
+               excludes="com/google/gwt/langtest/**,**/super/**"
                processorpath="test.extraclasspath"
                errorprone.args="
                  -Xep:SelfAssignment:OFF
@@ -331,39 +320,6 @@
       <compilerarg value="-processor"/>
       <compilerarg value="com.google.web.bindery.requestfactory.apt.RfValidator"/>
     </gwt.javac>
-  </target>
-  <target name="-compile.tests.java11" unless="isJava8" depends="-compile.tests.java8">
-    <gwt.javac srcdir="test" destdir="${javac.junit.out}"
-               excludes="com/google/gwt/langtest/**,**/super/**"
-               processorpath="test.extraclasspath"
-               release="11"
-               errorprone.args="
-                 -Xep:SelfAssignment:OFF
-                 -Xep:MissingCasesInEnumSwitch:OFF
-                 -Xep:SelfComparison:OFF
-                 -Xep:SelfEquals:OFF
-                 -Xep:FallThrough:OFF
-                 -Xep:ReturnValueIgnored:OFF
-                 -Xep:EqualsIncompatibleType:OFF
-                 -Xep:IdentityBinaryExpression:OFF
-                 -Xep:LoopConditionChecker:OFF
-                 -Xep:JUnitAssertSameCheck:OFF
-                 -Xep:CollectionIncompatibleType:OFF
-                 -Xep:DeadThread:OFF
-                 -Xep:ComplexBooleanConstant:OFF
-                 -Xep:ComparableType:OFF
-                 -Xep:DoNotCall:OFF
-                 -Xep:BadAnnotationImplementation:OFF
-               ">
-      <classpath>
-        <pathelement location="${javac.junit.out}"/>
-        <pathelement location="${javac.out}"/>
-        <pathelement location="${gwt.tools.lib}/junit/junit-4.8.2.jar"/>
-        <pathelement location="${gwt.tools.lib}/selenium/selenium-java-client-driver.jar"/>
-        <path refid="test.extraclasspath"/>
-      </classpath>
-    </gwt.javac>
-
   </target>
 
   <target name="build" depends="compile, compile-jakarta"

--- a/user/build.xml
+++ b/user/build.xml
@@ -2,7 +2,7 @@
   <property name="gwt.root" location=".."/>
   <property name="project.tail" value="user"/>
   <property name="test.args" value="-ea -sourceLevel auto"/>
-  <property name="test.jvmargs" value="-ea"/>
+  <property name="test.jvmargs" value="-ea -noverify"/>
 
   <!-- support old variables names -->
   <condition property="gwt.hosts.web.selenium" value="${gwt.selenium.hosts}">
@@ -96,17 +96,7 @@
   <target name="compile" description="Compile all class files"
           unless="compile.complete">
     <gwt.javac
-            excludes="**/EmulatedCharset.java,**/HashCodes.java,**/ConsoleLogger.java,**/NativeRegExp.java,**/SuperDevModeLogger.java"
-            errorprone.args="
-              -Xep:MissingCasesInEnumSwitch:OFF
-              -Xep:SelfComparison:OFF
-              -Xep:SelfEquals:OFF
-              -Xep:FallThrough:OFF
-              -Xep:ReturnValueIgnored:OFF
-              -Xep:EqualsIncompatibleType:OFF
-              -Xep:BoxedPrimitiveEquality:OFF
-              -Xep:DoubleBraceInitialization:OFF
-            ">
+            excludes="**/EmulatedCharset.java,**/HashCodes.java,**/ConsoleLogger.java,**/NativeRegExp.java,**/SuperDevModeLogger.java">
       <src path="super/com/google/gwt/emul/javaemul/internal" />
       <classpath>
         <pathelement location="${gwt.tools.lib}/gss/2015-11-04/closure-stylesheets-library-20151104-rebased.jar"/>
@@ -236,17 +226,7 @@
       <gwt.javac
               srcdir="${project.build}/jakarta-src"
               destdir="${javac.out}-jakarta"
-              excludes="**/EmulatedCharset.java,**/HashCodes.java,**/ConsoleLogger.java,**/NativeRegExp.java,**/SuperDevModeLogger.java,**/junit/**"
-              errorprone.args="
-              -Xep:MissingCasesInEnumSwitch:OFF
-              -Xep:SelfComparison:OFF
-              -Xep:SelfEquals:OFF
-              -Xep:FallThrough:OFF
-              -Xep:ReturnValueIgnored:OFF
-              -Xep:EqualsIncompatibleType:OFF
-              -Xep:BoxedPrimitiveEquality:OFF
-              -Xep:DoubleBraceInitialization:OFF
-            ">
+              excludes="**/EmulatedCharset.java,**/HashCodes.java,**/ConsoleLogger.java,**/NativeRegExp.java,**/SuperDevModeLogger.java,**/junit/**">
         <src path="${project.build}/no-servlet-src" />
         <src path="super/com/google/gwt/emul/javaemul/internal" />
         <classpath>
@@ -293,24 +273,7 @@
     <gwt.javac srcdir="test" destdir="${javac.junit.out}"
                excludes="com/google/gwt/langtest/**,**/super/**"
                processorpath="test.extraclasspath"
-               errorprone.args="
-                 -Xep:SelfAssignment:OFF
-                 -Xep:MissingCasesInEnumSwitch:OFF
-                 -Xep:SelfComparison:OFF
-                 -Xep:SelfEquals:OFF
-                 -Xep:FallThrough:OFF
-                 -Xep:ReturnValueIgnored:OFF
-                 -Xep:EqualsIncompatibleType:OFF
-                 -Xep:IdentityBinaryExpression:OFF
-                 -Xep:LoopConditionChecker:OFF
-                 -Xep:JUnitAssertSameCheck:OFF
-                 -Xep:CollectionIncompatibleType:OFF
-                 -Xep:DeadThread:OFF
-                 -Xep:ComplexBooleanConstant:OFF
-                 -Xep:ComparableType:OFF
-                 -Xep:DoNotCall:OFF
-                 -Xep:BadAnnotationImplementation:OFF
-               ">
+               release="11">
       <classpath>
         <pathelement location="${javac.out}"/>
         <pathelement location="${gwt.tools.lib}/junit/junit-4.8.2.jar"/>

--- a/user/build.xml
+++ b/user/build.xml
@@ -267,7 +267,7 @@
   <!--
       Compiles the test code for this project
   -->
-  <target name="-compile.tests" depends="compile.dev.tests, compile.emma.if.enabled">
+  <target name="compile.tests" depends="compile.dev.tests, compile.emma.if.enabled">
     <gwt.javac srcdir="test" destdir="${javac.junit.out}"
                excludes="com/google/gwt/langtest/**,**/super/**"
                processorpath="test.extraclasspath"

--- a/user/build.xml
+++ b/user/build.xml
@@ -267,15 +267,11 @@
   <!--
       Compiles the test code for this project
   -->
-  <target name="compile.tests"
-          depends="-compile.tests.java8,-compile.tests.java11"
-          unless="compile.tests.complete">
-  </target>
-
-  <target name="-compile.tests.java8" depends="compile.dev.tests, compile.emma.if.enabled">
+  <target name="-compile.tests" depends="compile.dev.tests, compile.emma.if.enabled">
     <gwt.javac srcdir="test" destdir="${javac.junit.out}"
-               excludes="com/google/gwt/langtest/**,**/super/**,**/java9/**,**/*Java9*.java,**/java10/**,**/*Java10*.java,**/java11/**,**/*Java11*.java"
-               processorpath="test.extraclasspath">
+               excludes="com/google/gwt/langtest/**,**/super/**"
+               processorpath="test.extraclasspath"
+               release="11">
       <classpath>
         <pathelement location="${javac.out}"/>
         <pathelement location="${gwt.tools.lib}/junit/junit-4.8.2.jar"/>
@@ -285,21 +281,6 @@
       <compilerarg value="-processor"/>
       <compilerarg value="com.google.web.bindery.requestfactory.apt.RfValidator"/>
     </gwt.javac>
-  </target>
-  <target name="-compile.tests.java11" unless="isJava8" depends="-compile.tests.java8">
-    <gwt.javac srcdir="test" destdir="${javac.junit.out}"
-               excludes="com/google/gwt/langtest/**,**/super/**"
-               processorpath="test.extraclasspath"
-               release="11">
-      <classpath>
-        <pathelement location="${javac.junit.out}"/>
-        <pathelement location="${javac.out}"/>
-        <pathelement location="${gwt.tools.lib}/junit/junit-4.8.2.jar"/>
-        <pathelement location="${gwt.tools.lib}/selenium/selenium-java-client-driver.jar"/>
-        <path refid="test.extraclasspath"/>
-      </classpath>
-    </gwt.javac>
-
   </target>
 
   <target name="build" depends="compile, compile-jakarta"

--- a/user/build.xml
+++ b/user/build.xml
@@ -268,12 +268,14 @@
       Compiles the test code for this project
   -->
   <target name="compile.tests"
-          depends="compile.dev.tests, compile.emma.if.enabled"
+          depends="-compile.tests.java8,-compile.tests.java11"
           unless="compile.tests.complete">
+  </target>
+
+  <target name="-compile.tests.java8" depends="compile.dev.tests, compile.emma.if.enabled">
     <gwt.javac srcdir="test" destdir="${javac.junit.out}"
-               excludes="com/google/gwt/langtest/**,**/super/**"
-               processorpath="test.extraclasspath"
-               release="11">
+               excludes="com/google/gwt/langtest/**,**/super/**,**/java9/**,**/*Java9*.java,**/java10/**,**/*Java10*.java,**/java11/**,**/*Java11*.java"
+               processorpath="test.extraclasspath">
       <classpath>
         <pathelement location="${javac.out}"/>
         <pathelement location="${gwt.tools.lib}/junit/junit-4.8.2.jar"/>
@@ -283,6 +285,21 @@
       <compilerarg value="-processor"/>
       <compilerarg value="com.google.web.bindery.requestfactory.apt.RfValidator"/>
     </gwt.javac>
+  </target>
+  <target name="-compile.tests.java11" unless="isJava8" depends="-compile.tests.java8">
+    <gwt.javac srcdir="test" destdir="${javac.junit.out}"
+               excludes="com/google/gwt/langtest/**,**/super/**"
+               processorpath="test.extraclasspath"
+               release="11">
+      <classpath>
+        <pathelement location="${javac.junit.out}"/>
+        <pathelement location="${javac.out}"/>
+        <pathelement location="${gwt.tools.lib}/junit/junit-4.8.2.jar"/>
+        <pathelement location="${gwt.tools.lib}/selenium/selenium-java-client-driver.jar"/>
+        <path refid="test.extraclasspath"/>
+      </classpath>
+    </gwt.javac>
+
   </target>
 
   <target name="build" depends="compile, compile-jakarta"

--- a/user/build.xml
+++ b/user/build.xml
@@ -2,11 +2,7 @@
   <property name="gwt.root" location=".."/>
   <property name="project.tail" value="user"/>
   <property name="test.args" value="-ea -sourceLevel auto"/>
-  <!--
-  Adding "-noverify" is a workaround for https://bugs.openjdk.org/browse/JDK-8323657
-  so that tests can be compiled under Java9+.
-  -->
-  <property name="test.jvmargs" value="-ea -noverify"/>
+  <property name="test.jvmargs" value="-ea"/>
 
   <!-- support old variables names -->
   <condition property="gwt.hosts.web.selenium" value="${gwt.selenium.hosts}">
@@ -282,6 +278,9 @@
         <pathelement location="${gwt.tools.lib}/selenium/selenium-java-client-driver.jar"/>
         <path refid="test.extraclasspath"/>
       </classpath>
+      <!-- Disable Java 9+ string concat feature, it breaks a JDT regression test,
+           see https://bugs.openjdk.org/browse/JDK-8323657 -->
+      <compilerarg value="-XDstringConcat=inline"/>
       <compilerarg value="-processor"/>
       <compilerarg value="com.google.web.bindery.requestfactory.apt.RfValidator"/>
     </gwt.javac>

--- a/user/src/com/google/gwt/cell/client/CheckboxCell.java
+++ b/user/src/com/google/gwt/cell/client/CheckboxCell.java
@@ -46,6 +46,7 @@ public class CheckboxCell extends AbstractEditableCell<Boolean, Boolean> {
   /**
    * Construct a new {@link CheckboxCell}.
    */
+  @SuppressWarnings("BoxedPrimitiveEquality")
   public CheckboxCell() {
     this(false);
   }
@@ -91,7 +92,8 @@ public class CheckboxCell extends AbstractEditableCell<Boolean, Boolean> {
   }
 
   @Override
-  public void onBrowserEvent(Context context, Element parent, Boolean value, 
+  @SuppressWarnings("BoxedPrimitiveEquality")
+  public void onBrowserEvent(Context context, Element parent, Boolean value,
       NativeEvent event, ValueUpdater<Boolean> valueUpdater) {
     String type = event.getType();
 

--- a/user/src/com/google/gwt/uibinder/elementparsers/BeanParser.java
+++ b/user/src/com/google/gwt/uibinder/elementparsers/BeanParser.java
@@ -46,6 +46,7 @@ public class BeanParser implements ElementParser {
    * methods that extend the normal bean naming pattern. So, that implementations of
    * {@link IsWidget} behave like UIObjects, they have to be translated.
    */
+  @SuppressWarnings("DoubleBraceInitialization")
   private static final Map<String, String> ADD_PROPERTY_TO_SETTER_MAP =
       new HashMap<String, String>() { {
         put("addStyleNames", "addStyleName");

--- a/user/src/com/google/gwt/view/client/DefaultSelectionModel.java
+++ b/user/src/com/google/gwt/view/client/DefaultSelectionModel.java
@@ -123,6 +123,7 @@ public abstract class DefaultSelectionModel<T> extends AbstractSelectionModel<T>
     return output;
   }
 
+  @SuppressWarnings("BoxedPrimitiveEquality")
   private void resolveChanges() {
     boolean changed = false;
     for (Map.Entry<Object, SelectionChange<T>> entry : selectionChanges.entrySet()) {

--- a/user/test/com/google/gwt/dev/jjs/test/AnnotationsTest.java
+++ b/user/test/com/google/gwt/dev/jjs/test/AnnotationsTest.java
@@ -24,6 +24,7 @@ import java.lang.annotation.Annotation;
  */
 public class AnnotationsTest extends GWTTestCase {
 
+  @SuppressWarnings("BadAnnotationImplementation")
   private static class Foo implements IFoo {
     @Override
     public Class<? extends Annotation> annotationType() {

--- a/user/test/com/google/gwt/dev/jjs/test/CompilerTest.java
+++ b/user/test/com/google/gwt/dev/jjs/test/CompilerTest.java
@@ -36,6 +36,7 @@ public class CompilerTest extends GWTTestCase {
 
   interface Silly { }
 
+  @SuppressWarnings("ComparableType")
   interface SillyComparable<T extends Silly> extends Comparable<T> {
     @Override
     int compareTo(T obj);
@@ -418,6 +419,7 @@ public class CompilerTest extends GWTTestCase {
       }
     }
 
+    @SuppressWarnings("ComparableType")
     class MyFoo extends AbstractFoo implements Comparable<AbstractFoo> {
     }
 
@@ -752,6 +754,7 @@ public class CompilerTest extends GWTTestCase {
     };
   }
 
+  @SuppressWarnings({"ReturnValueIgnored", "IdentityBinaryExpression"})
   public void testDeadTypes() {
     if (false) {
       new Object() {
@@ -771,7 +774,7 @@ public class CompilerTest extends GWTTestCase {
    * Development Mode or Production Mode, but the important thing is that the
    * compiler does not crash.
    */
-  @SuppressWarnings({"divzero", "ConstantOverflow"})
+  @SuppressWarnings({"divzero", "ConstantOverflow", "IdentityBinaryExpression"})
   public void testDivByZero() {
     assertTrue(Double.isNaN(0.0 / 0.0));
 
@@ -806,6 +809,7 @@ public class CompilerTest extends GWTTestCase {
     }
   }
 
+  @SuppressWarnings({"IdentityBinaryExpression", "LoopConditionChecker"})
   public void testEmptyBlockStatements() {
     boolean b = false;
     while (b) {
@@ -864,7 +868,7 @@ public class CompilerTest extends GWTTestCase {
 
   // CHECKSTYLE_OFF
 
-  @SuppressWarnings("empty")
+  @SuppressWarnings({"empty", "LoopConditionChecker"})
   public void testEmptyStatements() {
     boolean b = false;
 

--- a/user/test/com/google/gwt/dev/jjs/test/CoverageTest.java
+++ b/user/test/com/google/gwt/dev/jjs/test/CoverageTest.java
@@ -333,7 +333,7 @@ public class CoverageTest extends CoverageBase {
       assertEquals(15, i);
     }
 
-    @SuppressWarnings("cast")
+    @SuppressWarnings({"cast", "SelfAssignment"})
     private void testCastExpression() {
       // CastExpression
       o = (Super) o;

--- a/user/test/com/google/gwt/dev/jjs/test/InnerClassTest.java
+++ b/user/test/com/google/gwt/dev/jjs/test/InnerClassTest.java
@@ -26,6 +26,7 @@ import java.util.List;
 public class InnerClassTest extends GWTTestCase {
 
   static class OuterRefFromSuperCtorBase {
+    @SuppressWarnings("ReturnValueIgnored")
     OuterRefFromSuperCtorBase(Object o) {
       o.toString();
     }

--- a/user/test/com/google/gwt/dev/jjs/test/JStaticEvalTest.java
+++ b/user/test/com/google/gwt/dev/jjs/test/JStaticEvalTest.java
@@ -77,6 +77,7 @@ public class JStaticEvalTest extends GWTTestCase {
    * Test "true == booleanField" and permutations, as well as "true == false"
    * and permutations.
    */
+  @SuppressWarnings("IdentityBinaryExpression")
   public void testEqualsBool() {
     assertTrue(fieldTrue == returnTrue());
     assertTrue(returnTrue() == fieldTrue);
@@ -127,6 +128,7 @@ public class JStaticEvalTest extends GWTTestCase {
   /**
    * Tests constant folding.
    */
+  @SuppressWarnings("IdentityBinaryExpression")
   public void testOpsOnLiterals() {
     assertEquals(10, returnIntFive() + returnIntFive());
     assertEquals(0, returnIntFive() - returnIntFive());

--- a/user/test/com/google/gwt/dev/jjs/test/JsoTest.java
+++ b/user/test/com/google/gwt/dev/jjs/test/JsoTest.java
@@ -639,6 +639,7 @@ public class JsoTest extends GWTTestCase {
     assertEquals(stringHashCode, o.hashCode());
   }
 
+  @SuppressWarnings("JUnitAssertSameCheck")
   public void testIdentity() {
     JavaScriptObject jso = makeJSO();
     assertSame(jso, jso);

--- a/user/test/com/google/gwt/dev/jjs/test/MethodCallTest.java
+++ b/user/test/com/google/gwt/dev/jjs/test/MethodCallTest.java
@@ -27,6 +27,7 @@ public class MethodCallTest extends GWTTestCase {
 
   private static Object field;
 
+  @SuppressWarnings("ReturnValueIgnored")
   private static void clobberFieldNoInline() {
     try {
       field = null;
@@ -102,6 +103,7 @@ public class MethodCallTest extends GWTTestCase {
    * <code>o</code> will have been replaced by a direct reference to
    * {@link #field}. Both the Java and JS inliners must not inline this.
    */
+  @SuppressWarnings("ReturnValueIgnored")
   private static void shouldNotInline(Object o) {
     field = null;
     o.toString();
@@ -111,6 +113,7 @@ public class MethodCallTest extends GWTTestCase {
    * Same as {@link #shouldNotInline(Object)}, except the field clobber is done
    * indirectly in a non-inlinable method.
    */
+  @SuppressWarnings("ReturnValueIgnored")
   private static void shouldNotInline2(Object o) {
     clobberFieldNoInline();
     o.toString();

--- a/user/test/com/google/gwt/dev/jjs/test/MiscellaneousTest.java
+++ b/user/test/com/google/gwt/dev/jjs/test/MiscellaneousTest.java
@@ -58,6 +58,7 @@ public class MiscellaneousTest extends GWTTestCase {
     private static native void clinitInNative() /*-{
     }-*/;
 
+    @SuppressWarnings("ReturnValueIgnored")
     private int foo() {
       this.toString();
       return 3;
@@ -216,7 +217,7 @@ public class MiscellaneousTest extends GWTTestCase {
     assertEquals(100, result);
   }
 
-  @SuppressWarnings("cast")
+  @SuppressWarnings({"cast", "SelfAssignment"})
   public void testCasts() {
     Object o = FALSE ? (Object) new PolyA() : (Object) new PolyB();
     assertTrue(o instanceof I);

--- a/user/test/com/google/gwt/dev/jjs/test/NativeLongTest.java
+++ b/user/test/com/google/gwt/dev/jjs/test/NativeLongTest.java
@@ -162,6 +162,7 @@ public class NativeLongTest extends GWTTestCase {
     assertEquals(3L, LONG_ONE | LONG_THREE);
   }
 
+  @SuppressWarnings("IdentityBinaryExpression")
   public void testLogicalXor() {
     assertTrue((255L ^ LONG_5DEECE66D) != 0);
 

--- a/user/test/com/google/gwt/dev/js/client/CoverageTest.java
+++ b/user/test/com/google/gwt/dev/js/client/CoverageTest.java
@@ -28,6 +28,7 @@ import java.util.Map;
  * Tests coverage instrumentation.
  */
 public class CoverageTest extends GWTTestCase {
+  @SuppressWarnings("DoubleBraceInitialization")
   private static final Map<String, Double> EXPECTED_COVERAGE = new HashMap<String, Double>() { {
       put("25", 1.0);
       put("26", 1.0);

--- a/user/test/com/google/gwt/dev/strict/bad/client/BadSource.java
+++ b/user/test/com/google/gwt/dev/strict/bad/client/BadSource.java
@@ -19,6 +19,7 @@ package com.google.gwt.dev.strict.bad.client;
  * Used by {@link com.google.gwt.dev.StrictModeTest}.
  */
 public class BadSource {
+  @SuppressWarnings("DeadThread")
   public void useThread() {
     new Thread();
   }

--- a/user/test/com/google/gwt/dom/client/ElementTest.java
+++ b/user/test/com/google/gwt/dom/client/ElementTest.java
@@ -184,6 +184,7 @@ public class ElementTest extends GWTTestCase {
    * not return a numeric attribute based on the element property. See issue
    * 3238.
    */
+  @SuppressWarnings("ReturnValueIgnored")
   public void testElementAttributeNumeric() {
     DivElement div = Document.get().createDivElement();
     Document.get().getBody().appendChild(div);

--- a/user/test/com/google/gwt/emultest/java/lang/JsExceptionTest.java
+++ b/user/test/com/google/gwt/emultest/java/lang/JsExceptionTest.java
@@ -120,6 +120,7 @@ public class JsExceptionTest extends ThrowableTestBase {
     }
   }
 
+  @SuppressWarnings("ReturnValueIgnored")
   private static void throwTypeError() {
     Object nullObject = null;
     nullObject.getClass();

--- a/user/test/com/google/gwt/emultest/java/lang/StringTest.java
+++ b/user/test/com/google/gwt/emultest/java/lang/StringTest.java
@@ -651,6 +651,7 @@ public class StringTest extends GWTTestCase {
     }
   }
 
+  @SuppressWarnings("ReturnValueIgnored")
   public void testRegionMatches() {
     String test = String.valueOf(new char[] {'a', 'b', 'c', 'd', 'e', 'f'});
     assertTrue(test.regionMatches(1, "bcd", 0, 3));

--- a/user/test/com/google/gwt/emultest/java/util/ArraysTest.java
+++ b/user/test/com/google/gwt/emultest/java/util/ArraysTest.java
@@ -67,6 +67,7 @@ public class ArraysTest extends EmulTestBase {
    * embedded null references works properly (and most importantly doesn't
    * throw an NPE).
    */
+  @SuppressWarnings("ReturnValueIgnored")
   public void testArraysHashCodeWithNullElements() {
     String[] a = new String[] { "foo", null, "bar", "baz" };
     Arrays.hashCode(a);

--- a/user/test/com/google/gwt/emultest/java/util/ObjectsTest.java
+++ b/user/test/com/google/gwt/emultest/java/util/ObjectsTest.java
@@ -32,7 +32,7 @@ public class ObjectsTest extends GWTTestCase {
 
   public void testCompare() {
     Comparator<Integer> intComparator = new Comparator<Integer>() {
-      @SuppressWarnings("NumberEquality")
+      @SuppressWarnings({"NumberEquality", "BoxedPrimitiveEquality"})
       @Override
       public int compare(Integer a, Integer b) {
         if (a == b) {

--- a/user/test/com/google/gwt/emultest/java/util/TestCollection.java
+++ b/user/test/com/google/gwt/emultest/java/util/TestCollection.java
@@ -598,6 +598,7 @@ abstract class TestCollection extends TestObject {
   }
 
   /** Tests removals from {@link Collection#iterator()}. */
+  @SuppressWarnings("ReturnValueIgnored")
   public void testCollectionIteratorRemove() {
     if (!isRemoveSupported()) {
       return;

--- a/user/test/com/google/gwt/emultest/java/util/TestObject.java
+++ b/user/test/com/google/gwt/emultest/java/util/TestObject.java
@@ -57,6 +57,7 @@ abstract class TestObject extends EmulTestBase {
     assertEquals("hashCode should be repeatable", obj.hashCode(), obj.hashCode());
   }
 
+  @SuppressWarnings("SelfEquals")
   public void testObjectHashCodeEqualsContract() {
     Object obj1 = makeObject();
     if (obj1.equals(obj1)) {

--- a/user/test/com/google/gwt/emultest/java/util/TreeMapTest.java
+++ b/user/test/com/google/gwt/emultest/java/util/TreeMapTest.java
@@ -41,6 +41,7 @@ import java.util.TreeMap;
  */
 abstract class TreeMapTest<K extends Comparable<K>, V> extends TestMap {
 
+  @SuppressWarnings("ComparableType")
   private static class ConflictingKey implements Comparable<CharSequence> {
     private final String value;
 
@@ -488,6 +489,7 @@ abstract class TreeMapTest<K extends Comparable<K>, V> extends TestMap {
    *
    * @see java.util.Map#containsKey(Object)
    */
+  @SuppressWarnings("ReturnValueIgnored")
   public void testContainsKey_throwsClassCastException() {
     K[] keys = getKeys();
     V[] values = getValues();
@@ -549,6 +551,7 @@ abstract class TreeMapTest<K extends Comparable<K>, V> extends TestMap {
    *
    * @see java.util.Map#containsValue(Object)
    */
+  @SuppressWarnings("ReturnValueIgnored")
   public void testContainsValue_throwsClassCastException() {
     K[] keys = getKeys();
     V[] values = getValues();
@@ -759,6 +762,7 @@ abstract class TreeMapTest<K extends Comparable<K>, V> extends TestMap {
     }
   }
 
+  @SuppressWarnings("ReturnValueIgnored")
   public void testEntrySet() {
     K[] keys = getSortedKeys();
     V[] values = getSortedValues();
@@ -2155,6 +2159,7 @@ abstract class TreeMapTest<K extends Comparable<K>, V> extends TestMap {
    *
    * @see java.util.Map#put(Object, Object)
    */
+  @SuppressWarnings("ReturnValueIgnored")
   public void testPut_nullKey() {
     K[] keys = getSortedKeys();
     V[] values = getSortedValues();
@@ -2874,6 +2879,7 @@ abstract class TreeMapTest<K extends Comparable<K>, V> extends TestMap {
     assertTrue(subMap.values().isEmpty());
   }
 
+  @SuppressWarnings("ReturnValueIgnored")
   public void testSubMap_entrySet() {
     K[] keys = getSortedKeys();
     V[] values = getSortedValues();
@@ -3311,6 +3317,7 @@ abstract class TreeMapTest<K extends Comparable<K>, V> extends TestMap {
    *
    * @see java.util.Map#values()
    */
+  @SuppressWarnings("ReturnValueIgnored")
   public void testValues() {
     K[] keys = getSortedKeys();
     V[] values = getSortedValues();

--- a/user/test/com/google/gwt/emultest/java/util/TreeSetTest.java
+++ b/user/test/com/google/gwt/emultest/java/util/TreeSetTest.java
@@ -588,6 +588,7 @@ abstract class TreeSetTest<E extends Comparable<E>> extends TestSet {
    *
    * @see java.util.Set#contains(Object)
    */
+  @SuppressWarnings("ReturnValueIgnored")
   public void testContains_throwsClassCastException() {
     Set<E> set = createSet();
     set.add(getKeys()[0]);

--- a/user/test/com/google/gwt/emultest/java8/util/OptionalTest.java
+++ b/user/test/com/google/gwt/emultest/java8/util/OptionalTest.java
@@ -139,6 +139,7 @@ public class OptionalTest extends GWTTestCase {
     assertFalse(filtered.isPresent());
   }
 
+  @SuppressWarnings("ReturnValueIgnored")
   public void testMap() {
     // empty case
     try {
@@ -167,6 +168,7 @@ public class OptionalTest extends GWTTestCase {
     assertEquals(REFERENCE.toString(), mapped.get());
   }
 
+  @SuppressWarnings("ReturnValueIgnored")
   public void testFlatMap() {
     // empty case
     try {

--- a/user/test/com/google/gwt/emultest/java8/util/stream/DoubleStreamTest.java
+++ b/user/test/com/google/gwt/emultest/java8/util/stream/DoubleStreamTest.java
@@ -181,6 +181,7 @@ public class DoubleStreamTest extends EmulTestBase {
     assertFalse(maybe.isPresent());
   }
 
+  @SuppressWarnings("ReturnValueIgnored")
   public void testFilter() {
     // unconsumed stream never runs filter
     boolean[] data = {false};
@@ -210,6 +211,7 @@ public class DoubleStreamTest extends EmulTestBase {
         DoubleStream.of(1d, 2d, 3d, 4d, 3d).filter(a -> true).toArray());
   }
 
+  @SuppressWarnings("ReturnValueIgnored")
   public void testMap() {
     // unconsumed stream never runs map
     int[] data = {0};
@@ -219,6 +221,7 @@ public class DoubleStreamTest extends EmulTestBase {
     assertEquals(new double[] {2d, 4d, 6d}, DoubleStream.of(1d, 2d, 3d).map(i -> i * 2).toArray());
   }
 
+  @SuppressWarnings("ReturnValueIgnored")
   public void testPeek() {
     // unconsumed stream never peeks
     boolean[] data = {false};

--- a/user/test/com/google/gwt/emultest/java8/util/stream/IntStreamTest.java
+++ b/user/test/com/google/gwt/emultest/java8/util/stream/IntStreamTest.java
@@ -194,6 +194,7 @@ public class IntStreamTest extends EmulTestBase {
     assertFalse(maybe.isPresent());
   }
 
+  @SuppressWarnings("ReturnValueIgnored")
   public void testFilter() {
     // unconsumed stream never runs filter
     boolean[] data = {false};
@@ -219,6 +220,7 @@ public class IntStreamTest extends EmulTestBase {
         new int[] {1, 2, 3, 4, 3}, IntStream.of(1, 2, 3, 4, 3).filter(a -> true).toArray());
   }
 
+  @SuppressWarnings("ReturnValueIgnored")
   public void testMap() {
     // unconsumed stream never runs map
     int[] data = {0};
@@ -228,6 +230,7 @@ public class IntStreamTest extends EmulTestBase {
     assertEquals(new int[] {2, 4, 6}, IntStream.of(1, 2, 3).map(i -> i * 2).toArray());
   }
 
+  @SuppressWarnings("ReturnValueIgnored")
   public void testPeek() {
     // unconsumed stream never peeks
     boolean[] data = {false};

--- a/user/test/com/google/gwt/emultest/java8/util/stream/LongStreamTest.java
+++ b/user/test/com/google/gwt/emultest/java8/util/stream/LongStreamTest.java
@@ -193,6 +193,7 @@ public class LongStreamTest extends EmulTestBase {
     assertFalse(maybe.isPresent());
   }
 
+  @SuppressWarnings("ReturnValueIgnored")
   public void testFilter() {
     // unconsumed stream never runs filter
     boolean[] data = {false};
@@ -220,6 +221,7 @@ public class LongStreamTest extends EmulTestBase {
         LongStream.of(1L, 2L, 3L, 4L, 3L).filter(a -> true).toArray());
   }
 
+  @SuppressWarnings("ReturnValueIgnored")
   public void testMap() {
     // unconsumed stream never runs map
     int[] data = {0};
@@ -229,6 +231,7 @@ public class LongStreamTest extends EmulTestBase {
     assertEquals(new long[] {2L, 4L, 6L}, LongStream.of(1L, 2L, 3L).map(i -> i * 2).toArray());
   }
 
+  @SuppressWarnings("ReturnValueIgnored")
   public void testPeek() {
     // unconsumed stream never peeks
     boolean[] data = {false};

--- a/user/test/com/google/gwt/emultest/java8/util/stream/StreamTest.java
+++ b/user/test/com/google/gwt/emultest/java8/util/stream/StreamTest.java
@@ -243,6 +243,7 @@ public class StreamTest extends EmulTestBase {
     assertEquals(asList(values), collectedList);
   }
 
+  @SuppressWarnings("ReturnValueIgnored")
   public void testFilter() {
     // unconsumed stream never runs filter
     boolean[] data = {false};
@@ -277,6 +278,7 @@ public class StreamTest extends EmulTestBase {
         Stream.of("a", "b", "c", "d", "c").filter(a -> true).collect(Collectors.toList()));
   }
 
+  @SuppressWarnings("ReturnValueIgnored")
   public void testMap() {
     // unconsumed stream never runs map
     boolean[] data = {false};
@@ -288,6 +290,7 @@ public class StreamTest extends EmulTestBase {
         Stream.of(1, 2, 3).map(i -> "#" + i).collect(Collectors.toList()));
   }
 
+  @SuppressWarnings("ReturnValueIgnored")
   public void testPeek() {
     // unconsumed stream never peeks
     boolean[] data = {false};
@@ -471,6 +474,7 @@ public class StreamTest extends EmulTestBase {
   // This frustrating test was written first on the JVM stream to discover the basic behavior before
   // trying to implement it in GWT. As far as I can tell, none of this is clearly described in
   // javadoc. Also note that it is *not* required to use the returned stream from calling onClose
+  @SuppressWarnings("ReturnValueIgnored")
   public void testCloseQuirks() {
     // all subclasses use the same close()/onClose(...) impl, just test once with Stream.empty()
 
@@ -562,6 +566,7 @@ public class StreamTest extends EmulTestBase {
     assertEquals(1, calledCount[0]);
   }
 
+  @SuppressWarnings("ReturnValueIgnored")
   public void testCloseException() {
     // Try a single exception, confirm we catch it
     Stream<Object> s = Stream.of(1, 2, 3);

--- a/user/test/com/google/gwt/emultest/java9/util/ListTest.java
+++ b/user/test/com/google/gwt/emultest/java9/util/ListTest.java
@@ -25,6 +25,7 @@ import java.util.List;
  */
 public class ListTest extends EmulTestBase {
 
+  @SuppressWarnings("ReturnValueIgnored")
   public void testOf() {
     assertIsImmutableListOf(List.of());
     assertIsImmutableListOf(List.of("a"), "a");

--- a/user/test/com/google/gwt/emultest/java9/util/MapTest.java
+++ b/user/test/com/google/gwt/emultest/java9/util/MapTest.java
@@ -24,6 +24,7 @@ import java.util.Map;
  */
 public class MapTest extends EmulTestBase {
 
+  @SuppressWarnings("ReturnValueIgnored")
   public void testOf() {
     assertIsImmutableMapOf(Map.of());
     assertIsImmutableMapOf(Map.of("a", 1), "a");
@@ -151,6 +152,7 @@ public class MapTest extends EmulTestBase {
     }
   }
 
+  @SuppressWarnings("ReturnValueIgnored")
   public void testEntry() {
     Map.Entry<String, String> entry = Map.entry("a", "b");
 
@@ -172,7 +174,7 @@ public class MapTest extends EmulTestBase {
     });
   }
 
-  @SuppressWarnings("DuplicateMapKeys")
+  @SuppressWarnings({"DuplicateMapKeys", "ReturnValueIgnored"})
   public void testOfEntries() {
     Map<String, Integer> map = Map.ofEntries(
         Map.entry("a", 1),

--- a/user/test/com/google/gwt/emultest/java9/util/OptionalTest.java
+++ b/user/test/com/google/gwt/emultest/java9/util/OptionalTest.java
@@ -40,6 +40,7 @@ public class OptionalTest extends EmulTestBase {
     assertEquals(1, called[0]);
   }
 
+  @SuppressWarnings("ReturnValueIgnored")
   public void testOr() {
     Optional<String> or = Optional.of("value").or(() -> Optional.of("replacement"));
     assertTrue(or.isPresent());

--- a/user/test/com/google/gwt/emultest/java9/util/SetTest.java
+++ b/user/test/com/google/gwt/emultest/java9/util/SetTest.java
@@ -26,6 +26,7 @@ import java.util.Set;
  */
 public class SetTest extends EmulTestBase {
 
+  @SuppressWarnings("ReturnValueIgnored")
   public void testOf() {
     assertIsImmutableSetOf(Set.of());
     assertIsImmutableSetOf(Set.of("a"), "a");

--- a/user/test/com/google/gwt/junit/client/GWTTestCaseTest.java
+++ b/user/test/com/google/gwt/junit/client/GWTTestCaseTest.java
@@ -243,6 +243,7 @@ public class GWTTestCaseTest extends GWTTestCaseTestBase {
     assertNull("msg", "Hello");
   }
 
+  @SuppressWarnings("JUnitAssertSameCheck")
   public void testAssertSame() {
     assertSame(obj1, obj1);
     assertSame("msg", obj1, obj1);

--- a/user/test/com/google/gwt/storage/client/MapInterfaceTest.java
+++ b/user/test/com/google/gwt/storage/client/MapInterfaceTest.java
@@ -133,6 +133,7 @@ public abstract class MapInterfaceTest<K, V> extends GWTTestCase {
     }
   }
 
+  @SuppressWarnings("ReturnValueIgnored")
   protected final boolean supportsValuesHashCode(Map<K, V> map) {
     // get the first non-null value
     Collection<V> values = map.values();
@@ -274,6 +275,7 @@ public abstract class MapInterfaceTest<K, V> extends GWTTestCase {
     assertInvariants(map);
   }
 
+  @SuppressWarnings("ReturnValueIgnored")
   public void testContainsKey() {
     final Map<K, V> map;
     final K unmappedKey;
@@ -297,6 +299,7 @@ public abstract class MapInterfaceTest<K, V> extends GWTTestCase {
     assertInvariants(map);
   }
 
+  @SuppressWarnings("ReturnValueIgnored")
   public void testContainsValue() {
     final Map<K, V> map;
     final V unmappedValue;

--- a/user/test/com/google/gwt/uibinder/elementparsers/MenuItemParserTest.java
+++ b/user/test/com/google/gwt/uibinder/elementparsers/MenuItemParserTest.java
@@ -172,6 +172,7 @@ public class MenuItemParserTest extends TestCase {
    * Containers method to reference types referenced only from JavaDoc, used to
    * prevent CheckStyle errors.
    */
+  @SuppressWarnings("ReturnValueIgnored")
   public void unusedReferences(XMLElement p1, MenuBar p2) {
     p1.hashCode();
     p2.hashCode();

--- a/user/test/com/google/gwt/user/client/rpc/CollectionsTest.java
+++ b/user/test/com/google/gwt/user/client/rpc/CollectionsTest.java
@@ -559,6 +559,7 @@ public class CollectionsTest extends RpcTestBase {
           }
 
           @Override
+          @SuppressWarnings("CollectionIncompatibleType")
           public void onSuccess(
               LinkedHashMap<MarkerTypeLinkedHashMapKey, MarkerTypeLinkedHashMapValue> result) {
             assertNotNull(result);
@@ -586,6 +587,7 @@ public class CollectionsTest extends RpcTestBase {
           }
 
           @Override
+          @SuppressWarnings("CollectionIncompatibleType")
           public void onSuccess(
               LinkedHashMap<MarkerTypeLinkedHashMapKey, MarkerTypeLinkedHashMapValue> actual) {
             assertNotNull(actual);

--- a/user/test/com/google/gwt/user/client/rpc/TypeCheckedObjectsTestSetValidator.java
+++ b/user/test/com/google/gwt/user/client/rpc/TypeCheckedObjectsTestSetValidator.java
@@ -28,11 +28,13 @@ public class TypeCheckedObjectsTestSetValidator {
   public static final Integer markerKey = 12345;
   public static final String markerValue = "Marker";
 
+  @SuppressWarnings("DoubleBraceInitialization")
   public static final HashSet<Integer> invalidMarkerKey = new HashSet<Integer>() {
     {
       add(12345);
     }
   };
+  @SuppressWarnings("DoubleBraceInitialization")
   public static final HashSet<String> invalidMarkerValue = new HashSet<String>() {
     {
       add("Marker");


### PR DESCRIPTION
This patch updates to the latest version of ErrorProne, which requires dropping support for Java 8 (as planned). This  allows us to remove several "is this Java 8" checks in the build.

As the new ErrorProne version required adding new suppressions, all existing project-wide suppressions have been removed and distributed to the methods throughout the project that actually need them.

We cannot yet add support for running CI on Java 21, that also requires updating asm - otherwise there are a handful of compiler internals tests that will fail when asm interacts with Java's own bytecode (e.g. java.lang.Object).

The javac arg `-XDstringConcat=inline` must be added to gwt-user tests when compiled to release=11, as https://bugs.openjdk.org/browse/JDK-8323657 breaks a regression test for JDT, and the class fails to load for the ExtraCompilerSuite.

Fixes #9870 
Fixes #9859