### PR TITLE
Undo the disable of source maps for non-chrome browsers

### DIFF
--- a/user/src/com/google/gwt/core/CoreWithUserAgent.gwt.xml
+++ b/user/src/com/google/gwt/core/CoreWithUserAgent.gwt.xml
@@ -16,14 +16,6 @@
 <module>
   <inherits name="com.google.gwt.core.Core"/>
 
-  <!-- Disable source maps for non-Chrome browsers -->
-  <!-- TODO(goktug): enable source maps for non-Chrome browsers -->
-  <set-property name="compiler.useSourceMaps" value="false">
-    <none> 
-      <when-property-is name="user.agent" value="safari"/>
-    </none> 
-  </set-property>
-
   <replace-with class="com.google.gwt.core.client.impl.StackTraceCreator.CollectorModern">
     <when-type-is class="com.google.gwt.core.client.impl.StackTraceCreator.Collector" />
     <when-property-is name="compiler.stackMode" value="native" />

--- a/user/src/com/google/gwt/core/CoreWithUserAgent.gwt.xml
+++ b/user/src/com/google/gwt/core/CoreWithUserAgent.gwt.xml
@@ -15,12 +15,4 @@
 <!-- Deferred binding rules for core classes based on user agent. -->
 <module>
   <inherits name="com.google.gwt.core.Core"/>
-
-  <replace-with class="com.google.gwt.core.client.impl.StackTraceCreator.CollectorModern">
-    <when-type-is class="com.google.gwt.core.client.impl.StackTraceCreator.Collector" />
-    <when-property-is name="compiler.stackMode" value="native" />
-    <when-property-is name="user.agent" value="safari" />
-    <when-property-is name="compiler.useSourceMaps" value="true"/>
-  </replace-with>
-
 </module>

--- a/user/src/com/google/gwt/core/StackTrace.gwt.xml
+++ b/user/src/com/google/gwt/core/StackTrace.gwt.xml
@@ -45,9 +45,14 @@
     <when-property-is name="compiler.stackMode" value="native" />
   </replace-with>
 
-
   <replace-with class="com.google.gwt.core.client.impl.StackTraceCreator.CollectorNull">
     <when-type-is class="com.google.gwt.core.client.impl.StackTraceCreator.Collector" />
     <when-property-is name="compiler.stackMode" value="strip" />
+  </replace-with>
+
+  <replace-with class="com.google.gwt.core.client.impl.StackTraceCreator.CollectorModern">
+    <when-type-is class="com.google.gwt.core.client.impl.StackTraceCreator.Collector" />
+    <when-property-is name="compiler.stackMode" value="native" />
+    <when-property-is name="compiler.useSourceMaps" value="true"/>
   </replace-with>
 </module>

--- a/user/test/com/google/gwt/user/LoggingRPCSuite.gwt.xml
+++ b/user/test/com/google/gwt/user/LoggingRPCSuite.gwt.xml
@@ -30,12 +30,9 @@
   </set-property>
 
   <!-- when stack trace stripping is enabled, we need to replace the Null collector 
-       with one that does something for Chrome -->
+       with one that does something -->
   <replace-with class="com.google.gwt.core.client.impl.StackTraceCreator.CollectorChrome">
     <when-type-is class="com.google.gwt.core.client.impl.StackTraceCreator.Collector" />
-    <!-- For now, only Chrome provides Error.stack support, so we hijack the
-         entire WebKit permutation -->
-    <when-property-is name="user.agent" value="safari" />
     <when-property-is name="compiler.useSourceMaps" value="true" />
   </replace-with>
 


### PR DESCRIPTION
Nowadays, all modern browsers support sourcemaps by default, so there is no need to have exception configuration anymore.
