### PR TITLE
String method emulation for Java 11, align Character.isWhitespace with Java 11

### DIFF
--- a/.idea/codeStyles/codeStyleConfig.xml
+++ b/.idea/codeStyles/codeStyleConfig.xml
@@ -1,0 +1,5 @@
+<component name="ProjectCodeStyleConfiguration">
+  <state>
+    <option name="PREFERRED_PROJECT_CODE_STYLE" value="Default" />
+  </state>
+</component>

--- a/.idea/codeStyles/codeStyleConfig.xml
+++ b/.idea/codeStyles/codeStyleConfig.xml
@@ -1,5 +1,0 @@
-<component name="ProjectCodeStyleConfiguration">
-  <state>
-    <option name="PREFERRED_PROJECT_CODE_STYLE" value="Default" />
-  </state>
-</component>

--- a/user/super/com/google/gwt/emul/java/lang/Character.java
+++ b/user/super/com/google/gwt/emul/java/lang/Character.java
@@ -322,7 +322,7 @@ public final class Character implements Comparable<Character>, Serializable {
       // the Java definition includes separators.
       whitespaceRegex =
           new NativeRegExp(
-              "[\\u1680\\u180E\\u2000-\\u2006\\u2008-\\u200A\\u2028\\u2029\\u205F\\u3000\\uFEFF]"
+              "[\\u1680\\u2000-\\u2006\\u2008-\\u200A\\u2028\\u2029\\u205F\\u3000]"
                   + "|[\\t-\\r ]"
                   + "|[\\x1C-\\x1F]");
     }

--- a/user/super/com/google/gwt/emul/java/lang/String.java
+++ b/user/super/com/google/gwt/emul/java/lang/String.java
@@ -16,6 +16,7 @@
 
 package java.lang;
 
+import static javaemul.internal.InternalPreconditions.checkArgument;
 import static javaemul.internal.InternalPreconditions.checkCriticalStringBounds;
 import static javaemul.internal.InternalPreconditions.checkNotNull;
 import static javaemul.internal.InternalPreconditions.checkStringBounds;
@@ -782,13 +783,11 @@ public final class String implements Comparable<String>, CharSequence,
   }
 
   public Stream<String> lines() {
-    return StreamSupport.stream(new LinesSpliterator(this), false);
+    return StreamSupport.stream(new LinesSpliterator(), false);
   }
 
   public String repeat(int count) {
-    if (count < 0) {
-      throw new IllegalArgumentException("count is negative: " + count);
-    }
+    checkArgument(count >= 0, "count is negative: " + count);
     return asNativeString().repeat(count);
   }
 
@@ -812,15 +811,13 @@ public final class String implements Comparable<String>, CharSequence,
     return length;
   }
 
-  private static class LinesSpliterator extends Spliterators.AbstractSpliterator<String> {
+  private class LinesSpliterator extends Spliterators.AbstractSpliterator<String> {
     private int nextIndex = 0;
-    private String content;
-    int rPosition = -2;
-    int nPosition = -2;
+    private int rPosition = -1;
+    private int nPosition = -1;
 
-    private LinesSpliterator(String content) {
+    private LinesSpliterator() {
       super(Long.MAX_VALUE, Spliterator.IMMUTABLE | Spliterator.ORDERED);
-      this.content = content;
     }
 
     @Override
@@ -832,17 +829,17 @@ public final class String implements Comparable<String>, CharSequence,
         nPosition = cappedIndexOf('\n');
       }
       int lineEnd = Math.min(nPosition, rPosition);
-      action.accept(content.substring(nextIndex, lineEnd));
+      action.accept(substring(nextIndex, lineEnd));
       nextIndex = lineEnd + 1;
       if (nPosition == rPosition + 1) {
         nextIndex++;
       }
-      return nextIndex < content.length();
+      return nextIndex < length();
     }
 
     private int cappedIndexOf(char c) {
-      int index = content.indexOf(c);
-      return index == -1 ? content.length() : index;
+      int index = indexOf(c);
+      return index == -1 ? length() : index;
     }
   }
 

--- a/user/super/com/google/gwt/emul/java/lang/String.java
+++ b/user/super/com/google/gwt/emul/java/lang/String.java
@@ -822,6 +822,9 @@ public final class String implements Comparable<String>, CharSequence,
 
     @Override
     public boolean tryAdvance(Consumer<? super String> action) {
+      if (isEmpty()) {
+        return false;
+      }
       if (rPosition < nextIndex) {
         rPosition = cappedIndexOf('\r');
       }
@@ -838,7 +841,7 @@ public final class String implements Comparable<String>, CharSequence,
     }
 
     private int cappedIndexOf(char c) {
-      int index = indexOf(c);
+      int index = indexOf(c, nextIndex);
       return index == -1 ? length() : index;
     }
   }

--- a/user/test/com/google/gwt/emultest/EmulJava11Suite.java
+++ b/user/test/com/google/gwt/emultest/EmulJava11Suite.java
@@ -15,6 +15,7 @@
  */
 package com.google.gwt.emultest;
 
+import com.google.gwt.emultest.java11.lang.StringTest;
 import com.google.gwt.emultest.java11.util.OptionalDoubleTest;
 import com.google.gwt.emultest.java11.util.OptionalIntTest;
 import com.google.gwt.emultest.java11.util.OptionalLongTest;
@@ -32,6 +33,7 @@ import org.junit.runners.Suite;
         OptionalLongTest.class,
         OptionalTest.class,
         PredicateTest.class,
+        StringTest.class,
 })
 public class EmulJava11Suite {
 }

--- a/user/test/com/google/gwt/emultest/java/lang/CharacterTest.java
+++ b/user/test/com/google/gwt/emultest/java/lang/CharacterTest.java
@@ -360,7 +360,8 @@ public class CharacterTest extends GWTTestCase {
     char[] nonBreakingSpaceSeparators = {
         '\u00A0', // NO-BREAK SPACE.
         '\u2007', // FIGURE SPACE.
-        '\u202F' // NARROW NO-BREAK SPACE.
+        '\u202F', // NARROW NO-BREAK SPACE.
+        '\uFFEF'  // ZERO WIDTH NO-BREAK SPACE.
     };
 
     char[] specialCases = {
@@ -379,7 +380,8 @@ public class CharacterTest extends GWTTestCase {
         'a', // LATIN SMALL LETTER A.
         'B', // LATIN CAPITAL LETTER B.
         '_', // LOW LINE.
-        '\u2500' // BOX DRAWINGS LIGHT HORIZONTAL.
+        '\u2500', // BOX DRAWINGS LIGHT HORIZONTAL.
+        '\u180E', // MONGOLIAN VOWEL SEPARATOR, was considered whitespace in Java 8.
     };
 
     int[] supplementaryCounterExamples = {

--- a/user/test/com/google/gwt/emultest/java/lang/StringTest.java
+++ b/user/test/com/google/gwt/emultest/java/lang/StringTest.java
@@ -895,6 +895,7 @@ public class StringTest extends GWTTestCase {
 
     // JavaScript would trim \u2029 and other unicode whitespace type characters; but Java wont
     trimRightAssertEquals("\u2029abc\u00a0","\u2029abc\u00a0");
+    trimRightAssertEquals("\uffefx\u180e", "\uffefx\u180e ");
   }
 
   public void testUpperCase() {

--- a/user/test/com/google/gwt/emultest/java11/lang/StringTest.java
+++ b/user/test/com/google/gwt/emultest/java11/lang/StringTest.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2023 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.gwt.emultest.java11.lang;
+
+import com.google.gwt.emultest.java.util.EmulTestBase;
+
+import java.util.Arrays;
+import java.util.stream.Collectors;
+
+/**
+ * Tests for java.lang.String Java 11 API emulation.
+ */
+public class StringTest extends EmulTestBase {
+    public void testIsBlank() {
+        assertTrue("".isBlank());
+        assertTrue("  ".isBlank());
+        assertFalse("x ".isBlank());
+        assertTrue("\u001c".isBlank());
+        assertFalse("\u00a0".isBlank());
+    }
+
+    public void testStrip() {
+        assertEquals("", "".strip());
+        assertEquals("", "  ".strip());
+        assertEquals("x", " x ".strip());
+        assertEquals("x", "\u001cx\u001c".strip());
+        assertEquals("\u00a0x\u00a0", "\u00a0x\u00a0 ".strip());
+    }
+
+    public void testStripLeading() {
+        assertEquals("", "".stripLeading());
+        assertEquals("", "  ".stripLeading());
+        assertEquals("x ", " x ".stripLeading());
+        assertEquals("x\u001c", "\u001cx\u001c".stripLeading());
+        assertEquals("\u00a0x\u00a0", "\u00a0x\u00a0".stripLeading());
+    }
+
+    public void testStripTrailing() {
+        assertEquals("", "".stripTrailing());
+        assertEquals("", "  ".stripTrailing());
+        assertEquals(" x", " x ".stripTrailing());
+        assertEquals("\u001cx", "\u001cx\u001c".stripTrailing());
+        assertEquals("\u00a0x\u00a0", "\u00a0x\u00a0 ".stripTrailing());
+    }
+
+    public void testRepeat() {
+        assertEquals("", "foo".repeat(0));
+        assertEquals("foo", "foo".repeat(1));
+        assertEquals("foofoofoo", "foo".repeat(3));
+        try {
+            String noFoo = "foo".repeat(-1);
+            throw new Error("Should fail with negative arg");
+        } catch (IllegalArgumentException ex) {
+            assertEquals("count is negative: -1", ex.getMessage());
+        }
+    }
+
+    public void testLines() {
+        assertEquals(Arrays.asList("a", "b", "c", "d"),
+                "a\rb\nc\r\nd".lines().collect(Collectors.toList()));
+        assertEquals(Arrays.asList("a"),
+                "a\n".lines().collect(Collectors.toList()));
+        assertEquals(Arrays.asList(),
+                "".lines().collect(Collectors.toList()));
+        assertEquals(Arrays.asList(""),
+                "\n".lines().collect(Collectors.toList()));
+    }
+}

--- a/user/test/com/google/gwt/emultest/java11/lang/StringTest.java
+++ b/user/test/com/google/gwt/emultest/java11/lang/StringTest.java
@@ -25,11 +25,11 @@ import java.util.stream.Collectors;
  */
 public class StringTest extends EmulTestBase {
   public void testIsBlank() {
-    assertTrue("".isBlank());
-    assertTrue("  ".isBlank());
-    assertFalse("x ".isBlank());
-    assertTrue("\u001c".isBlank());
-    assertFalse("\u00a0".isBlank());
+    assertTrue(hideFromCompiler("").isBlank());
+    assertTrue(hideFromCompiler("  ").isBlank());
+    assertFalse(hideFromCompiler("x ").isBlank());
+    assertTrue(hideFromCompiler("\u001c").isBlank());
+    assertFalse(hideFromCompiler("\u00a0").isBlank());
   }
 
   public void testStrip() {
@@ -58,23 +58,23 @@ public class StringTest extends EmulTestBase {
   }
 
   private void stripRightAsssertEquals(String expected, String arg) {
-    assertEquals(expected, arg.strip())
+    assertEquals(expected, hideFromCompiler(arg).strip());
   }
 
   private void stripRightLeadingAsssertEquals(String expected, String arg) {
-    assertEquals(expected, arg.stripLeading())
+    assertEquals(expected, hideFromCompiler(arg).stripLeading());
   }
 
   private void stripRightTrailingAsssertEquals(String expected, String arg) {
-    assertEquals(expected, arg.stripTrailing())
+    assertEquals(expected, hideFromCompiler(arg).stripTrailing());
   }
 
   public void testRepeat() {
-    assertEquals("", "foo".repeat(0));
-    assertEquals("foo", "foo".repeat(1));
-    assertEquals("foofoofoo", "foo".repeat(3));
+    assertEquals("", hideFromCompiler("foo").repeat(0));
+    assertEquals("foo", hideFromCompiler("foo").repeat(1));
+    assertEquals("foofoofoo", hideFromCompiler("foo").repeat(3));
     try {
-      String noFoo = "foo".repeat(-1);
+      String noFoo = hideFromCompiler("foo").repeat(-1);
       throw new Error("Should fail with negative arg");
     } catch (IllegalArgumentException ex) {
       assertEquals("count is negative: -1", ex.getMessage());
@@ -98,5 +98,13 @@ public class StringTest extends EmulTestBase {
         "\n\r\n".lines().collect(Collectors.toList()));
     assertEquals(Arrays.asList("", "", "c"),
         "\n\r\nc".lines().collect(Collectors.toList()));
+  }
+
+  private <T> T hideFromCompiler(T value) {
+    if (Math.random() < -1) {
+      // Can never happen, but fools the compiler enough not to optimize this call.
+      fail();
+    }
+    return value;
   }
 }

--- a/user/test/com/google/gwt/emultest/java11/lang/StringTest.java
+++ b/user/test/com/google/gwt/emultest/java11/lang/StringTest.java
@@ -33,27 +33,40 @@ public class StringTest extends EmulTestBase {
   }
 
   public void testStrip() {
-    assertEquals("", "".strip());
-    assertEquals("", "  ".strip());
-    assertEquals("x", " x ".strip());
-    assertEquals("x", "\u001cx\u001c".strip());
-    assertEquals("\u00a0x\u00a0", "\u00a0x\u00a0 ".strip());
+    stripRightAsssertEquals("", "");
+    stripRightAsssertEquals("", "  ");
+    stripRightAsssertEquals("x", " x ");
+    stripRightAsssertEquals("x", "\u001cx\u001c");
+    stripRightAsssertEquals("\u00a0x\u00a0", "\u00a0x\u00a0 ");
+    stripRightAsssertEquals("\uffefx\u180e", "\uffefx\u180e ");
   }
 
   public void testStripLeading() {
-    assertEquals("", "".stripLeading());
-    assertEquals("", "  ".stripLeading());
-    assertEquals("x ", " x ".stripLeading());
-    assertEquals("x\u001c", "\u001cx\u001c".stripLeading());
-    assertEquals("\u00a0x\u00a0", "\u00a0x\u00a0".stripLeading());
+    stripRightLeadingAsssertEquals("", "");
+    stripRightLeadingAsssertEquals("", "  ");
+    stripRightLeadingAsssertEquals("x ", " x ");
+    stripRightLeadingAsssertEquals("x\u001c", "\u001cx\u001c");
+    stripRightLeadingAsssertEquals("\u00a0x\u00a0", "\u00a0x\u00a0");
   }
 
   public void testStripTrailing() {
-    assertEquals("", "".stripTrailing());
-    assertEquals("", "  ".stripTrailing());
-    assertEquals(" x", " x ".stripTrailing());
-    assertEquals("\u001cx", "\u001cx\u001c".stripTrailing());
-    assertEquals("\u00a0x\u00a0", "\u00a0x\u00a0 ".stripTrailing());
+    stripRightTrailingAsssertEquals("", "");
+    stripRightTrailingAsssertEquals("", "  ");
+    stripRightTrailingAsssertEquals(" x", " x ");
+    stripRightTrailingAsssertEquals("\u001cx", "\u001cx\u001c");
+    stripRightTrailingAsssertEquals("\u00a0x\u00a0", "\u00a0x\u00a0 ");
+  }
+
+  private void stripRightAsssertEquals(String expected, String arg) {
+    assertEquals(expected, arg.strip())
+  }
+
+  private void stripRightLeadingAsssertEquals(String expected, String arg) {
+    assertEquals(expected, arg.stripLeading())
+  }
+
+  private void stripRightTrailingAsssertEquals(String expected, String arg) {
+    assertEquals(expected, arg.stripTrailing())
   }
 
   public void testRepeat() {

--- a/user/test/com/google/gwt/emultest/java11/lang/StringTest.java
+++ b/user/test/com/google/gwt/emultest/java11/lang/StringTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Google Inc.
+ * Copyright 2024 GWT Project Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -24,58 +24,66 @@ import java.util.stream.Collectors;
  * Tests for java.lang.String Java 11 API emulation.
  */
 public class StringTest extends EmulTestBase {
-    public void testIsBlank() {
-        assertTrue("".isBlank());
-        assertTrue("  ".isBlank());
-        assertFalse("x ".isBlank());
-        assertTrue("\u001c".isBlank());
-        assertFalse("\u00a0".isBlank());
-    }
+  public void testIsBlank() {
+    assertTrue("".isBlank());
+    assertTrue("  ".isBlank());
+    assertFalse("x ".isBlank());
+    assertTrue("\u001c".isBlank());
+    assertFalse("\u00a0".isBlank());
+  }
 
-    public void testStrip() {
-        assertEquals("", "".strip());
-        assertEquals("", "  ".strip());
-        assertEquals("x", " x ".strip());
-        assertEquals("x", "\u001cx\u001c".strip());
-        assertEquals("\u00a0x\u00a0", "\u00a0x\u00a0 ".strip());
-    }
+  public void testStrip() {
+    assertEquals("", "".strip());
+    assertEquals("", "  ".strip());
+    assertEquals("x", " x ".strip());
+    assertEquals("x", "\u001cx\u001c".strip());
+    assertEquals("\u00a0x\u00a0", "\u00a0x\u00a0 ".strip());
+  }
 
-    public void testStripLeading() {
-        assertEquals("", "".stripLeading());
-        assertEquals("", "  ".stripLeading());
-        assertEquals("x ", " x ".stripLeading());
-        assertEquals("x\u001c", "\u001cx\u001c".stripLeading());
-        assertEquals("\u00a0x\u00a0", "\u00a0x\u00a0".stripLeading());
-    }
+  public void testStripLeading() {
+    assertEquals("", "".stripLeading());
+    assertEquals("", "  ".stripLeading());
+    assertEquals("x ", " x ".stripLeading());
+    assertEquals("x\u001c", "\u001cx\u001c".stripLeading());
+    assertEquals("\u00a0x\u00a0", "\u00a0x\u00a0".stripLeading());
+  }
 
-    public void testStripTrailing() {
-        assertEquals("", "".stripTrailing());
-        assertEquals("", "  ".stripTrailing());
-        assertEquals(" x", " x ".stripTrailing());
-        assertEquals("\u001cx", "\u001cx\u001c".stripTrailing());
-        assertEquals("\u00a0x\u00a0", "\u00a0x\u00a0 ".stripTrailing());
-    }
+  public void testStripTrailing() {
+    assertEquals("", "".stripTrailing());
+    assertEquals("", "  ".stripTrailing());
+    assertEquals(" x", " x ".stripTrailing());
+    assertEquals("\u001cx", "\u001cx\u001c".stripTrailing());
+    assertEquals("\u00a0x\u00a0", "\u00a0x\u00a0 ".stripTrailing());
+  }
 
-    public void testRepeat() {
-        assertEquals("", "foo".repeat(0));
-        assertEquals("foo", "foo".repeat(1));
-        assertEquals("foofoofoo", "foo".repeat(3));
-        try {
-            String noFoo = "foo".repeat(-1);
-            throw new Error("Should fail with negative arg");
-        } catch (IllegalArgumentException ex) {
-            assertEquals("count is negative: -1", ex.getMessage());
-        }
+  public void testRepeat() {
+    assertEquals("", "foo".repeat(0));
+    assertEquals("foo", "foo".repeat(1));
+    assertEquals("foofoofoo", "foo".repeat(3));
+    try {
+      String noFoo = "foo".repeat(-1);
+      throw new Error("Should fail with negative arg");
+    } catch (IllegalArgumentException ex) {
+      assertEquals("count is negative: -1", ex.getMessage());
     }
+  }
 
-    public void testLines() {
-        assertEquals(Arrays.asList("a", "b", "c", "d"),
-                "a\rb\nc\r\nd".lines().collect(Collectors.toList()));
-        assertEquals(Arrays.asList("a"),
-                "a\n".lines().collect(Collectors.toList()));
-        assertEquals(Arrays.asList(),
-                "".lines().collect(Collectors.toList()));
-        assertEquals(Arrays.asList(""),
-                "\n".lines().collect(Collectors.toList()));
-    }
+  public void testLines() {
+    assertEquals(Arrays.asList("a", "b", "c", "d"),
+        "a\rb\nc\r\nd".lines().collect(Collectors.toList()));
+    assertEquals(Arrays.asList("a"),
+        "a\n".lines().collect(Collectors.toList()));
+    assertEquals(Arrays.asList("a"),
+        "a\r\n".lines().collect(Collectors.toList()));
+    assertEquals(Arrays.asList(),
+        "".lines().collect(Collectors.toList()));
+    assertEquals(Arrays.asList(""),
+        "\n".lines().collect(Collectors.toList()));
+    assertEquals(Arrays.asList(""),
+        "\r\n".lines().collect(Collectors.toList()));
+    assertEquals(Arrays.asList("", ""),
+        "\n\r\n".lines().collect(Collectors.toList()));
+    assertEquals(Arrays.asList("", "", "c"),
+        "\n\r\nc".lines().collect(Collectors.toList()));
+  }
 }


### PR DESCRIPTION
Adds emulation for java.lang.String methods added in Java 11, partially completing #9831:
* isBlank
* lines
* repeat
* strip
* stripLeading
* stripTrailing

Fixes #9973
Partial #9831