### PR TITLE
Make rpc serialization chunk size configurable

### DIFF
--- a/user/src/com/google/gwt/user/server/rpc/impl/ServerSerializationStreamWriter.java
+++ b/user/src/com/google/gwt/user/server/rpc/impl/ServerSerializationStreamWriter.java
@@ -48,11 +48,11 @@ public final class ServerSerializationStreamWriter extends
    * array literals.
    */
   public static class LengthConstrainedArray {
-    public static final int MAXIMUM_ARRAY_LENGTH = 1 << 15;
     private static final String POSTLUDE = "])";
     private static final String PRELUDE = "].concat([";
 
     private final StringBuffer buffer;
+    private final int maximumArrayLength = Integer.getInteger("gwt.rpc.maxPayloadChunkSize", 1 << 15);
     private int count = 0;
     private boolean needsComma = false;
     private int total = 0;
@@ -68,8 +68,8 @@ public final class ServerSerializationStreamWriter extends
 
     public void addToken(CharSequence token) {
       total++;
-      if (count++ == MAXIMUM_ARRAY_LENGTH) {
-        if (total == MAXIMUM_ARRAY_LENGTH + 1) {
+      if (count++ == maximumArrayLength) {
+        if (total == maximumArrayLength + 1) {
           buffer.append(PRELUDE);
           javascript = true;
         } else {
@@ -106,7 +106,7 @@ public final class ServerSerializationStreamWriter extends
 
     @Override
     public String toString() {
-      if (total > MAXIMUM_ARRAY_LENGTH) {
+      if (total > maximumArrayLength) {
         return "[" + buffer.toString() + POSTLUDE;
       } else {
         return "[" + buffer.toString() + "]";


### PR DESCRIPTION
Make the RPC chunk size configurable through a system property `gwt.rpc.maxPayloadChunkSize`. This allows implementors to circumvent the RPC protocol version to fallback to version 7 on large payloads. Which in the current client implementation uses unsafe javascript eval, preventing proper operation on sites with CSP's restricting `unsafe-eval`.

Fixes https://github.com/gwtproject/gwt/issues/9578