### PR TITLE
Fix SDM (dev_mode_on.js) to work with strong CSP

### DIFF
--- a/dev/codeserver/java/com/google/gwt/dev/codeserver/dev_mode_on.js
+++ b/dev/codeserver/java/com/google/gwt/dev/codeserver/dev_mode_on.js
@@ -122,19 +122,22 @@
     result.style.background = '#ddd';
     result.style.border = '2px outset #ddd';
     result.style.padding = '3pt';
-    result.setAttribute('href', 'javascript:' + encodeURIComponent(javascript));
+    result.onclick = javascript;
     result.title = 'Tip: drag this button to the bookmark bar';
     return result;
   }
 
   function makeCompileBookmarklet(codeserver_url, module_name) {
     var bookmarklets_js = codeserver_url + 'dev_mode_on.js';
-    var javascript = '{ window.__gwt_bookmarklet_params = {'
-        + 'server_url:\'' + codeserver_url + '\','
-        + 'module_name:\'' + module_name + '\'};'
-        + ' var s = document.createElement(\'script\');'
-        + ' s.src = \'' + bookmarklets_js + '\';'
-        + ' void(document.getElementsByTagName(\'head\')[0].appendChild(s));}';
+    var javascript = function() { 
+	  window.__gwt_bookmarklet_params = {
+        server_url: codeserver_url,
+        module_name: module_name
+	  };
+       var s = document.createElement('script');
+       s.src = bookmarklets_js;
+       void(document.getElementsByTagName('head')[0].appendChild(s));
+	};
     return makeBookmarklet('Compile', javascript);
   }
 

--- a/dev/codeserver/java/com/google/gwt/dev/codeserver/dev_mode_on.js
+++ b/dev/codeserver/java/com/google/gwt/dev/codeserver/dev_mode_on.js
@@ -130,7 +130,7 @@
 
   function makeCompileBookmarklet(codeserver_url, module_name) {
     var bookmarklets_js = codeserver_url + 'dev_mode_on.js';
-	var javascript = '{ window.__gwt_bookmarklet_params = {'
+    var javascript = '{ window.__gwt_bookmarklet_params = {'
         + 'server_url:\'' + codeserver_url + '\','
         + 'module_name:\'' + module_name + '\'};'
         + ' var s = document.createElement(\'script\');'

--- a/dev/codeserver/java/com/google/gwt/dev/codeserver/dev_mode_on.js
+++ b/dev/codeserver/java/com/google/gwt/dev/codeserver/dev_mode_on.js
@@ -115,30 +115,37 @@
     return dialog;
   }
 
-  function makeBookmarklet(name, javascript) {
+  function makeBookmarklet(name, javascript, javascriptFunction) {
     var result = makeTextElt('a', '12pt', name);
     result.style.fontFamily = 'sans';
     result.style.textDecoration = 'none';
     result.style.background = '#ddd';
     result.style.border = '2px outset #ddd';
     result.style.padding = '3pt';
-    result.onclick = javascript;
+    result.onclick = javascriptFunction; // used in CSP case (clicking the button)
+	result.setAttribute('href', 'javascript:' + encodeURIComponent(javascript)); // used in bookmarklet case
     result.title = 'Tip: drag this button to the bookmark bar';
     return result;
   }
 
   function makeCompileBookmarklet(codeserver_url, module_name) {
     var bookmarklets_js = codeserver_url + 'dev_mode_on.js';
-    var javascript = function() { 
-	  window.__gwt_bookmarklet_params = {
+	var javascript = '{ window.__gwt_bookmarklet_params = {'
+        + 'server_url:\'' + codeserver_url + '\','
+        + 'module_name:\'' + module_name + '\'};'
+        + ' var s = document.createElement(\'script\');'
+        + ' s.src = \'' + bookmarklets_js + '\';'
+        + ' void(document.getElementsByTagName(\'head\')[0].appendChild(s));}';
+    var javascriptFunction = function() { 
+      window.__gwt_bookmarklet_params = {
         server_url: codeserver_url,
         module_name: module_name
-	  };
-       var s = document.createElement('script');
-       s.src = bookmarklets_js;
-       void(document.getElementsByTagName('head')[0].appendChild(s));
+      };
+      var s = document.createElement('script');
+      s.src = bookmarklets_js;
+      void(document.getElementsByTagName('head')[0].appendChild(s));
 	};
-    return makeBookmarklet('Compile', javascript);
+    return makeBookmarklet('Compile', javascript, javascriptFunction);
   }
 
   /**

--- a/dev/codeserver/java/com/google/gwt/dev/codeserver/dev_mode_on.js
+++ b/dev/codeserver/java/com/google/gwt/dev/codeserver/dev_mode_on.js
@@ -123,7 +123,7 @@
     result.style.border = '2px outset #ddd';
     result.style.padding = '3pt';
     result.onclick = javascriptFunction; // used in CSP case (clicking the button)
-	result.setAttribute('href', 'javascript:' + encodeURIComponent(javascript)); // used in bookmarklet case
+    result.setAttribute('href', 'javascript:' + encodeURIComponent(javascript)); // used in bookmarklet case
     result.title = 'Tip: drag this button to the bookmark bar';
     return result;
   }
@@ -144,7 +144,7 @@
       var s = document.createElement('script');
       s.src = bookmarklets_js;
       void(document.getElementsByTagName('head')[0].appendChild(s));
-	};
+    };
     return makeBookmarklet('Compile', javascript, javascriptFunction);
   }
 

--- a/dev/codeserver/java/com/google/gwt/dev/codeserver/dev_mode_on.js
+++ b/dev/codeserver/java/com/google/gwt/dev/codeserver/dev_mode_on.js
@@ -130,13 +130,14 @@
 
   function makeCompileBookmarklet(codeserver_url, module_name) {
     var bookmarklets_js = codeserver_url + 'dev_mode_on.js';
-    var javascript = '{ window.__gwt_bookmarklet_params = {'
+	var javascript = '{ window.__gwt_bookmarklet_params = {'
         + 'server_url:\'' + codeserver_url + '\','
         + 'module_name:\'' + module_name + '\'};'
         + ' var s = document.createElement(\'script\');'
         + ' s.src = \'' + bookmarklets_js + '\';'
         + ' void(document.getElementsByTagName(\'head\')[0].appendChild(s));}';
-    var javascriptFunction = function() { 
+    var javascriptFunction = function(e) {
+      e.preventDefault(); // avoid CSP warning
       window.__gwt_bookmarklet_params = {
         server_url: codeserver_url,
         module_name: module_name


### PR DESCRIPTION
This PR converts the inline javascript call (within dev_mode_on.js in SDM) to a javascript function, to allow CSP (Content Security Policy) to avoid "unsafe-inline".

Fixes #9951