### PR TITLE
Checkstyle import rules should be consistent with the codebase

### DIFF
--- a/dev/core/src/com/google/gwt/dev/javac/UnitCacheSingleton.java
+++ b/dev/core/src/com/google/gwt/dev/javac/UnitCacheSingleton.java
@@ -17,7 +17,6 @@ package com.google.gwt.dev.javac;
 
 import com.google.gwt.core.ext.TreeLogger;
 import com.google.gwt.core.ext.UnableToCompleteException;
-
 import com.google.gwt.dev.jjs.JJSOptions;
 import com.google.gwt.thirdparty.guava.common.base.Joiner;
 import com.google.gwt.util.tools.shared.Md5Utils;

--- a/dev/core/src/com/google/gwt/dev/js/JsUtils.java
+++ b/dev/core/src/com/google/gwt/dev/js/JsUtils.java
@@ -47,7 +47,6 @@ import com.google.gwt.thirdparty.guava.common.collect.Lists;
 
 import java.util.Collections;
 import java.util.List;
-
 import java.util.regex.Pattern;
 
 /**

--- a/dev/core/src/com/google/gwt/dev/shell/StaticResourceServer.java
+++ b/dev/core/src/com/google/gwt/dev/shell/StaticResourceServer.java
@@ -23,6 +23,7 @@ import com.google.gwt.dev.shell.jetty.ClientAuthType;
 import com.google.gwt.dev.shell.jetty.JettyLauncherUtils;
 import com.google.gwt.dev.shell.jetty.JettyTreeLogger;
 import com.google.gwt.dev.shell.jetty.SslConfiguration;
+
 import org.eclipse.jetty.security.ConstraintSecurityHandler;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.server.ServerConnector;

--- a/dev/core/src/com/google/gwt/dev/shell/jetty/JettyLauncherUtils.java
+++ b/dev/core/src/com/google/gwt/dev/shell/jetty/JettyLauncherUtils.java
@@ -16,6 +16,7 @@
 package com.google.gwt.dev.shell.jetty;
 
 import com.google.gwt.core.ext.TreeLogger;
+
 import org.eclipse.jetty.server.HttpConfiguration;
 import org.eclipse.jetty.server.HttpConnectionFactory;
 import org.eclipse.jetty.server.SecureRequestCustomizer;

--- a/dev/core/src/com/google/gwt/dev/shell/jetty/JettyTreeLogger.java
+++ b/dev/core/src/com/google/gwt/dev/shell/jetty/JettyTreeLogger.java
@@ -16,6 +16,7 @@
 package com.google.gwt.dev.shell.jetty;
 
 import com.google.gwt.core.ext.TreeLogger;
+
 import org.eclipse.jetty.util.log.Logger;
 
 /**

--- a/dev/core/test/com/google/gwt/dev/CompilerTest.java
+++ b/dev/core/test/com/google/gwt/dev/CompilerTest.java
@@ -39,6 +39,7 @@ import com.google.gwt.thirdparty.guava.common.collect.Lists;
 import com.google.gwt.thirdparty.guava.common.collect.Sets;
 import com.google.gwt.thirdparty.guava.common.io.Files;
 import com.google.gwt.util.tools.Utility;
+
 import java.io.File;
 import java.io.IOException;
 import java.util.Arrays;

--- a/dev/core/test/com/google/gwt/dev/jjs/impl/Java17AstTest.java
+++ b/dev/core/test/com/google/gwt/dev/jjs/impl/Java17AstTest.java
@@ -19,6 +19,7 @@ import com.google.gwt.dev.jjs.InternalCompilerException;
 import com.google.gwt.dev.jjs.ast.JInterfaceType;
 import com.google.gwt.dev.jjs.ast.JProgram;
 import com.google.gwt.dev.jjs.ast.JStringLiteral;
+
 import java.util.Arrays;
 import java.util.List;
 

--- a/dev/core/test/com/google/gwt/dev/resource/impl/DefaultFiltersTest.java
+++ b/dev/core/test/com/google/gwt/dev/resource/impl/DefaultFiltersTest.java
@@ -16,10 +16,9 @@
 package com.google.gwt.dev.resource.impl;
 
 import com.google.gwt.dev.resource.impl.DefaultFilters.FilterFileType;
+import com.google.gwt.thirdparty.apache.ant.types.ZipScanner;
 
 import junit.framework.TestCase;
-
-import com.google.gwt.thirdparty.apache.ant.types.ZipScanner;
 
 import java.util.ArrayList;
 import java.util.Arrays;

--- a/eclipse/settings/code-style/gwt-checkstyle-tests.xml
+++ b/eclipse/settings/code-style/gwt-checkstyle-tests.xml
@@ -94,10 +94,12 @@ A more lenient set of style checks for test cases, needed because test often nee
             <property name="allowMissingReturnTag" value="true"/>
             <property name="tokens" value="METHOD_DEF"/>
         </module>
-        <module name="CustomImportOrder">
-            <property name="sortImportsInGroupAlphabetically" value="true"/>
-            <property name="separateLineBetweenGroups" value="true"/>
-            <property name="customImportOrderRules" value="STATIC###THIRD_PARTY_PACKAGE"/>
+        <module name="ImportOrder">
+            <property name="groups" value="/^com\.google\./, /^cern\./, /^com\./, /^junit\./, /^net\./, /^org\./, /^(java|javaemul|jsinterop)\./, /^javax\./" />
+            <property name="option" value="top" />
+            <property name="separated" value="true" />
+            <property name="separatedStaticGroups" value="true" />
+            <property name="sortStaticImportsAlphabetically" value="true" />
         </module>
         <module name="DefaultComesLast">
             <metadata name="com.atlassw.tools.eclipse.checkstyle.lastEnabledSeverity" value="error"/>

--- a/eclipse/settings/code-style/gwt-checkstyle.xml
+++ b/eclipse/settings/code-style/gwt-checkstyle.xml
@@ -91,10 +91,12 @@ Description:
             <property name="allowMissingReturnTag" value="true"/>
             <property name="tokens" value="METHOD_DEF"/>
         </module>
-        <module name="CustomImportOrder">
-            <property name="sortImportsInGroupAlphabetically" value="true"/>
-            <property name="separateLineBetweenGroups" value="true"/>
-            <property name="customImportOrderRules" value="STATIC###THIRD_PARTY_PACKAGE"/>
+        <module name="ImportOrder">
+            <property name="groups" value="/^com\.google\./, /^cern\./, /^com\./, /^junit\./, /^net\./, /^org\./, /^(java|javaemul|jsinterop)\./, /^javax\./" />
+            <property name="option" value="top" />
+            <property name="separated" value="true" />
+            <property name="separatedStaticGroups" value="true" />
+            <property name="sortStaticImportsAlphabetically" value="true" />
         </module>
         <module name="DefaultComesLast">
             <property name="severity" value="error"/>

--- a/samples/validation/src/main/java/com/google/gwt/sample/validation/shared/Person.java
+++ b/samples/validation/src/main/java/com/google/gwt/sample/validation/shared/Person.java
@@ -16,7 +16,6 @@
 package com.google.gwt.sample.validation.shared;
 
 import com.google.gwt.sample.validation.server.ServerConstraint;
-
 import com.google.gwt.user.client.rpc.IsSerializable;
 
 import java.util.Map;

--- a/tools/api-checker/src/com/google/gwt/tools/apichecker/ApiCompatibilityChecker.java
+++ b/tools/api-checker/src/com/google/gwt/tools/apichecker/ApiCompatibilityChecker.java
@@ -24,11 +24,10 @@ import com.google.gwt.dev.util.Util;
 import com.google.gwt.dev.util.arg.SourceLevel;
 import com.google.gwt.dev.util.log.AbstractTreeLogger;
 import com.google.gwt.dev.util.log.PrintWriterTreeLogger;
+import com.google.gwt.thirdparty.apache.ant.types.ZipScanner;
 import com.google.gwt.util.tools.ArgHandlerFlag;
 import com.google.gwt.util.tools.ArgHandlerString;
 import com.google.gwt.util.tools.ToolBase;
-
-import com.google.gwt.thirdparty.apache.ant.types.ZipScanner;
 
 import java.io.BufferedInputStream;
 import java.io.BufferedReader;

--- a/user/src/com/google/web/bindery/requestfactory/server/RequestFactoryJarExtractor.java
+++ b/user/src/com/google/web/bindery/requestfactory/server/RequestFactoryJarExtractor.java
@@ -18,7 +18,6 @@ package com.google.web.bindery.requestfactory.server;
 import com.google.gwt.dev.util.Name;
 import com.google.gwt.dev.util.Name.SourceOrBinaryName;
 import com.google.gwt.dev.util.Util;
-
 import com.google.web.bindery.event.shared.SimpleEventBus;
 import com.google.web.bindery.requestfactory.apt.RfValidator;
 import com.google.web.bindery.requestfactory.apt.ValidationTool;

--- a/user/super/com/google/gwt/emul/java/lang/Boolean.java
+++ b/user/super/com/google/gwt/emul/java/lang/Boolean.java
@@ -18,9 +18,7 @@ package java.lang;
 import static javaemul.internal.InternalPreconditions.checkNotNull;
 
 import java.io.Serializable;
-
 import javaemul.internal.JsUtils;
-
 import jsinterop.annotations.JsMethod;
 
 /**

--- a/user/super/com/google/gwt/emul/java/lang/CharSequence.java
+++ b/user/super/com/google/gwt/emul/java/lang/CharSequence.java
@@ -22,9 +22,7 @@ import java.util.Spliterator;
 import java.util.Spliterators;
 import java.util.stream.IntStream;
 import java.util.stream.StreamSupport;
-
 import javaemul.internal.JsUtils;
-
 import jsinterop.annotations.JsMethod;
 
 /**

--- a/user/super/com/google/gwt/emul/java/lang/Class.java
+++ b/user/super/com/google/gwt/emul/java/lang/Class.java
@@ -18,7 +18,6 @@ package java.lang;
 import com.google.gwt.core.client.JavaScriptObject;
 
 import java.lang.reflect.Type;
-
 import javaemul.internal.annotations.DoNotInline;
 
 /**

--- a/user/super/com/google/gwt/emul/java/lang/Comparable.java
+++ b/user/super/com/google/gwt/emul/java/lang/Comparable.java
@@ -16,7 +16,6 @@
 package java.lang;
 
 import javaemul.internal.JsUtils;
-
 import jsinterop.annotations.JsMethod;
 
 /**

--- a/user/super/com/google/gwt/emul/java/lang/Enum.java
+++ b/user/super/com/google/gwt/emul/java/lang/Enum.java
@@ -19,6 +19,7 @@ import static javaemul.internal.InternalPreconditions.checkCriticalArgument;
 import static javaemul.internal.InternalPreconditions.checkNotNull;
 
 import com.google.gwt.core.client.JavaScriptObject;
+
 import java.io.Serializable;
 import jsinterop.annotations.JsIgnore;
 import jsinterop.annotations.JsNonNull;

--- a/user/super/com/google/gwt/emul/java/lang/Throwable.java
+++ b/user/super/com/google/gwt/emul/java/lang/Throwable.java
@@ -21,9 +21,7 @@ import static javaemul.internal.InternalPreconditions.checkState;
 
 import java.io.PrintStream;
 import java.io.Serializable;
-
 import javaemul.internal.annotations.DoNotInline;
-
 import jsinterop.annotations.JsMethod;
 import jsinterop.annotations.JsNonNull;
 import jsinterop.annotations.JsPackage;

--- a/user/super/com/google/gwt/emul/java/math/MathContext.java
+++ b/user/super/com/google/gwt/emul/java/math/MathContext.java
@@ -38,7 +38,6 @@ import static javaemul.internal.InternalPreconditions.checkCriticalArgument;
 import static javaemul.internal.InternalPreconditions.checkNotNull;
 
 import java.io.Serializable;
-
 import javaemul.internal.NativeRegExp;
 
 /**

--- a/user/super/com/google/gwt/emul/java/util/Collection.java
+++ b/user/super/com/google/gwt/emul/java/util/Collection.java
@@ -20,7 +20,6 @@ import static javaemul.internal.InternalPreconditions.checkNotNull;
 import java.util.function.Predicate;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
-
 import jsinterop.annotations.JsIgnore;
 import jsinterop.annotations.JsType;
 

--- a/user/super/com/google/gwt/emul/java/util/Collections.java
+++ b/user/super/com/google/gwt/emul/java/util/Collections.java
@@ -23,7 +23,6 @@ import static javaemul.internal.InternalPreconditions.checkNotNull;
 import java.io.Serializable;
 import java.util.function.Predicate;
 import java.util.function.UnaryOperator;
-
 import jsinterop.annotations.JsNonNull;
 
 /**

--- a/user/super/com/google/gwt/emul/java/util/Date.java
+++ b/user/super/com/google/gwt/emul/java/util/Date.java
@@ -16,7 +16,6 @@
 package java.util;
 
 import java.io.Serializable;
-
 import jsinterop.annotations.JsPackage;
 import jsinterop.annotations.JsType;
 

--- a/user/super/com/google/gwt/emul/java/util/List.java
+++ b/user/super/com/google/gwt/emul/java/util/List.java
@@ -18,9 +18,8 @@ package java.util;
 import static javaemul.internal.InternalPreconditions.checkNotNull;
 
 import java.util.function.UnaryOperator;
-import javaemul.internal.ArrayHelper;
 import java.util.stream.Collectors;
-
+import javaemul.internal.ArrayHelper;
 import jsinterop.annotations.JsIgnore;
 import jsinterop.annotations.JsMethod;
 import jsinterop.annotations.JsNonNull;

--- a/user/super/com/google/gwt/emul/java/util/Map.java
+++ b/user/super/com/google/gwt/emul/java/util/Map.java
@@ -23,7 +23,6 @@ import java.util.function.BiConsumer;
 import java.util.function.BiFunction;
 import java.util.function.Function;
 import java.util.stream.Collectors;
-
 import jsinterop.annotations.JsIgnore;
 import jsinterop.annotations.JsNonNull;
 import jsinterop.annotations.JsType;

--- a/user/super/com/google/gwt/emul/java/util/Set.java
+++ b/user/super/com/google/gwt/emul/java/util/Set.java
@@ -19,7 +19,6 @@ import static javaemul.internal.InternalPreconditions.checkArgument;
 import static javaemul.internal.InternalPreconditions.checkNotNull;
 
 import java.util.stream.Collectors;
-
 import jsinterop.annotations.JsIgnore;
 import jsinterop.annotations.JsType;
 

--- a/user/super/com/google/gwt/emul/java/util/Vector.java
+++ b/user/super/com/google/gwt/emul/java/util/Vector.java
@@ -21,7 +21,6 @@ import java.io.Serializable;
 import java.util.function.Consumer;
 import java.util.function.Predicate;
 import java.util.function.UnaryOperator;
-
 import jsinterop.annotations.JsNonNull;
 
 /**

--- a/user/super/com/google/gwt/emul/java/util/function/BinaryOperator.java
+++ b/user/super/com/google/gwt/emul/java/util/function/BinaryOperator.java
@@ -15,9 +15,9 @@
  */
 package java.util.function;
 
-import java.util.Comparator;
-
 import static javaemul.internal.InternalPreconditions.checkCriticalNotNull;
+
+import java.util.Comparator;
 
 /**
  * See <a href="https://docs.oracle.com/javase/8/docs/api/java/util/function/BinaryOperator.html">

--- a/user/super/com/google/gwt/emul/java/util/function/Predicate.java
+++ b/user/super/com/google/gwt/emul/java/util/function/Predicate.java
@@ -15,9 +15,9 @@
  */
 package java.util.function;
 
-import java.util.Objects;
-
 import static javaemul.internal.InternalPreconditions.checkCriticalNotNull;
+
+import java.util.Objects;
 
 /**
  * See <a href="https://docs.oracle.com/javase/8/docs/api/java/util/function/Predicate.html">

--- a/user/test/com/google/gwt/core/client/impl/StackTraceEmulTest.java
+++ b/user/test/com/google/gwt/core/client/impl/StackTraceEmulTest.java
@@ -67,7 +67,7 @@ public class StackTraceEmulTest extends StackTraceNativeTest {
     String[] methodNames = getTraceJava();
 
     StackTraceElement[] expectedTrace = new StackTraceElement[] {
-        createSTE(methodNames[0], "Throwable.java", 68),
+        createSTE(methodNames[0], "Throwable.java", 66),
         createSTE(methodNames[1], "Exception.java", 29),
         createSTE(methodNames[2], "StackTraceExamples.java", 57),
         createSTE(methodNames[3], "StackTraceExamples.java", 52),

--- a/user/test/com/google/gwt/core/interop/ElementLikeNativeInterface.java
+++ b/user/test/com/google/gwt/core/interop/ElementLikeNativeInterface.java
@@ -15,7 +15,6 @@
  */
 package com.google.gwt.core.interop;
 
-
 import jsinterop.annotations.JsProperty;
 import jsinterop.annotations.JsType;
 

--- a/user/test/com/google/gwt/core/interop/JsTypeTest.java
+++ b/user/test/com/google/gwt/core/interop/JsTypeTest.java
@@ -21,7 +21,6 @@ import com.google.gwt.core.client.JavaScriptObject;
 import com.google.gwt.junit.client.GWTTestCase;
 
 import java.util.Iterator;
-
 import jsinterop.annotations.JsFunction;
 import jsinterop.annotations.JsMethod;
 import jsinterop.annotations.JsPackage;

--- a/user/test/com/google/gwt/dev/jjs/optimized/CastOptimizationTest.java
+++ b/user/test/com/google/gwt/dev/jjs/optimized/CastOptimizationTest.java
@@ -20,7 +20,6 @@ import com.google.gwt.junit.DoNotRunWith;
 import com.google.gwt.junit.Platform;
 
 import java.util.Random;
-
 import jsinterop.annotations.JsPackage;
 import jsinterop.annotations.JsType;
 

--- a/user/test/com/google/gwt/dev/jjs/optimized/UncheckedCastOptimizationTest.java
+++ b/user/test/com/google/gwt/dev/jjs/optimized/UncheckedCastOptimizationTest.java
@@ -19,7 +19,6 @@ import com.google.gwt.junit.DoNotRunWith;
 import com.google.gwt.junit.Platform;
 
 import javaemul.internal.annotations.UncheckedCast;
-
 import jsinterop.annotations.JsPackage;
 import jsinterop.annotations.JsType;
 

--- a/user/test/com/google/gwt/dev/jjs/test/CompilerMiscRegressionTest.java
+++ b/user/test/com/google/gwt/dev/jjs/test/CompilerMiscRegressionTest.java
@@ -34,7 +34,6 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-
 import javaemul.internal.annotations.DoNotInline;
 import jsinterop.annotations.JsMethod;
 import jsinterop.annotations.JsOverlay;

--- a/user/test/com/google/gwt/emultest/CollectionsSuite.java
+++ b/user/test/com/google/gwt/emultest/CollectionsSuite.java
@@ -40,6 +40,7 @@ import com.google.gwt.emultest.java.util.TreeMapStringStringWithComparatorTest;
 import com.google.gwt.emultest.java.util.TreeSetIntegerTest;
 import com.google.gwt.emultest.java.util.TreeSetIntegerWithComparatorTest;
 import com.google.gwt.emultest.java.util.VectorTest;
+
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
 import org.junit.runners.Suite.SuiteClasses;

--- a/user/test/com/google/gwt/emultest/EmulJava10Suite.java
+++ b/user/test/com/google/gwt/emultest/EmulJava10Suite.java
@@ -15,14 +15,15 @@
  */
 package com.google.gwt.emultest;
 
+import com.google.gwt.emultest.java10.util.ListTest;
+import com.google.gwt.emultest.java10.util.MapTest;
 import com.google.gwt.emultest.java10.util.OptionalDoubleTest;
 import com.google.gwt.emultest.java10.util.OptionalIntTest;
 import com.google.gwt.emultest.java10.util.OptionalLongTest;
 import com.google.gwt.emultest.java10.util.OptionalTest;
-import com.google.gwt.emultest.java10.util.ListTest;
-import com.google.gwt.emultest.java10.util.MapTest;
 import com.google.gwt.emultest.java10.util.SetTest;
 import com.google.gwt.emultest.java10.util.stream.CollectorsTest;
+
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
 import org.junit.runners.Suite.SuiteClasses;

--- a/user/test/com/google/gwt/emultest/EmulJava11Suite.java
+++ b/user/test/com/google/gwt/emultest/EmulJava11Suite.java
@@ -20,6 +20,7 @@ import com.google.gwt.emultest.java11.util.OptionalIntTest;
 import com.google.gwt.emultest.java11.util.OptionalLongTest;
 import com.google.gwt.emultest.java11.util.OptionalTest;
 import com.google.gwt.emultest.java11.util.function.PredicateTest;
+
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
 

--- a/user/test/com/google/gwt/emultest/EmulJava9Suite.java
+++ b/user/test/com/google/gwt/emultest/EmulJava9Suite.java
@@ -15,11 +15,6 @@
  */
 package com.google.gwt.emultest;
 
-import com.google.gwt.emultest.java9.util.stream.CollectorsTest;
-import com.google.gwt.emultest.java9.util.stream.DoubleStreamTest;
-import com.google.gwt.emultest.java9.util.stream.IntStreamTest;
-import com.google.gwt.emultest.java9.util.stream.LongStreamTest;
-import com.google.gwt.emultest.java9.util.stream.StreamTest;
 import com.google.gwt.emultest.java9.util.ListTest;
 import com.google.gwt.emultest.java9.util.MapTest;
 import com.google.gwt.emultest.java9.util.OptionalDoubleTest;
@@ -27,6 +22,12 @@ import com.google.gwt.emultest.java9.util.OptionalIntTest;
 import com.google.gwt.emultest.java9.util.OptionalLongTest;
 import com.google.gwt.emultest.java9.util.OptionalTest;
 import com.google.gwt.emultest.java9.util.SetTest;
+import com.google.gwt.emultest.java9.util.stream.CollectorsTest;
+import com.google.gwt.emultest.java9.util.stream.DoubleStreamTest;
+import com.google.gwt.emultest.java9.util.stream.IntStreamTest;
+import com.google.gwt.emultest.java9.util.stream.LongStreamTest;
+import com.google.gwt.emultest.java9.util.stream.StreamTest;
+
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
 import org.junit.runners.Suite.SuiteClasses;

--- a/user/test/com/google/gwt/emultest/EmulSuite.java
+++ b/user/test/com/google/gwt/emultest/EmulSuite.java
@@ -62,6 +62,7 @@ import com.google.gwt.emultest.java.util.ComparatorTest;
 import com.google.gwt.emultest.java.util.DateTest;
 import com.google.gwt.emultest.java.util.ObjectsTest;
 import com.google.gwt.emultest.java.util.RandomTest;
+
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
 import org.junit.runners.Suite.SuiteClasses;

--- a/user/test/com/google/gwt/emultest/java/internal/CoercionsTest.java
+++ b/user/test/com/google/gwt/emultest/java/internal/CoercionsTest.java
@@ -18,7 +18,6 @@ package com.google.gwt.emultest.java.internal;
 import com.google.gwt.junit.client.GWTTestCase;
 
 import java.util.Random;
-
 import javaemul.internal.Coercions;
 
 /**

--- a/user/test/com/google/gwt/emultest/java/io/BufferedWriterTest.java
+++ b/user/test/com/google/gwt/emultest/java/io/BufferedWriterTest.java
@@ -16,6 +16,7 @@
 package com.google.gwt.emultest.java.io;
 
 import com.google.gwt.junit.client.GWTTestCase;
+
 import java.io.BufferedWriter;
 import java.io.IOException;
 import java.io.Writer;

--- a/user/test/com/google/gwt/emultest/java/io/OutputStreamWriterTest.java
+++ b/user/test/com/google/gwt/emultest/java/io/OutputStreamWriterTest.java
@@ -18,6 +18,7 @@ package com.google.gwt.emultest.java.io;
 import static java.nio.charset.StandardCharsets.UTF_8;
 
 import com.google.gwt.junit.client.GWTTestCase;
+
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.OutputStreamWriter;

--- a/user/test/com/google/gwt/emultest/java/io/PrintStreamTest.java
+++ b/user/test/com/google/gwt/emultest/java/io/PrintStreamTest.java
@@ -18,6 +18,7 @@ package com.google.gwt.emultest.java.io;
 import static java.nio.charset.StandardCharsets.UTF_8;
 
 import com.google.gwt.junit.client.GWTTestCase;
+
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;

--- a/user/test/com/google/gwt/emultest/java/lang/CharacterTest.java
+++ b/user/test/com/google/gwt/emultest/java/lang/CharacterTest.java
@@ -16,6 +16,7 @@
 package com.google.gwt.emultest.java.lang;
 
 import com.google.gwt.junit.client.GWTTestCase;
+
 import java.util.Arrays;
 
 /**

--- a/user/test/com/google/gwt/emultest/java/lang/JsExceptionTest.java
+++ b/user/test/com/google/gwt/emultest/java/lang/JsExceptionTest.java
@@ -14,6 +14,7 @@
 package com.google.gwt.emultest.java.lang;
 
 import com.google.gwt.testing.TestUtils;
+
 import jsinterop.annotations.JsMethod;
 import jsinterop.annotations.JsPackage;
 import jsinterop.annotations.JsType;

--- a/user/test/com/google/gwt/emultest/java/lang/StringTest.java
+++ b/user/test/com/google/gwt/emultest/java/lang/StringTest.java
@@ -18,6 +18,7 @@ package com.google.gwt.emultest.java.lang;
 import com.google.gwt.core.client.JavaScriptException;
 import com.google.gwt.junit.client.GWTTestCase;
 import com.google.gwt.testing.TestUtils;
+
 import java.io.UnsupportedEncodingException;
 import java.nio.charset.Charset;
 import java.util.Arrays;

--- a/user/test/com/google/gwt/emultest/java/lang/ThrowableTest.java
+++ b/user/test/com/google/gwt/emultest/java/lang/ThrowableTest.java
@@ -16,6 +16,7 @@
 package com.google.gwt.emultest.java.lang;
 
 import com.google.gwt.testing.TestUtils;
+
 import java.io.IOException;
 import jsinterop.annotations.JsType;
 

--- a/user/test/com/google/gwt/emultest/java/lang/ThrowableTestBase.java
+++ b/user/test/com/google/gwt/emultest/java/lang/ThrowableTestBase.java
@@ -16,6 +16,7 @@
 package com.google.gwt.emultest.java.lang;
 
 import com.google.gwt.junit.client.GWTTestCase;
+
 import jsinterop.annotations.JsFunction;
 import jsinterop.annotations.JsMethod;
 import jsinterop.annotations.JsPackage;

--- a/user/test/com/google/gwt/emultest/java/math/BigIntegerConstructorsTest.java
+++ b/user/test/com/google/gwt/emultest/java/math/BigIntegerConstructorsTest.java
@@ -38,6 +38,7 @@
 package com.google.gwt.emultest.java.math;
 
 import com.google.gwt.emultest.java.util.EmulTestBase;
+
 import java.math.BigInteger;
 import java.util.Random;
 

--- a/user/test/com/google/gwt/emultest/java/nio/charset/CharsetTest.java
+++ b/user/test/com/google/gwt/emultest/java/nio/charset/CharsetTest.java
@@ -17,6 +17,7 @@
 package com.google.gwt.emultest.java.nio.charset;
 
 import com.google.gwt.emultest.java.util.EmulTestBase;
+
 import java.nio.charset.Charset;
 import java.nio.charset.IllegalCharsetNameException;
 import java.nio.charset.UnsupportedCharsetException;

--- a/user/test/com/google/gwt/emultest/java/sql/SqlDateTest.java
+++ b/user/test/com/google/gwt/emultest/java/sql/SqlDateTest.java
@@ -16,6 +16,7 @@
 package com.google.gwt.emultest.java.sql;
 
 import com.google.gwt.junit.client.GWTTestCase;
+
 import java.sql.Date;
 
 /**

--- a/user/test/com/google/gwt/emultest/java/util/ArrayDequeTest.java
+++ b/user/test/com/google/gwt/emultest/java/util/ArrayDequeTest.java
@@ -19,6 +19,7 @@ import static java.util.Arrays.asList;
 
 import com.google.gwt.core.client.JavaScriptException;
 import com.google.gwt.testing.TestUtils;
+
 import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Collection;

--- a/user/test/com/google/gwt/emultest/java/util/ArraysDoubleSemanticsTest.java
+++ b/user/test/com/google/gwt/emultest/java/util/ArraysDoubleSemanticsTest.java
@@ -16,6 +16,7 @@
 package com.google.gwt.emultest.java.util;
 
 import com.google.gwt.testing.TestUtils;
+
 import java.util.Arrays;
 
 /** Tests {@link Arrays} (incorrect) Double semantics. */

--- a/user/test/com/google/gwt/emultest/java/util/ArraysFloatSemanticsTest.java
+++ b/user/test/com/google/gwt/emultest/java/util/ArraysFloatSemanticsTest.java
@@ -16,6 +16,7 @@
 package com.google.gwt.emultest.java.util;
 
 import com.google.gwt.testing.TestUtils;
+
 import java.util.Arrays;
 
 /** Tests {@link Arrays} (incorrect) Float semantics. */

--- a/user/test/com/google/gwt/emultest/java/util/DateTest.java
+++ b/user/test/com/google/gwt/emultest/java/util/DateTest.java
@@ -17,6 +17,7 @@ package com.google.gwt.emultest.java.util;
 
 import com.google.gwt.junit.client.GWTTestCase;
 import com.google.gwt.testing.TestUtils;
+
 import java.util.ArrayList;
 import java.util.Date;
 

--- a/user/test/com/google/gwt/emultest/java/util/IdentityHashMapTest.java
+++ b/user/test/com/google/gwt/emultest/java/util/IdentityHashMapTest.java
@@ -16,6 +16,7 @@
 package com.google.gwt.emultest.java.util;
 
 import com.google.gwt.testing.TestUtils;
+
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.IdentityHashMap;

--- a/user/test/com/google/gwt/emultest/java/util/LinkedHashMapTest.java
+++ b/user/test/com/google/gwt/emultest/java/util/LinkedHashMapTest.java
@@ -16,6 +16,7 @@
 package com.google.gwt.emultest.java.util;
 
 import com.google.gwt.testing.TestUtils;
+
 import java.util.Collection;
 import java.util.Iterator;
 import java.util.LinkedHashMap;

--- a/user/test/com/google/gwt/emultest/java/util/TestMap.java
+++ b/user/test/com/google/gwt/emultest/java/util/TestMap.java
@@ -18,6 +18,7 @@
 package com.google.gwt.emultest.java.util;
 
 import com.google.gwt.testing.TestUtils;
+
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.ConcurrentModificationException;

--- a/user/test/com/google/gwt/emultest/java/util/TreeMapTest.java
+++ b/user/test/com/google/gwt/emultest/java/util/TreeMapTest.java
@@ -16,6 +16,7 @@
 package com.google.gwt.emultest.java.util;
 
 import com.google.gwt.testing.TestUtils;
+
 import java.util.AbstractMap.SimpleEntry;
 import java.util.ArrayList;
 import java.util.Collection;

--- a/user/test/com/google/gwt/emultest/java/util/TreeSetTest.java
+++ b/user/test/com/google/gwt/emultest/java/util/TreeSetTest.java
@@ -16,6 +16,7 @@
 package com.google.gwt.emultest.java.util;
 
 import com.google.gwt.testing.TestUtils;
+
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;

--- a/user/test/com/google/gwt/emultest/java11/util/function/PredicateTest.java
+++ b/user/test/com/google/gwt/emultest/java11/util/function/PredicateTest.java
@@ -16,6 +16,7 @@
 package com.google.gwt.emultest.java11.util.function;
 
 import com.google.gwt.emultest.java.util.EmulTestBase;
+
 import java.util.function.Predicate;
 
 /**

--- a/user/test/com/google/gwt/emultest/java8/util/DoubleSummaryStatisticsTest.java
+++ b/user/test/com/google/gwt/emultest/java8/util/DoubleSummaryStatisticsTest.java
@@ -16,13 +16,14 @@
 
 package com.google.gwt.emultest.java8.util;
 
-import com.google.gwt.emultest.java.util.EmulTestBase;
 
 import static java.lang.Double.MAX_VALUE;
 import static java.lang.Double.MIN_VALUE;
 import static java.lang.Double.NEGATIVE_INFINITY;
 import static java.lang.Double.NaN;
 import static java.lang.Double.POSITIVE_INFINITY;
+
+import com.google.gwt.emultest.java.util.EmulTestBase;
 
 import java.util.Arrays;
 import java.util.DoubleSummaryStatistics;

--- a/user/test/com/google/gwt/emultest/java8/util/IntSummaryStatisticsTest.java
+++ b/user/test/com/google/gwt/emultest/java8/util/IntSummaryStatisticsTest.java
@@ -16,10 +16,10 @@
 
 package com.google.gwt.emultest.java8.util;
 
-import com.google.gwt.emultest.java.util.EmulTestBase;
-
 import static java.lang.Integer.MAX_VALUE;
 import static java.lang.Integer.MIN_VALUE;
+
+import com.google.gwt.emultest.java.util.EmulTestBase;
 
 import java.util.IntSummaryStatistics;
 

--- a/user/test/com/google/gwt/emultest/java8/util/LongSummaryStatisticsTest.java
+++ b/user/test/com/google/gwt/emultest/java8/util/LongSummaryStatisticsTest.java
@@ -16,10 +16,10 @@
 
 package com.google.gwt.emultest.java8.util;
 
-import com.google.gwt.emultest.java.util.EmulTestBase;
-
 import static java.lang.Long.MAX_VALUE;
 import static java.lang.Long.MIN_VALUE;
+
+import com.google.gwt.emultest.java.util.EmulTestBase;
 
 import java.util.LongSummaryStatistics;
 

--- a/user/test/com/google/gwt/emultest/java8/util/stream/StreamTest.java
+++ b/user/test/com/google/gwt/emultest/java8/util/stream/StreamTest.java
@@ -19,7 +19,6 @@ package com.google.gwt.emultest.java8.util.stream;
 import static java.util.Arrays.asList;
 
 import com.google.gwt.emultest.java.util.EmulTestBase;
-
 import com.google.gwt.testing.TestUtils;
 
 import java.util.ArrayList;

--- a/user/test/com/google/gwt/i18n/rebind/ConstantsWithLookupImplCreatorTest.java
+++ b/user/test/com/google/gwt/i18n/rebind/ConstantsWithLookupImplCreatorTest.java
@@ -15,6 +15,10 @@
  */
 package com.google.gwt.i18n.rebind;
 
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
 import com.google.gwt.core.ext.TreeLogger;
 import com.google.gwt.core.ext.UnableToCompleteException;
 import com.google.gwt.core.ext.typeinfo.JClassType;
@@ -34,10 +38,6 @@ import com.google.gwt.user.rebind.SourceWriter;
 import com.google.gwt.user.rebind.StringSourceWriter;
 
 import junit.framework.TestCase;
-
-import static org.mockito.Matchers.anyString;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
 import java.util.ArrayList;
 import java.util.Arrays;

--- a/user/test/com/google/gwt/i18n/rebind/LookupMethodCreatorTest.java
+++ b/user/test/com/google/gwt/i18n/rebind/LookupMethodCreatorTest.java
@@ -15,6 +15,8 @@
  */
 package com.google.gwt.i18n.rebind;
 
+import static org.mockito.Mockito.mock;
+
 import com.google.gwt.core.ext.TreeLogger;
 import com.google.gwt.core.ext.UnableToCompleteException;
 import com.google.gwt.core.ext.typeinfo.JClassType;
@@ -34,8 +36,6 @@ import com.google.gwt.user.rebind.SourceWriter;
 import com.google.gwt.user.rebind.StringSourceWriter;
 
 import junit.framework.TestCase;
-
-import static org.mockito.Mockito.mock;
 
 import java.util.List;
 

--- a/user/test/com/google/gwt/resources/rg/CssOutputTestCase.java
+++ b/user/test/com/google/gwt/resources/rg/CssOutputTestCase.java
@@ -15,6 +15,11 @@
  */
 package com.google.gwt.resources.rg;
 
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
 import com.google.gwt.core.ext.GeneratorContext;
 import com.google.gwt.core.ext.UnableToCompleteException;
 import com.google.gwt.core.ext.linker.GeneratedResource;
@@ -24,11 +29,6 @@ import com.google.gwt.dev.util.UnitTestTreeLogger;
 import com.google.gwt.resources.ext.ResourceContext;
 
 import junit.framework.TestCase;
-
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyNoMoreInteractions;
-import static org.mockito.Mockito.when;
 
 import java.io.ByteArrayOutputStream;
 import java.io.OutputStream;

--- a/user/test/com/google/gwt/uibinder/rebind/HandlerEvaluatorTest.java
+++ b/user/test/com/google/gwt/uibinder/rebind/HandlerEvaluatorTest.java
@@ -15,6 +15,9 @@
  */
 package com.google.gwt.uibinder.rebind;
 
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
 import com.google.gwt.core.ext.typeinfo.JClassType;
 import com.google.gwt.core.ext.typeinfo.TypeOracle;
 import com.google.gwt.dev.util.log.PrintWriterTreeLogger;
@@ -23,9 +26,6 @@ import com.google.gwt.uibinder.rebind.model.OwnerClass;
 import com.google.web.bindery.event.shared.HandlerRegistration;
 
 import junit.framework.TestCase;
-
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
 import java.io.PrintWriter;
 import java.io.StringWriter;

--- a/user/test/com/google/gwt/user/client/rpc/TestSetValidator.java
+++ b/user/test/com/google/gwt/user/client/rpc/TestSetValidator.java
@@ -15,6 +15,11 @@
  */
 package com.google.gwt.user.client.rpc;
 
+import static junit.framework.Assert.assertEquals;
+import static junit.framework.Assert.assertFalse;
+import static junit.framework.Assert.assertNotNull;
+import static junit.framework.Assert.assertSame;
+
 import com.google.gwt.event.shared.UmbrellaException;
 import com.google.gwt.user.client.rpc.FinalFieldsTestService.FinalFieldsNode;
 import com.google.gwt.user.client.rpc.TestSetFactory.MarkerTypeEmptyKey;
@@ -32,11 +37,6 @@ import com.google.gwt.user.client.rpc.TestSetFactory.SerializableDoublyLinkedNod
 import com.google.gwt.user.client.rpc.TestSetFactory.SerializableGraphWithCFS;
 import com.google.gwt.user.client.rpc.TestSetFactory.SerializablePrivateNoArg;
 import com.google.gwt.user.client.rpc.TestSetFactory.SerializableWithTwoArrays;
-
-import static junit.framework.Assert.assertEquals;
-import static junit.framework.Assert.assertFalse;
-import static junit.framework.Assert.assertNotNull;
-import static junit.framework.Assert.assertSame;
 
 import java.util.ArrayList;
 import java.util.EnumMap;


### PR DESCRIPTION
The old checkstyle was similar but not identical to the Google Java Style Guide, and it seems that checkstyle updates have changed import behaviors in a way to make them incompatible with those conventions (but more compatible with the Google style). These new rules are a close approximation to the old convention, with a few exceptions, mostly that imports are all listed at the top. There were also some inconsistencies, such as grouping jsinterop and javaemul with java packages - those have been resolved as simply as possible, with checkstyle rules to enforce this.