### PR TITLE
Update JDT and asm for Java 17 language support

### DIFF
--- a/.github/workflows/full-check.yml
+++ b/.github/workflows/full-check.yml
@@ -29,7 +29,8 @@ jobs:
       - name: Checkout GWT tools into a sibling directory
         uses: actions/checkout@v4
         with:
-          repository: 'gwtproject/tools'
+          repository: 'Vertispan/tools'
+          ref: 'errorprone-2.23'
           path: 'tools'
       - name: Set up JDK ${{ matrix.java-version }}
         # GWT requires Java 11+ to build

--- a/.github/workflows/full-check.yml
+++ b/.github/workflows/full-check.yml
@@ -1,4 +1,4 @@
-# Run all tests and builds all aspects of GWT using Java 11 and 17. Runs
+# Run all tests and builds all aspects of GWT using Java 8, 11, and 17. Runs
 # nightly (plus or minus timzeones) on the main branch, and will also run right
 # away on a push to a release branch. Release zips are uploaded as part of the
 # build, though maven snapshots are not yet deployed.
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        java-version: [ '11', '17' ]
+        java-version: [ '11', '17', '21' ]
     steps:
       - name: Checkout GWT itself into one directory
         uses: actions/checkout@v4
@@ -83,7 +83,7 @@ jobs:
       - name: Set up sonatype credentials
         # Using the same java version as above, set up a settings.xml file
         uses: actions/setup-java@v4
-        if: ${{ github.event_name == 'schedule' && github.repository_owner == 'gwtproject' && matrix.java-version == '17' }}
+        if: ${{ github.event_name == 'schedule' && github.repository_owner == 'gwtproject' && matrix.java-version == '21' }}
         with:
           java-version: ${{ matrix.java-version }}
           distribution: 'temurin'
@@ -93,7 +93,7 @@ jobs:
           server-password: SONATYPE_PASSWORD
 
       - name: Nightly builds should be deployed as snapshots to sonatype
-        if: ${{ github.event_name == 'schedule' && github.repository_owner == 'gwtproject' && matrix.java-version == '17' }}
+        if: ${{ github.event_name == 'schedule' && github.repository_owner == 'gwtproject' && matrix.java-version == '21' }}
         env:
           SONATYPE_USERNAME: ${{ secrets.SONATYPE_USERNAME }}
           SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}

--- a/.github/workflows/full-check.yml
+++ b/.github/workflows/full-check.yml
@@ -29,8 +29,8 @@ jobs:
       - name: Checkout GWT tools into a sibling directory
         uses: actions/checkout@v4
         with:
-          repository: 'Vertispan/tools'
-          ref: 'errorprone-2.23'
+          repository: 'vegegoku/tools'
+          ref: 'java-17-support'
           path: 'tools'
       - name: Set up JDK ${{ matrix.java-version }}
         # GWT requires Java 11+ to build

--- a/.github/workflows/full-check.yml
+++ b/.github/workflows/full-check.yml
@@ -52,7 +52,7 @@ jobs:
             GWT_VERSION=HEAD-SNAPSHOT
           # Run the ant tasks, disabling watchFileChanges to work around a github actions limitation
           ant clean test dist doc \
-            -Dtest.jvmargs='-ea -Dgwt.watchFileChanges=false' \
+            -Dtest.jvmargs='-ea -noverify -Dgwt.watchFileChanges=false' \
             -Dtest.web.htmlunit.disable=true \
             -Dtest.nometa.htmlunit.disable=true \
             -Dtest.emma.htmlunit.disable=true

--- a/.github/workflows/full-check.yml
+++ b/.github/workflows/full-check.yml
@@ -1,4 +1,4 @@
-# Run all tests and builds all aspects of GWT using Java 8, 11, and 17. Runs
+# Run all tests and builds all aspects of GWT using Java 11, 17, and 21. Runs
 # nightly (plus or minus timzeones) on the main branch, and will also run right
 # away on a push to a release branch. Release zips are uploaded as part of the
 # build, though maven snapshots are not yet deployed.
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        java-version: [ '11', '17' ]
+        java-version: [ '11', '17', '21' ]
     steps:
       - name: Checkout GWT itself into one directory
         uses: actions/checkout@v4
@@ -29,8 +29,7 @@ jobs:
       - name: Checkout GWT tools into a sibling directory
         uses: actions/checkout@v4
         with:
-          repository: 'vegegoku/tools'
-          ref: 'java-17-support'
+          repository: 'gwtproject/tools'
           path: 'tools'
       - name: Set up JDK ${{ matrix.java-version }}
         # GWT requires Java 11+ to build
@@ -52,7 +51,7 @@ jobs:
             GWT_VERSION=HEAD-SNAPSHOT
           # Run the ant tasks, disabling watchFileChanges to work around a github actions limitation
           ant clean test dist doc \
-            -Dtest.jvmargs='-ea -noverify -Dgwt.watchFileChanges=false' \
+            -Dtest.jvmargs='-ea -Dgwt.watchFileChanges=false' \
             -Dtest.web.htmlunit.disable=true \
             -Dtest.nometa.htmlunit.disable=true \
             -Dtest.emma.htmlunit.disable=true

--- a/.github/workflows/full-check.yml
+++ b/.github/workflows/full-check.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        java-version: [ '11', '17', '21' ]
+        java-version: [ '11', '17' ]
     steps:
       - name: Checkout GWT itself into one directory
         uses: actions/checkout@v4

--- a/.github/workflows/quick-check.yml
+++ b/.github/workflows/quick-check.yml
@@ -19,7 +19,8 @@ jobs:
       - name: Checkout GWT tools into a sibling directory
         uses: actions/checkout@v4
         with:
-          repository: 'gwtproject/tools'
+          repository: 'Vertispan/tools'
+          ref: 'errorprone-2.23'
           path: 'tools'
       - name: Set up JDK ${{ matrix.java-version }}
         # GWT presently requires Java 11+ to build

--- a/.github/workflows/quick-check.yml
+++ b/.github/workflows/quick-check.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        java-version: ['11', '17', '21']
+        java-version: ['11', '17']
     steps:
       - name: Checkout GWT itself into one directory
         uses: actions/checkout@v4

--- a/.github/workflows/quick-check.yml
+++ b/.github/workflows/quick-check.yml
@@ -19,8 +19,8 @@ jobs:
       - name: Checkout GWT tools into a sibling directory
         uses: actions/checkout@v4
         with:
-          repository: 'Vertispan/tools'
-          ref: 'errorprone-2.23'
+          repository: 'vegegoku/tools'
+          ref: 'java-17-support'
           path: 'tools'
       - name: Set up JDK ${{ matrix.java-version }}
         # GWT presently requires Java 11+ to build

--- a/.github/workflows/quick-check.yml
+++ b/.github/workflows/quick-check.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        java-version: ['11', '17']
+        java-version: ['11', '17', '21']
     steps:
       - name: Checkout GWT itself into one directory
         uses: actions/checkout@v4
@@ -19,8 +19,7 @@ jobs:
       - name: Checkout GWT tools into a sibling directory
         uses: actions/checkout@v4
         with:
-          repository: 'vegegoku/tools'
-          ref: 'java-17-support'
+          repository: 'gwtproject/tools'
           path: 'tools'
       - name: Set up JDK ${{ matrix.java-version }}
         # GWT presently requires Java 11+ to build

--- a/.github/workflows/quick-check.yml
+++ b/.github/workflows/quick-check.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        java-version: ['11', '17']
+        java-version: ['11', '17', '21']
     steps:
       - name: Checkout GWT itself into one directory
         uses: actions/checkout@v4
@@ -44,8 +44,8 @@ jobs:
             ANT_OPTS=-Xmx2g
           ant clean dist doc checkstyle apicheck
 
-      - name: Create pull request comments/annotations for checkstyle from the java 17 build, even on failure
-        if: ${{ always() && github.event_name == 'pull_request' && matrix.java-version == '17' }}
+      - name: Create pull request comments/annotations for checkstyle from the java 21 build, even on failure
+        if: ${{ always() && github.event_name == 'pull_request' && matrix.java-version == '21' }}
         env:
           REVIEWDOG_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
@@ -58,7 +58,7 @@ jobs:
           done
       - name: Upload checkstyle xml for manual review
         uses: actions/upload-artifact@v4
-        if: ${{ matrix.java-version == '17' }}
+        if: ${{ matrix.java-version == '21' }}
         with:
           name: checkstyle-reports-java${{ matrix.java-version }}
           path: 'gwt/build/out/**/checkstyle*.xml'

--- a/dev/build.xml
+++ b/dev/build.xml
@@ -63,11 +63,11 @@
           <include name="apache/tapestry-util-text-4.0.2.jar"/>
           <include name="apache/ant-zipscanner/ant-zipscanner-1.6.5-1-rebased.jar"/>
           <include name="colt/colt-1.2.jar"/>
-          <include name="eclipse/org.eclipse.jdt.core_3.17.0.v20190306-2240.jar"/>
-          <include name="eclipse/jdtCompilerAdapter_3.17.0.v20190306-2240.jar"/>
-          <include name="objectweb/asm-9.2/asm-9.2.jar"/>
-          <include name="objectweb/asm-9.2/asm-commons-9.2.jar"/>
-          <include name="objectweb/asm-9.2/asm-util-9.2.jar"/>
+          <include name="eclipse/org.eclipse.jdt.core_3.32.0.v20221108-1853.jar"/>
+          <include name="eclipse/jdtCompilerAdapter_3.32.0.v20221108-1853.jar"/>
+          <include name="objectweb/asm-9.6/asm-9.6.jar"/>
+          <include name="objectweb/asm-9.6/asm-commons-9.6.jar"/>
+          <include name="objectweb/asm-9.6/asm-util-9.6.jar"/>
           <include name="guava/guava-19.0/guava-19.0-rebased.jar"/>
           <include name="icu4j/63.1/icu4j.jar"/>
           <include name="jetty/jetty-9.4.44.v20210927/jetty-all-9.4.44.v20210927.jar"/>
@@ -119,16 +119,16 @@
             <provider classname="org.eclipse.jetty.websocket.jsr356.server.deploy.WebSocketServerContainerInitializer"/>
             <provider classname="org.eclipse.jetty.apache.jsp.JettyJasperInitializer"/>
           </service>
-          <zipfileset src="${gwt.tools.lib}/objectweb/asm-9.2/asm-9.2.jar"/>
-          <zipfileset src="${gwt.tools.lib}/objectweb/asm-9.2/asm-commons-9.2.jar"/>
-          <zipfileset src="${gwt.tools.lib}/objectweb/asm-9.2/asm-util-9.2.jar"/>
+          <zipfileset src="${gwt.tools.lib}/objectweb/asm-9.6/asm-9.6.jar"/>
+          <zipfileset src="${gwt.tools.lib}/objectweb/asm-9.6/asm-commons-9.6.jar"/>
+          <zipfileset src="${gwt.tools.lib}/objectweb/asm-9.6/asm-util-9.6.jar"/>
           <zipfileset src="${gwt.tools.lib}/apache/tapestry-util-text-4.0.2.jar"/>
           <zipfileset src="${gwt.tools.lib}/apache/ant-zipscanner/ant-zipscanner-1.6.5-1-rebased.jar"/>
           <zipfileset src="${gwt.tools.lib}/colt/colt-1.2.jar"/>
           <zipfileset
-              src="${gwt.tools.lib}/eclipse/org.eclipse.jdt.core_3.17.0.v20190306-2240.jar"/>
+              src="${gwt.tools.lib}/eclipse/org.eclipse.jdt.core_3.32.0.v20221108-1853.jar"/>
           <zipfileset
-              src="${gwt.tools.lib}/eclipse/jdtCompilerAdapter_3.17.0.v20190306-2240.jar"/>
+              src="${gwt.tools.lib}/eclipse/jdtCompilerAdapter_3.32.0.v20221108-1853.jar"/>
           <zipfileset src="${gwt.tools.lib}/guava/guava-19.0/guava-19.0-rebased.jar"/>
           <zipfileset src="${gwt.tools.lib}/icu4j/63.1/icu4j.jar"/>
           <zipfileset
@@ -217,15 +217,15 @@
       <classpath>
         <pathelement location="${gwt.tools.lib}/apache/ant-zipscanner/ant-zipscanner-1.6.5-1-rebased.jar"/>
         <pathelement location="${gwt.tools.lib}/colt/colt-1.2.jar"/>
-        <pathelement location="${gwt.tools.lib}/objectweb/asm-9.2/asm-9.2.jar"/>
-        <pathelement location="${gwt.tools.lib}/objectweb/asm-9.2/asm-commons-9.2.jar"/>
-        <pathelement location="${gwt.tools.lib}/objectweb/asm-9.2/asm-util-9.2.jar"/>
+        <pathelement location="${gwt.tools.lib}/objectweb/asm-9.6/asm-9.6.jar"/>
+        <pathelement location="${gwt.tools.lib}/objectweb/asm-9.6/asm-commons-9.6.jar"/>
+        <pathelement location="${gwt.tools.lib}/objectweb/asm-9.6/asm-util-9.6.jar"/>
         <pathelement
             location="${gwt.tools.lib}/apache/commons/commons-collections-3.2.2.jar"/>
         <pathelement
-            location="${gwt.tools.lib}/eclipse/org.eclipse.jdt.core_3.17.0.v20190306-2240.jar"/>
+            location="${gwt.tools.lib}/eclipse/org.eclipse.jdt.core_3.32.0.v20221108-1853.jar"/>
         <pathelement
-            location="${gwt.tools.lib}/eclipse/jdtCompilerAdapter_3.17.0.v20190306-2240.jar"/>
+            location="${gwt.tools.lib}/eclipse/jdtCompilerAdapter_3.32.0.v20221108-1853.jar"/>
         <pathelement
             location="${gwt.tools.lib}/guava/guava-19.0/guava-19.0-rebased.jar"/>
         <pathelement location="${gwt.tools.lib}/gson/gson-2.6.2.jar"/>

--- a/dev/core/src/com/google/gwt/dev/javac/JdtCompiler.java
+++ b/dev/core/src/com/google/gwt/dev/javac/JdtCompiler.java
@@ -787,7 +787,8 @@ public class JdtCompiler {
           SourceLevel.JAVA8, ClassFileConstants.JDK1_8,
           SourceLevel.JAVA9, ClassFileConstants.JDK9,
           SourceLevel.JAVA10, ClassFileConstants.JDK10,
-          SourceLevel.JAVA11, ClassFileConstants.JDK11);
+          SourceLevel.JAVA11, ClassFileConstants.JDK11,
+          SourceLevel.JAVA17, ClassFileConstants.JDK17);
 
   public JdtCompiler(CompilerContext compilerContext, UnitProcessor processor) {
     this.compilerContext = compilerContext;

--- a/dev/core/src/com/google/gwt/dev/jjs/impl/GwtAstBuilder.java
+++ b/dev/core/src/com/google/gwt/dev/jjs/impl/GwtAstBuilder.java
@@ -537,13 +537,25 @@ public class GwtAstBuilder {
 
     @Override
     public void endVisit(CaseStatement x, BlockScope scope) {
+      if(x.isExpr){
+        InternalCompilerException excption =
+            new InternalCompilerException("Switch expressions not yet supported");
+        excption.addNode(new JCaseStatement(makeSourceInfo(x), null));
+        throw excption;
+      }
       try {
         SourceInfo info = makeSourceInfo(x);
-        JExpression caseExpression = pop(x.constantExpression);
-        if (caseExpression != null && x.constantExpression.resolvedType.isEnum()) {
-          caseExpression = synthesizeCallToOrdinal(scope, info, caseExpression);
+        if (x.constantExpressions == null) {
+          push(new JCaseStatement(info, null));
+        } else {
+          for (Expression constantExpression : x.constantExpressions) {
+            JExpression caseExpression = pop(constantExpression);
+            if (caseExpression != null && caseExpression.getType().isEnumOrSubclass() != null) {
+              caseExpression = synthesizeCallToOrdinal(scope, info, caseExpression);
+            }
+            push(new JCaseStatement(info, caseExpression));
+          }
         }
-        push(new JCaseStatement(info, caseExpression));
       } catch (Throwable e) {
         throw translateException(x, e);
       }

--- a/dev/core/src/com/google/gwt/dev/jjs/impl/GwtAstBuilder.java
+++ b/dev/core/src/com/google/gwt/dev/jjs/impl/GwtAstBuilder.java
@@ -194,6 +194,7 @@ import org.eclipse.jdt.internal.compiler.ast.Statement;
 import org.eclipse.jdt.internal.compiler.ast.StringLiteral;
 import org.eclipse.jdt.internal.compiler.ast.StringLiteralConcatenation;
 import org.eclipse.jdt.internal.compiler.ast.SuperReference;
+import org.eclipse.jdt.internal.compiler.ast.SwitchExpression;
 import org.eclipse.jdt.internal.compiler.ast.SwitchStatement;
 import org.eclipse.jdt.internal.compiler.ast.SynchronizedStatement;
 import org.eclipse.jdt.internal.compiler.ast.ThisReference;
@@ -538,10 +539,10 @@ public class GwtAstBuilder {
     @Override
     public void endVisit(CaseStatement x, BlockScope scope) {
       if (x.isExpr) {
-        InternalCompilerException excption =
+        InternalCompilerException exception =
             new InternalCompilerException("Switch expressions not yet supported");
-        excption.addNode(new JCaseStatement(makeSourceInfo(x), null));
-        throw excption;
+        exception.addNode(new JCaseStatement(makeSourceInfo(x), null));
+        throw exception;
       }
       try {
         SourceInfo info = makeSourceInfo(x);
@@ -2547,6 +2548,14 @@ public class GwtAstBuilder {
     }
 
     @Override
+    public boolean visit(SwitchExpression x, BlockScope blockScope) {
+      InternalCompilerException exception =
+          new InternalCompilerException("Switch expressions not yet supported");
+      exception.addNode(new JCaseStatement(makeSourceInfo(x), null));
+      throw exception;
+    }
+
+    @Override
     public boolean visit(LocalDeclaration x, BlockScope scope) {
       try {
         createLocal(x);
@@ -2764,6 +2773,12 @@ public class GwtAstBuilder {
     }
 
     protected boolean visit(TypeDeclaration x) {
+      if (x.isRecord()) {
+        InternalCompilerException exception =
+            new InternalCompilerException("Records not yet supported");
+        exception.addNode(new JClassType(makeSourceInfo(x), intern(x.name), false, false));
+        throw exception;
+      }
       JDeclaredType type = (JDeclaredType) typeMap.get(x.binding);
       assert !type.isExternal();
       classStack.push(curClass);

--- a/dev/core/src/com/google/gwt/dev/jjs/impl/GwtAstBuilder.java
+++ b/dev/core/src/com/google/gwt/dev/jjs/impl/GwtAstBuilder.java
@@ -537,7 +537,7 @@ public class GwtAstBuilder {
 
     @Override
     public void endVisit(CaseStatement x, BlockScope scope) {
-      if(x.isExpr){
+      if (x.isExpr) {
         InternalCompilerException excption =
             new InternalCompilerException("Switch expressions not yet supported");
         excption.addNode(new JCaseStatement(makeSourceInfo(x), null));
@@ -3717,7 +3717,6 @@ public class GwtAstBuilder {
         return new JType[] {typeMap.get(type)};
       }
     }
-
 
     private boolean isFunctionalInterfaceWithMethod(ReferenceBinding referenceBinding, Scope scope,
         String samSignature) {

--- a/dev/core/src/com/google/gwt/dev/util/arg/SourceLevel.java
+++ b/dev/core/src/com/google/gwt/dev/util/arg/SourceLevel.java
@@ -26,7 +26,8 @@ public enum SourceLevel {
   JAVA8("1.8", "8"),
   JAVA9("9", "1.9"),
   JAVA10("10", "1.10"),
-  JAVA11("11", "1.11");
+  JAVA11("11", "1.11"),
+  JAVA17("17", "1.17");
 
   /**
    * The default java sourceLevel.

--- a/dev/core/test/com/google/gwt/dev/javac/BinaryTypeReferenceRestrictionsCheckerTest.java
+++ b/dev/core/test/com/google/gwt/dev/javac/BinaryTypeReferenceRestrictionsCheckerTest.java
@@ -37,6 +37,7 @@ import org.eclipse.jdt.internal.compiler.env.IBinaryMethod;
 import org.eclipse.jdt.internal.compiler.env.IBinaryNestedType;
 import org.eclipse.jdt.internal.compiler.env.IBinaryType;
 import org.eclipse.jdt.internal.compiler.env.IBinaryTypeAnnotation;
+import org.eclipse.jdt.internal.compiler.env.IRecordComponent;
 import org.eclipse.jdt.internal.compiler.env.ITypeAnnotationWalker;
 import org.eclipse.jdt.internal.compiler.impl.CompilerOptions;
 import org.eclipse.jdt.internal.compiler.lookup.BinaryTypeBinding;
@@ -180,6 +181,16 @@ public class BinaryTypeReferenceRestrictionsCheckerTest extends TestCase {
     @Override
     public ExternalAnnotationStatus getExternalAnnotationStatus() {
       return null;
+    }
+
+    @Override
+    public IRecordComponent[] getRecordComponents() {
+      return null;
+    }
+
+    @Override
+    public boolean isRecord() {
+      return false;
     }
   }
 

--- a/dev/core/test/com/google/gwt/dev/jjs/impl/Java17AstTest.java
+++ b/dev/core/test/com/google/gwt/dev/jjs/impl/Java17AstTest.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright 2019 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.gwt.dev.jjs.impl;
+
+import com.google.gwt.core.ext.UnableToCompleteException;
+import com.google.gwt.dev.javac.testing.impl.JavaResourceBase;
+import com.google.gwt.dev.jjs.InternalCompilerException;
+import com.google.gwt.dev.jjs.ast.JInterfaceType;
+import com.google.gwt.dev.jjs.ast.JProgram;
+import com.google.gwt.dev.jjs.ast.JStringLiteral;
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * Tests that {@link GwtAstBuilder} correctly builds the AST for
+ * features introduced in Java 17.
+ */
+public class Java17AstTest extends FullCompileTestBase {
+
+  @Override
+  public void setUp() throws Exception {
+    super.setUp();
+    addAll(JavaResourceBase.createMockJavaResource("test.TextBlock",
+        "package test;",
+        "public interface TextBlock {",
+        "String text =\"\"\"",
+        "line 1",
+        "line 2",
+        "line 3",
+        "\"\"\";",
+        "}"
+    ));
+
+    addAll(JavaResourceBase.createMockJavaResource("test.Shape",
+        "package test;",
+        "public sealed class Shape permits Square, Circle {",
+        "}"
+    ));
+
+    addAll(JavaResourceBase.createMockJavaResource("test.Square",
+        "package test;",
+        "public final class Square extends Shape {",
+        "}"
+    ));
+
+    addAll(JavaResourceBase.createMockJavaResource("test.Circle",
+        "package test;",
+        "public final class Circle extends Shape {",
+        "}"
+    ));
+
+    addAll(JavaResourceBase.createMockJavaResource("test.Months",
+        "package test;",
+        "public enum Months {",
+        "JANUARY, FEBRUARY, MARCH, APRIL, MAY, JUNE, JULY, AUGUST, SEPTEMBER, OCTOBER, NOVEMBER, DECEMBER;",
+        "}"
+    ));
+  }
+
+  public void testTextBlocks() throws Exception {
+    JProgram program = compileSnippet("void", "new TextBlock(){};");
+    JInterfaceType textBlock = (JInterfaceType) findType(program, "TextBlock");
+    JStringLiteral initializer = (JStringLiteral) textBlock.getFields().get(0).getInitializer();
+    String multiLineString = initializer.getValue();
+    List<String> lines = Arrays.asList(multiLineString.split("\n"));
+    assertEquals(3, lines.size());
+    assertEquals("line 1", lines.get(0));
+    assertEquals("line 2", lines.get(1));
+    assertEquals("line 3", lines.get(2));
+  }
+
+  public void testSealedClassesPermitted() throws Exception {
+    compileSnippet("void", "Shape square = new Square();");
+    compileSnippet("void", "Shape circle = new Circle();");
+  }
+
+  public void testSealedClassesNotPermitted() {
+    try {
+      addSnippetClassDecl("public final class Rectangle extends Shape {" +
+          "}");
+      compileSnippet("void", "Shape rectangle = new Rectangle();");
+      fail("Compile should have failed but succeeded.");
+    }catch (Exception e) {
+      if (!(e.getCause() instanceof UnableToCompleteException)
+          && !(e instanceof UnableToCompleteException)) {
+        e.printStackTrace();
+        fail();
+      }
+    }
+  }
+
+  public void testSwitchExpressionsNotSupported(){
+    try {
+      compileSnippet("void", "var month = Months.JUNE;" +
+          "var result = switch(month) {\n" +
+          "    case JANUARY, JUNE, JULY -> 3;\n" +
+          "    case FEBRUARY, SEPTEMBER, OCTOBER, NOVEMBER, DECEMBER -> 1;\n" +
+          "    case MARCH, MAY, APRIL, AUGUST -> 2;\n" +
+          "    default -> 0;" +
+          "};");
+      fail("Compile should have failed but succeeded, switch expression is not supported.");
+    }catch (Exception e){
+      if (!(e.getCause() instanceof InternalCompilerException)
+          && !(e instanceof InternalCompilerException)) {
+        e.printStackTrace();
+        fail();
+      }
+      assertEquals("Switch expressions not yet supported", e.getMessage());
+    }
+
+  }
+
+  @Override
+  protected void optimizeJava() {
+  }
+}

--- a/dev/core/test/com/google/gwt/dev/jjs/impl/Java17AstTest.java
+++ b/dev/core/test/com/google/gwt/dev/jjs/impl/Java17AstTest.java
@@ -91,7 +91,7 @@ public class Java17AstTest extends FullCompileTestBase {
           "}");
       compileSnippet("void", "Shape rectangle = new Rectangle();");
       fail("Compile should have failed but succeeded.");
-    }catch (Exception e) {
+    } catch (Exception e) {
       if (!(e.getCause() instanceof UnableToCompleteException)
           && !(e instanceof UnableToCompleteException)) {
         e.printStackTrace();
@@ -100,7 +100,7 @@ public class Java17AstTest extends FullCompileTestBase {
     }
   }
 
-  public void testSwitchExpressionsNotSupported(){
+  public void testSwitchExpressionsNotSupported() {
     try {
       compileSnippet("void", "var month = Months.JUNE;" +
           "var result = switch(month) {\n" +
@@ -110,7 +110,7 @@ public class Java17AstTest extends FullCompileTestBase {
           "    default -> 0;" +
           "};");
       fail("Compile should have failed but succeeded, switch expression is not supported.");
-    }catch (Exception e){
+    } catch (Exception e) {
       if (!(e.getCause() instanceof InternalCompilerException)
           && !(e instanceof InternalCompilerException)) {
         e.printStackTrace();
@@ -118,7 +118,6 @@ public class Java17AstTest extends FullCompileTestBase {
       }
       assertEquals("Switch expressions not yet supported", e.getMessage());
     }
-
   }
 
   @Override

--- a/dev/core/test/com/google/gwt/dev/jjs/impl/Java17AstTest.java
+++ b/dev/core/test/com/google/gwt/dev/jjs/impl/Java17AstTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Google Inc.
+ * Copyright 2024 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -100,6 +100,20 @@ public class Java17AstTest extends FullCompileTestBase {
     }
   }
 
+  public void testRecordsNotSupported() {
+    try {
+      addSnippetClassDecl("public record Point(int x, int y) {}");
+      compileSnippet("void", "Point rectangle = new Point(0, 0);");
+      fail("Compile should have failed but succeeded.");
+    } catch (Exception e) {
+      if (!(e.getCause() instanceof UnableToCompleteException)
+          && !(e instanceof UnableToCompleteException)) {
+        e.printStackTrace();
+        fail();
+      }
+    }
+  }
+
   public void testSwitchExpressionsNotSupported() {
     try {
       compileSnippet("void", "var month = Months.JUNE;" +
@@ -110,6 +124,25 @@ public class Java17AstTest extends FullCompileTestBase {
           "    default -> 0;" +
           "};");
       fail("Compile should have failed but succeeded, switch expression is not supported.");
+    } catch (Exception e) {
+      if (!(e.getCause() instanceof InternalCompilerException)
+          && !(e instanceof InternalCompilerException)) {
+        e.printStackTrace();
+        fail();
+      }
+      assertEquals("Switch expressions not yet supported", e.getMessage());
+    }
+  }
+
+  public void testSwitchExpressionsInitializerShouldFail() {
+    try {
+      compileSnippet("void", "    int i = switch(1) {\n" +
+          "      case 1:\n" +
+          "        yield 2;\n" +
+          "      default:\n" +
+          "        yield 7;\n" +
+          "    };");
+      fail("Compile should have failed but succeeded, switch expressions as initializer should fail.");
     } catch (Exception e) {
       if (!(e.getCause() instanceof InternalCompilerException)
           && !(e instanceof InternalCompilerException)) {

--- a/maven/google-poms/gwt/pom-template.xml
+++ b/maven/google-poms/gwt/pom-template.xml
@@ -22,7 +22,7 @@
     </licenses>
     <properties>
         <jetty.version>9.4.44.v20210927</jetty.version>
-        <asm.version>9.2</asm.version>
+        <asm.version>9.6</asm.version>
     </properties>
     <dependencyManagement>
         <dependencies>

--- a/maven/poms/gwt/pom-template.xml
+++ b/maven/poms/gwt/pom-template.xml
@@ -22,7 +22,7 @@
     </licenses>
     <properties>
       <jetty.version>9.4.44.v20210927</jetty.version>
-      <asm.version>9.2</asm.version>
+      <asm.version>9.6</asm.version>
     </properties>
     <dependencyManagement>
         <dependencies>

--- a/user/build.xml
+++ b/user/build.xml
@@ -2,7 +2,7 @@
   <property name="gwt.root" location=".."/>
   <property name="project.tail" value="user"/>
   <property name="test.args" value="-ea -sourceLevel auto"/>
-  <property name="test.jvmargs" value="-ea"/>
+  <property name="test.jvmargs" value="-ea -noverify"/>
 
   <!-- support old variables names -->
   <condition property="gwt.hosts.web.selenium" value="${gwt.selenium.hosts}">

--- a/user/build.xml
+++ b/user/build.xml
@@ -2,7 +2,7 @@
   <property name="gwt.root" location=".."/>
   <property name="project.tail" value="user"/>
   <property name="test.args" value="-ea -sourceLevel auto"/>
-  <property name="test.jvmargs" value="-ea -noverify"/>
+  <property name="test.jvmargs" value="-ea"/>
 
   <!-- support old variables names -->
   <condition property="gwt.hosts.web.selenium" value="${gwt.selenium.hosts}">

--- a/user/build.xml
+++ b/user/build.xml
@@ -61,8 +61,8 @@
     <pathelement location="${gwt.tools.lib}/cglib/cglib-3.1.jar"/>
     <pathelement location="${gwt.tools.lib}/mockito/1.9.5/mockito-all-1.9.5.jar"/>
     <pathelement location="${gwt.tools.lib}/objenesis/objenesis-1.2.jar"/>
-    <pathelement location="${gwt.tools.lib}/objectweb/asm-9.2/asm-9.2.jar"/>
-    <pathelement location="${gwt.tools.lib}/objectweb/asm-9.2/asm-commons-9.2.jar"/>
+    <pathelement location="${gwt.tools.lib}/objectweb/asm-9.6/asm-9.6.jar"/>
+    <pathelement location="${gwt.tools.lib}/objectweb/asm-9.6/asm-commons-9.6.jar"/>
     <pathelement location="${gwt.tools.lib}/javax/validation/validation-api-1.0.0.GA.jar"/>
     <pathelement location="${gwt.tools.lib}/javax/validation/validation-api-1.0.0.GA-sources.jar"/>
     <pathelement

--- a/user/build.xml
+++ b/user/build.xml
@@ -2,11 +2,7 @@
   <property name="gwt.root" location=".."/>
   <property name="project.tail" value="user"/>
   <property name="test.args" value="-ea -sourceLevel auto"/>
-  <!--
-  Adding "-noverify" is a workaround for https://bugs.openjdk.org/browse/JDK-8323657
-  so that tests can be compiled under Java9+.
-  -->
-  <property name="test.jvmargs" value="-ea -noverify"/>
+  <property name="test.jvmargs" value="-ea"/>
 
   <!-- support old variables names -->
   <condition property="gwt.hosts.web.selenium" value="${gwt.selenium.hosts}">

--- a/user/build.xml
+++ b/user/build.xml
@@ -2,7 +2,11 @@
   <property name="gwt.root" location=".."/>
   <property name="project.tail" value="user"/>
   <property name="test.args" value="-ea -sourceLevel auto"/>
-  <property name="test.jvmargs" value="-ea"/>
+  <!--
+  Adding "-noverify" is a workaround for https://bugs.openjdk.org/browse/JDK-8323657
+  so that tests can be compiled under Java9+.
+  -->
+  <property name="test.jvmargs" value="-ea -noverify"/>
 
   <!-- support old variables names -->
   <condition property="gwt.hosts.web.selenium" value="${gwt.selenium.hosts}">

--- a/user/test-super/com/google/gwt/dev/jjs/super/com/google/gwt/dev/jjs/test/Java17Test.java
+++ b/user/test-super/com/google/gwt/dev/jjs/super/com/google/gwt/dev/jjs/test/Java17Test.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2019 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.gwt.dev.jjs.test;
+
+import com.google.gwt.core.client.GwtScriptOnly;
+import com.google.gwt.junit.client.GWTTestCase;
+
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * Tests Java 17 features. It is super sourced so that gwt can be compiles under Java 11.
+ *
+ * IMPORTANT: For each test here there must exist the corresponding method in the non super sourced
+ * version.
+ *
+ * Eventually this test will graduate and not be super sourced.
+ */
+@GwtScriptOnly
+public class Java17Test extends GWTTestCase {
+
+  public interface TextBlock {
+    String text = """
+        line 1
+        line 2
+        line 3
+        """;
+  }
+
+  public sealed class Shape permits Square, Circle {
+
+  }
+
+  public final class Square extends Shape {
+
+  }
+
+  public final class Circle extends Shape {
+
+  }
+
+  @Override
+  public String getModuleName() {
+    return "com.google.gwt.dev.jjs.test.Java17Test";
+  }
+
+  public void testTextBlocks() {
+    List<String> lines = Arrays.asList(TextBlock.text.split("\n"));
+    assertEquals(3, lines.size());
+    assertEquals("line 1", lines.get(0));
+    assertEquals("line 2", lines.get(1));
+    assertEquals("line 3", lines.get(2));
+  }
+
+  public void testSealedClassesPermitted() {
+    Shape square = new Square();
+    Shape circle =  new Circle();
+
+    checkIfCompiled(square, circle);
+  }
+
+  private void checkIfCompiled(Shape square, Shape circle) {
+    assertTrue(square instanceof Square);
+    assertTrue(circle instanceof Circle);
+  }
+}

--- a/user/test/com/google/gwt/dev/jjs/CompilerSuite.java
+++ b/user/test/com/google/gwt/dev/jjs/CompilerSuite.java
@@ -29,6 +29,7 @@ import com.google.gwt.dev.jjs.test.InnerClassTest;
 import com.google.gwt.dev.jjs.test.InnerOuterSuperTest;
 import com.google.gwt.dev.jjs.test.Java10Test;
 import com.google.gwt.dev.jjs.test.Java11Test;
+import com.google.gwt.dev.jjs.test.Java17Test;
 import com.google.gwt.dev.jjs.test.Java7Test;
 import com.google.gwt.dev.jjs.test.Java8Test;
 import com.google.gwt.dev.jjs.test.Java9Test;
@@ -77,6 +78,7 @@ public class CompilerSuite {
     suite.addTestSuite(Java9Test.class);
     suite.addTestSuite(Java10Test.class);
     suite.addTestSuite(Java11Test.class);
+    suite.addTestSuite(Java17Test.class);
     suite.addTestSuite(JavaAccessFromJavaScriptTest.class);
     suite.addTestSuite(JsniConstructorTest.class);
     suite.addTestSuite(JsniDispatchTest.class);

--- a/user/test/com/google/gwt/dev/jjs/Java17Test.gwt.xml
+++ b/user/test/com/google/gwt/dev/jjs/Java17Test.gwt.xml
@@ -1,0 +1,19 @@
+<!--                                                                        -->
+<!-- Copyright 2019 Google Inc.                                             -->
+<!-- Licensed under the Apache License, Version 2.0 (the "License"); you    -->
+<!-- may not use this file except in compliance with the License. You may   -->
+<!-- may obtain a copy of the License at                                    -->
+<!--                                                                        -->
+<!-- http://www.apache.org/licenses/LICENSE-2.0                             -->
+<!--                                                                        -->
+<!-- Unless required by applicable law or agreed to in writing, software    -->
+<!-- distributed under the License is distributed on an "AS IS" BASIS,      -->
+<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or        -->
+<!-- implied. License for the specific language governing permissions and   -->
+<!-- limitations under the License.                                         -->
+
+<!-- Contains tests for breaking out of the client source path  -->
+<module>
+  <inherits name="com.google.gwt.core.Core" />
+  <super-source path='super' />
+</module>

--- a/user/test/com/google/gwt/dev/jjs/test/Java17Test.java
+++ b/user/test/com/google/gwt/dev/jjs/test/Java17Test.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2019 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.gwt.dev.jjs.test;
+
+import com.google.gwt.dev.util.arg.SourceLevel;
+import com.google.gwt.junit.DoNotRunWith;
+import com.google.gwt.junit.JUnitShell;
+import com.google.gwt.junit.Platform;
+import com.google.gwt.junit.client.GWTTestCase;
+
+/**
+ * Dummy test case. Java17Test is super sourced so that GWT can be compiled by Java 8.
+ *
+ * NOTE: Make sure this class has the same test methods of its supersourced variant.
+ */
+@DoNotRunWith(Platform.Devel)
+public class Java17Test extends GWTTestCase {
+
+  @Override
+  public String getModuleName() {
+    return "com.google.gwt.dev.jjs.Java17Test";
+  }
+
+  @Override
+  public void runTest() throws Throwable {
+    // Only run these tests if -sourceLevel 17 (or greater) is enabled.
+    if (isGwtSourceLevel17()) {
+      super.runTest();
+    }
+  }
+
+  public void testTextBlocks() {
+    assertFalse(isGwtSourceLevel17());
+  }
+
+  public void testSealedClassesPermitted() {
+    assertFalse(isGwtSourceLevel17());
+  }
+
+  private boolean isGwtSourceLevel17() {
+    return JUnitShell.getCompilerOptions().getSourceLevel().compareTo(SourceLevel.JAVA17) >= 0;
+  }
+}


### PR DESCRIPTION
Update build scripts to point to the latest JDT [3.36.0.v20231115-1055] and the latest asm 9.6. Updating beyond this would drop support for running compiler/devmode on Java 11.

fix #9871
