### PR TITLE
Update API reference check to validate that GWT 2.11 APIs are preserved

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -31,9 +31,9 @@
   </macrodef>
 
   <property name="gwt.apicheck.config"
-            location="tools/api-checker/config/gwt210_211userapi.conf"/>
+            location="tools/api-checker/config/gwt211_212userapi.conf"/>
   <property name="gwt.apicheck.referencelibs"
-            value="${gwt.tools}/api-checker-reference/2.10.0/gwt-dev-modified.jar:${gwt.tools}/api-checker-reference/2.10.0/gwt-user-modified.jar"/>
+            value="${gwt.tools}/api-checker-reference/2.11.0/gwt-dev-modified.jar:${gwt.tools}/api-checker-reference/2.11.0/gwt-user-modified.jar"/>
 
   <target name="buildonly"
           description="[action] Minimal one-platform devel build, without distro packaging">

--- a/tools/api-checker/config/gwt211_212userapi.conf
+++ b/tools/api-checker/config/gwt211_212userapi.conf
@@ -1,0 +1,152 @@
+#existing API
+
+# dirRoot_old is missing because refJars are being supplied
+name_old gwt211userApi
+#sourceFiles is specified as colon-separated list of files
+sourceFiles_old com/google/gwt\
+:com/google/web\
+:javax/validation\
+
+#excludedFiles is specified as colon-separated ant patterns
+# The entries for javax and org exclude the validation stuff.
+# Bug: http://code.google.com/p/google-web-toolkit/issues/detail?id=5566
+excludedFiles_old **/linker/**\
+:**/rebind/**\
+:**/server/**\
+:**/tools/**\
+:**/vm/**\
+:com/google/gwt/core/client/impl/JavaScriptExceptionBase.java\
+:com/google/gwt/core/client/impl/WeakMapping.java\
+:com/google/gwt/core/shared/impl/StringCase.java\
+:com/google/gwt/core/shared/impl/ThrowableTypeResolver.java\
+:com/google/gwt/core/ext/**\
+:com/google/gwt/dev/*.java\
+:com/google/gwt/dev/asm/**\
+:com/google/gwt/dev/cfg/**\
+:com/google/gwt/dev/codeserver/**\
+:com/google/gwt/dev/common/**\
+:com/google/gwt/dev/generator/**\
+:com/google/gwt/dev/javac/**\
+:com/google/gwt/dev/jdt/**\
+:com/google/gwt/dev/jjs/*.java\
+:com/google/gwt/dev/jjs/ast/**\
+:com/google/gwt/dev/jjs/impl/**\
+:com/google/gwt/dev/js/**\
+:com/google/gwt/dev/json/**\
+:com/google/gwt/dev/resource/**\
+:com/google/gwt/dev/shell/**\
+:com/google/gwt/dev/ui/**\
+:com/google/gwt/dev/url/**\
+:com/google/gwt/dev/util/**\
+:com/google/gwt/i18n/**/impl/cldr/**\
+:com/google/gwt/junit/*.java\
+:com/google/gwt/junit/client/GWTTestCase.java\
+:com/google/gwt/junit/client/impl/GWTRunner.java\
+:com/google/gwt/junit/client/impl/GWTTestAccessor.java\
+:com/google/gwt/junit/remote/**\
+:com/google/gwt/regexp/shared/**\
+:com/google/gwt/resources/css/**\
+:com/google/gwt/resources/gss/**\
+:com/google/gwt/resources/converter/**\
+:com/google/gwt/resources/ext/**\
+:com/google/gwt/resources/rg/**\
+:com/google/gwt/safecss/shared/SafeStylesHostedModeUtils.java\
+:com/google/gwt/safehtml/shared/SafeHtmlHostedModeUtils.java\
+:com/google/gwt/safehtml/shared/SafeUriHostedModeUtils.java\
+:com/google/gwt/soyc/**\
+:com/google/gwt/typedarrays/super/com/google/gwt/typedarrays/shared/TypedArraysFactory.java\
+:com/google/gwt/user/client/rpc/core/**\
+:com/google/gwt/user/client/rpc/impl/**\
+:com/google/gwt/uibinder/attributeparsers/**\
+:com/google/gwt/uibinder/client/impl/**\
+:com/google/gwt/uibinder/elementparsers/**\
+:com/google/gwt/uibinder/testing/**\
+:com/google/gwt/util/**\
+:com/google/gwt/validation/**\
+:com/google/web/bindery/autobean/shared/ValueCodexHelper.java\
+:com/google/web/bindery/autobean/**/impl/**\
+:com/google/web/bindery/requestfactory/apt/**\
+:com/google/web/bindery/requestfactory/gwt/client/RequestBatcher.java\
+:com/google/web/bindery/requestfactory/gwt/client/impl/**\
+:com/google/web/bindery/requestfactory/server/impl/**\
+:com/google/web/bindery/requestfactory/shared/impl/**\
+:com/google/web/bindery/requestfactory/vm/**\
+:javax/**\
+:org/**\
+
+##############################################
+#new Api
+
+dirRoot_new ./
+name_new gwt28userApi
+#sourceFiles is specified as colon-separated list of files
+sourceFiles_new dev/core/super\
+:user/src\
+:user/super\
+
+#excludedFiles is specified as colon-separated ant patterns
+# The entries for javax and org exclude the validation stuff.
+# Bug: http://code.google.com/p/google-web-toolkit/issues/detail?id=5566
+excludedFiles_new **/linker/**\
+:**/rebind/**\
+:**/server/**\
+:**/tools/**\
+:**/vm/**\
+:user/src/com/google/gwt/core/client/impl/JavaScriptExceptionBase.java\
+:user/src/com/google/gwt/core/client/impl/WeakMapping.java\
+:user/src/com/google/gwt/core/shared/impl/ThrowableTypeResolver.java\
+:user/src/com/google/gwt/i18n/**/impl/cldr/**\
+:user/src/com/google/gwt/junit/*.java\
+:user/src/com/google/gwt/junit/client/GWTTestCase.java\
+:user/src/com/google/gwt/junit/client/impl/GWTRunner.java\
+:user/src/com/google/gwt/junit/client/impl/GWTTestAccessor.java\
+:user/src/com/google/gwt/regexp/shared/**\
+:user/src/com/google/gwt/resources/css/**\
+:user/src/com/google/gwt/resources/gss/**\
+:user/src/com/google/gwt/resources/converter/**\
+:user/src/com/google/gwt/resources/ext/**\
+:user/src/com/google/gwt/resources/rg/**\
+:user/src/com/google/gwt/safecss/shared/SafeStylesHostedModeUtils.java\
+:user/src/com/google/gwt/safehtml/shared/SafeHtmlHostedModeUtils.java\
+:user/src/com/google/gwt/safehtml/shared/SafeUriHostedModeUtils.java\
+:user/src/com/google/gwt/user/client/rpc/core/**\
+:user/src/com/google/gwt/user/client/rpc/impl/**\
+:user/src/com/google/gwt/uibinder/attributeparsers/**\
+:user/src/com/google/gwt/uibinder/client/impl/**\
+:user/src/com/google/gwt/uibinder/elementparsers/**\
+:user/src/com/google/gwt/uibinder/testing/**\
+:user/src/com/google/gwt/util/**\
+:user/src/com/google/gwt/validation/**\
+:user/src/com/google/web/bindery/autobean/shared/ValueCodexHelper.java\
+:user/src/com/google/web/bindery/autobean/**/impl/**\
+:user/src/com/google/web/bindery/requestfactory/apt/**\
+:user/src/com/google/web/bindery/requestfactory/gwt/client/RequestBatcher.java\
+:user/src/com/google/web/bindery/requestfactory/gwt/client/impl/**\
+:user/src/com/google/web/bindery/requestfactory/server/impl/**\
+:user/src/com/google/web/bindery/requestfactory/shared/impl/**\
+:user/src/com/google/web/bindery/requestfactory/vm/**\
+:user/src/javax/**\
+:user/src/org/**\
+:user/super/com/google/gwt/typedarrays/super/com/google/gwt/typedarrays/shared/TypedArraysFactory.java\
+
+##############################################
+#excluded packages colon separated list
+excludedPackages com.google.gwt.core.client.impl\
+:com.google.gwt.core.shared.impl\
+:com.google.gwt.core.client.js.impl\
+:com.google.gwt.editor.client.impl\
+:com.google.gwt.i18n.client.impl\
+:com.google.gwt.junit.client.impl\
+:com.google.gwt.lang\
+:com.google.gwt.logging.impl\
+:com.google.gwt.resources.client.impl\
+:com.google.gwt.rpc.client.impl\
+:com.google.gwt.user.client.impl\
+:com.google.gwt.user.client.ui.impl\
+:com.google.gwt.xml.client.impl\
+:javaemul.internal\
+
+##############################################
+#Api  whitelist
+# when adding to the white-list, include comments as to why the addition is
+# being made.


### PR DESCRIPTION
Requires https://github.com/gwtproject/tools/pull/33 to merge first.