### PR TITLE
Allow SDM's web server to reuse a socket without waiting

### DIFF
--- a/dev/codeserver/java/com/google/gwt/dev/codeserver/WebServer.java
+++ b/dev/codeserver/java/com/google/gwt/dev/codeserver/WebServer.java
@@ -121,7 +121,7 @@ public class WebServer {
     ServerConnector connector = new ServerConnector(newServer);
     connector.setHost(bindAddress);
     connector.setPort(port);
-    connector.setReuseAddress(false);
+    connector.setReuseAddress(true);
     newServer.addConnector(connector);
 
     ServletContextHandler newHandler = new ServletContextHandler(ServletContextHandler.GZIP);


### PR DESCRIPTION
This is Jetty's default for a Connector, and is the configuration also used by the DevMode Jetty app server instance.

Fixes #9944