### PR TITLE
Use wheel event type instead of deprected mousewheel

### DIFF
--- a/user/src/com/google/gwt/dom/client/BrowserEvents.java
+++ b/user/src/com/google/gwt/dom/client/BrowserEvents.java
@@ -53,7 +53,9 @@ public class BrowserEvents {
   public static final String MOUSEOUT = "mouseout";
   public static final String MOUSEOVER = "mouseover";
   public static final String MOUSEUP = "mouseup";
+  @Deprecated
   public static final String MOUSEWHEEL = "mousewheel";
+  public static final String WHEEL = "wheel";
   public static final String PROGRESS = "progress";
   public static final String SCROLL = "scroll";
   public static final String TOUCHCANCEL = "touchcancel";

--- a/user/src/com/google/gwt/dom/client/DOMImpl.java
+++ b/user/src/com/google/gwt/dom/client/DOMImpl.java
@@ -139,7 +139,7 @@ abstract class DOMImpl {
   }-*/;
 
   public int eventGetMouseWheelVelocityY(NativeEvent evt) {
-    return evt.getDeltaY() == 0.0 ? 0 : (evt.getDeltaY() > 0 ? 1 : -1);
+    return (int) Math.signum(evt.getDeltaY());
   }
 
   public abstract EventTarget eventGetRelatedTarget(NativeEvent nativeEvent);

--- a/user/src/com/google/gwt/dom/client/DOMImpl.java
+++ b/user/src/com/google/gwt/dom/client/DOMImpl.java
@@ -138,9 +138,9 @@ abstract class DOMImpl {
     return !!evt.metaKey;
   }-*/;
 
-  public native int eventGetMouseWheelVelocityY(NativeEvent evt) /*-{
-    return Math.sign(evt.deltaY);
-  }-*/;
+  public int eventGetMouseWheelVelocityY(NativeEvent evt) {
+    return evt.getDeltaY() == 0.0 ? 0 : (evt.getDeltaY() > 0 ? 1 : -1);
+  }
 
   public abstract EventTarget eventGetRelatedTarget(NativeEvent nativeEvent);
 

--- a/user/src/com/google/gwt/dom/client/DOMImpl.java
+++ b/user/src/com/google/gwt/dom/client/DOMImpl.java
@@ -138,7 +138,9 @@ abstract class DOMImpl {
     return !!evt.metaKey;
   }-*/;
 
-  public abstract int eventGetMouseWheelVelocityY(NativeEvent evt);
+  public native int eventGetMouseWheelVelocityY(NativeEvent evt) /*-{
+    return Math.sign(evt.deltaY);
+  }-*/;
 
   public abstract EventTarget eventGetRelatedTarget(NativeEvent nativeEvent);
 

--- a/user/src/com/google/gwt/dom/client/DOMImplMozilla.java
+++ b/user/src/com/google/gwt/dom/client/DOMImplMozilla.java
@@ -125,11 +125,6 @@ class DOMImplMozilla extends DOMImplStandard {
   }
 
   @Override
-  public native int eventGetMouseWheelVelocityY(NativeEvent evt) /*-{
-    return evt.detail || 0;
-  }-*/;
-
-  @Override
   public native EventTarget eventGetRelatedTarget(NativeEvent evt) /*-{
     // Hack around Mozilla bug 497780 (relatedTarget sometimes returns XUL
     // elements). Trying to access relatedTarget.nodeName will throw an

--- a/user/src/com/google/gwt/dom/client/DOMImplStandardBase.java
+++ b/user/src/com/google/gwt/dom/client/DOMImplStandardBase.java
@@ -205,11 +205,6 @@ class DOMImplStandardBase extends DOMImplStandard {
   }-*/;
 
   @Override
-  public native int eventGetMouseWheelVelocityY(NativeEvent evt) /*-{
-    return Math.round(-evt.wheelDelta / 40) || 0;
-  }-*/;
-
-  @Override
   public int getAbsoluteLeft(Element elem) {
     ClientRect rect = getBoundingClientRect(elem);
     double left = rect != null ? rect.getSubPixelLeft()

--- a/user/src/com/google/gwt/dom/client/NativeEvent.java
+++ b/user/src/com/google/gwt/dom/client/NativeEvent.java
@@ -158,22 +158,39 @@ public class NativeEvent extends JavaScriptObject {
   }
 
   /**
-   * Gets the velocity of the mouse wheel associated with the event along the Y
+   * Gets the sign of the velocity of the mouse wheel associated with the event along the Y
    * axis.
    * <p>
-   * The velocity of the event is an artificial measurement for relative
-   * comparisons of wheel activity. It is affected by some non-browser factors,
-   * including choice of input hardware and mouse acceleration settings. The
-   * sign of the velocity measurement agrees with the screen coordinate system;
-   * negative values are towards the origin and positive values are away from
-   * the origin. Standard scrolling speed is approximately ten units per event.
+   * In previous versions of GWT this returne the velocity normalized to a small integer.
+   * Unfortunately for some devices such normalization rounded non-trivial velocities to 0.
+   * To maintain compatibility with that implementation, this still returns an integer,
+   * but using the sign function
    * </p>
    * 
-   * @return The velocity of the mouse wheel.
+   * @return The velocity of the mouse wheel: -1 for scrolling up, 1 for scrolling down,
+   *         0 if not scrolled at all
+   * @deprecated use getDeltaY() instead
    */
+  @Deprecated
   public final int getMouseWheelVelocityY() {
     return DOMImpl.impl.eventGetMouseWheelVelocityY(this);
   }
+
+  /**
+   * Gets the native velocity of the mouse wheel in Y direction.
+   * @return The velocity of the mouse wheel
+   */
+  public final native double getDeltaY() /*-{
+    return this.deltaY;
+  }-*/;
+
+  /**
+   * Gets the native velocity of the mouse wheel in X direction.
+   * @return The velocity of the mouse wheel
+   */
+  public final native double getDeltaX() /*-{
+    return this.deltaX;
+  }-*/;
 
   /**
    * Gets the related target for this event.

--- a/user/src/com/google/gwt/dom/client/NativeEvent.java
+++ b/user/src/com/google/gwt/dom/client/NativeEvent.java
@@ -161,7 +161,7 @@ public class NativeEvent extends JavaScriptObject {
    * Gets the sign of the velocity of the mouse wheel associated with the event along the Y
    * axis.
    * <p>
-   * In previous versions of GWT this returne the velocity normalized to a small integer.
+   * In previous versions of GWT this returned the velocity normalized to a small integer.
    * Unfortunately for some devices such normalization rounded non-trivial velocities to 0.
    * To maintain compatibility with that implementation, this still returns an integer,
    * but using the sign function

--- a/user/src/com/google/gwt/event/dom/client/MouseWheelEvent.java
+++ b/user/src/com/google/gwt/event/dom/client/MouseWheelEvent.java
@@ -27,16 +27,7 @@ public class MouseWheelEvent extends MouseEvent<MouseWheelHandler> {
    * this event.
    */
   private static final Type<MouseWheelHandler> TYPE = new Type<MouseWheelHandler>(
-      BrowserEvents.MOUSEWHEEL, new MouseWheelEvent());
-
-  static {
-    /**
-     * Hidden type used to ensure DOMMouseScroll gets registered in the type map.
-     * This is the special name used on Mozilla browsers for what everyone else
-     * calls 'mousewheel'.
-     */
-    new Type<MouseWheelHandler>("DOMMouseScroll", new MouseWheelEvent());
-  }
+      BrowserEvents.WHEEL, new MouseWheelEvent());
 
   /**
    * Gets the event type associated with mouse wheel events.
@@ -61,16 +52,28 @@ public class MouseWheelEvent extends MouseEvent<MouseWheelHandler> {
   }
 
   /**
-   * Get the change in the mouse wheel position along the Y-axis; negative if
-   * the mouse wheel is moving north (toward the top of the screen) or positive
+   * Get the sign of the change in the mouse wheel position along the Y-axis; -1 if
+   * the mouse wheel is moving north (toward the top of the screen) or 1
    * if the mouse wheel is moving south (toward the bottom of the screen).
    * 
-   * Note that delta values are not normalized across browsers or OSes.
-   * 
-   * @return the delta of the mouse wheel along the y axis
+   * @return the sign of the delta of the mouse wheel along the y axis
+   * @deprecated use getNativeDeltaY() instead
    */
+  @Deprecated
   public int getDeltaY() {
     return getNativeEvent().getMouseWheelVelocityY();
+  }
+
+  /**
+   * Get the change in the mouse wheel position along the Y-axis; -1 if
+   * the mouse wheel is moving north (toward the top of the screen) or 1
+   * if the mouse wheel is moving south (toward the bottom of the screen).
+   * Note that the return values are not normalized for browsers and OSs.
+   *
+   * @return the sign of the delta of the mouse wheel along the y axis
+   */
+  public double getNativeDeltaY() {
+    return getNativeEvent().getDeltaY();
   }
 
   /**
@@ -81,7 +84,7 @@ public class MouseWheelEvent extends MouseEvent<MouseWheelHandler> {
    * @return true if the velocity is directed toward the top of the screen
    */
   public boolean isNorth() {
-    return getDeltaY() < 0;
+    return getNativeDeltaY() < 0;
   }
 
   /**
@@ -92,7 +95,7 @@ public class MouseWheelEvent extends MouseEvent<MouseWheelHandler> {
    * @return true if the velocity is directed toward the bottom of the screen
    */
   public boolean isSouth() {
-    return getDeltaY() > 0;
+    return getNativeDeltaY() > 0;
   }
 
   @Override

--- a/user/src/com/google/gwt/user/client/impl/DOMImpl.java
+++ b/user/src/com/google/gwt/user/client/impl/DOMImpl.java
@@ -102,7 +102,7 @@ public abstract class DOMImpl {
     case "scroll": return 0x04000;
     case "error": return 0x10000;
     case "mousewheel": return 0x20000;
-    case "DOMMouseScroll": return 0x20000;
+    case "wheel": return 0x20000;
     case "contextmenu": return 0x40000;
     case "paste": return 0x80000;
     case "touchstart": return 0x100000;

--- a/user/src/com/google/gwt/user/client/impl/DOMImplMozilla.java
+++ b/user/src/com/google/gwt/user/client/impl/DOMImplMozilla.java
@@ -15,35 +15,10 @@
  */
 package com.google.gwt.user.client.impl;
 
-import com.google.gwt.dom.client.Element;
-
 /**
  * Mozilla implementation of StandardBrowser.
  */
 class DOMImplMozilla extends DOMImplStandard {
-
-  static {
-    addMozillaCaptureEventDispatchers();
-  }
-
-  @SuppressWarnings("deprecation")
-  private static native void addMozillaCaptureEventDispatchers() /*-{
-    @com.google.gwt.user.client.impl.DOMImplStandard::captureEventDispatchers['DOMMouseScroll'] =
-        @com.google.gwt.user.client.impl.DOMImplStandard::dispatchCapturedMouseEvent(*);
-  }-*/;
-
-  @Override
-  public void sinkEvents(Element elem, int bits) {
-    super.sinkEvents(elem, bits);
-    sinkEventsMozilla(elem, bits);
-  }
-
-  @SuppressWarnings("deprecation")
-  public native void sinkEventsMozilla(Element elem, int bits) /*-{
-    if (bits & 0x20000) {
-      elem.addEventListener('DOMMouseScroll', @com.google.gwt.user.client.impl.DOMImplStandard::dispatchEvent, false);
-    }
-  }-*/;
 
   @Override
   protected void initEventSystem() {

--- a/user/src/com/google/gwt/user/client/impl/DOMImplStandard.java
+++ b/user/src/com/google/gwt/user/client/impl/DOMImplStandard.java
@@ -292,7 +292,7 @@ public abstract class DOMImplStandard extends DOMImpl {
         @com.google.gwt.user.client.impl.DOMImplStandard::dispatchUnhandledEvent : null;
     if (chMask & 0x10000) elem.onerror       = (bits & 0x10000) ?
         @com.google.gwt.user.client.impl.DOMImplStandard::dispatchEvent : null;
-    if (chMask & 0x20000) elem.onmousewheel  = (bits & 0x20000) ?
+    if (chMask & 0x20000) elem.onwheel       = (bits & 0x20000) ?
         @com.google.gwt.user.client.impl.DOMImplStandard::dispatchEvent : null;
     if (chMask & 0x40000) elem.oncontextmenu = (bits & 0x40000) ?
         @com.google.gwt.user.client.impl.DOMImplStandard::dispatchEvent : null;


### PR DESCRIPTION
Fixes #8009
Fixes the velocity detection problem mentioned in #9671 and  #8806 

This is a bit more direct than https://gwt-review.googlesource.com/c/gwt/+/3171 as it removes the deprecated events where possible.

Teste in FF and Chrome using a mouse.