### PR TITLE
Deprecate and avoid unload event handler

### DIFF
--- a/user/src/com/google/gwt/user/client/Window.java
+++ b/user/src/com/google/gwt/user/client/Window.java
@@ -506,6 +506,7 @@ public class Window {
   // Package protected for testing.
   static WindowHandlers handlers;
   private static boolean closeHandlersInitialized;
+  private static boolean beforeCloseHandlersInitialized;
   private static boolean scrollHandlersInitialized;
   private static boolean resizeHandlersInitialized;
   private static int lastResizeWidth;
@@ -518,7 +519,10 @@ public class Window {
    *
    * @param handler the handler
    * @return returns the handler registration
+   * @deprecated This method requires the use of the {@code unload} browser event, which is
+   * deprecated in all browsers.
    */
+  @Deprecated
   public static HandlerRegistration addCloseHandler(CloseHandler<Window> handler) {
     maybeInitializeCloseHandlers();
     return addHandler(CloseEvent.getType(), handler);
@@ -531,7 +535,6 @@ public class Window {
    * @return returns the handler registration
    */
   public static HandlerRegistration addResizeHandler(ResizeHandler handler) {
-    maybeInitializeCloseHandlers();
     maybeInitializeResizeHandlers();
     return addHandler(ResizeEvent.getType(), handler);
   }
@@ -556,7 +559,7 @@ public class Window {
    */
   public static HandlerRegistration addWindowClosingHandler(
       ClosingHandler handler) {
-    maybeInitializeCloseHandlers();
+    maybeInitializeBeforeCloseHandlers();
     return addHandler(Window.ClosingEvent.getType(), handler);
   }
 
@@ -579,7 +582,6 @@ public class Window {
    */
   public static HandlerRegistration addWindowScrollHandler(
       Window.ScrollHandler handler) {
-    maybeInitializeCloseHandlers();
     maybeInitializeScrollHandlers();
     return addHandler(Window.ScrollEvent.getType(), handler);
   }
@@ -910,10 +912,18 @@ public class Window {
     return handlers;
   }
 
+  @Deprecated
   private static void maybeInitializeCloseHandlers() {
     if (GWT.isClient() && !closeHandlersInitialized) {
-      impl.initWindowCloseHandler();
+      impl.initWindowUnloadHandler();
       closeHandlersInitialized = true;
+    }
+  }
+
+  private static void maybeInitializeBeforeCloseHandlers() {
+    if (GWT.isClient() && !beforeCloseHandlersInitialized) {
+      impl.initWindowBeforeUnloadHandler();
+      beforeCloseHandlersInitialized = true;
     }
   }
 

--- a/user/src/com/google/gwt/user/client/impl/WindowImpl.java
+++ b/user/src/com/google/gwt/user/client/impl/WindowImpl.java
@@ -62,12 +62,7 @@ public class WindowImpl {
       try {
         ret = $entry(@com.google.gwt.user.client.Window::onClosing())();
       } finally {
-        try {
-          oldRet = oldOnBeforeUnload && oldOnBeforeUnload(evt);
-        } catch (unhandled) {
-          // Pass to uncaught exception handler, if registered
-          $wnd.onerror(unhandled);
-        }
+        oldRet = oldOnBeforeUnload && oldOnBeforeUnload(evt);
       }
       // Avoid returning null as IE6 will coerce it into a string.
       // Ensure that "" gets returned properly.

--- a/user/src/com/google/gwt/user/client/impl/WindowImpl.java
+++ b/user/src/com/google/gwt/user/client/impl/WindowImpl.java
@@ -64,7 +64,10 @@ public class WindowImpl {
       } finally {
         try {
           oldRet = oldOnBeforeUnload && oldOnBeforeUnload(evt);
-        } catch (ignored) {}
+        } catch (unhandled) {
+          // Pass to uncaught exception handler, if registered
+          $wnd.onerror(unhandled);
+        }
       }
       // Avoid returning null as IE6 will coerce it into a string.
       // Ensure that "" gets returned properly.

--- a/user/src/com/google/gwt/user/client/impl/WindowImpl.java
+++ b/user/src/com/google/gwt/user/client/impl/WindowImpl.java
@@ -29,11 +29,30 @@ public class WindowImpl {
   public native String getQueryString() /*-{
     return $wnd.location.search;
   }-*/;
-  
-  public native void initWindowCloseHandler() /*-{
+
+  @Deprecated
+  public void initWindowCloseHandler() {
+    initWindowUnloadHandler();
+    initWindowBeforeUnloadHandler();
+  }
+
+  @Deprecated
+  public native void initWindowUnloadHandler() /*-{
+    var oldOnUnload = $wnd.onunload;
+
+    $wnd.onunload = $entry(function(evt) {
+      try {
+        @com.google.gwt.user.client.Window::onClosed()();
+      } finally {
+        oldOnUnload && oldOnUnload(evt);
+        $wnd.onunload = null;
+      }
+    });
+  }-*/;
+
+  public native void initWindowBeforeUnloadHandler() /*-{
     var oldOnBeforeUnload = $wnd.onbeforeunload;
-    var oldOnUnload =  $wnd.onunload;
-    
+
     // Old mozilla doesn't like $entry's explicit return statement and
     // will always pop up a confirmation dialog.  This is worked around by
     // just wrapping the call to onClosing(), which still has the semantics
@@ -43,7 +62,9 @@ public class WindowImpl {
       try {
         ret = $entry(@com.google.gwt.user.client.Window::onClosing())();
       } finally {
-        oldRet = oldOnBeforeUnload && oldOnBeforeUnload(evt);
+        try {
+          oldRet = oldOnBeforeUnload && oldOnBeforeUnload(evt);
+        } catch (ignored) {}
       }
       // Avoid returning null as IE6 will coerce it into a string.
       // Ensure that "" gets returned properly.
@@ -55,18 +76,6 @@ public class WindowImpl {
       }
       // returns undefined.
     };
-    
-    $wnd.onunload = $entry(function(evt) {
-      try {
-        @com.google.gwt.user.client.Window::onClosed()();
-      } finally {
-        oldOnUnload && oldOnUnload(evt);
-        $wnd.onresize = null;
-        $wnd.onscroll = null;
-        $wnd.onbeforeunload = null;
-        $wnd.onunload = null;
-      }
-    });
   }-*/;
 
   public native void initWindowResizeHandler() /*-{

--- a/user/src/com/google/gwt/user/client/ui/Anchor.java
+++ b/user/src/com/google/gwt/user/client/ui/Anchor.java
@@ -73,7 +73,7 @@ public class Anchor extends FocusWidget implements HasHorizontalAlignment,
    * 
    * This element must already be attached to the document. If the element is
    * removed from the document, you must call
-   * {@link RootPanel#detachNow(Widget)}.
+   * {@link Widget#removeFromParent()}.
    * 
    * @param element the element to be wrapped
    */

--- a/user/src/com/google/gwt/user/client/ui/Button.java
+++ b/user/src/com/google/gwt/user/client/ui/Button.java
@@ -47,7 +47,7 @@ public class Button extends ButtonBase {
    * 
    * This element must already be attached to the document. If the element is
    * removed from the document, you must call
-   * {@link RootPanel#detachNow(Widget)}.
+   * {@link Widget#removeFromParent()}.
    * 
    * @param element the element to be wrapped
    */

--- a/user/src/com/google/gwt/user/client/ui/FileUpload.java
+++ b/user/src/com/google/gwt/user/client/ui/FileUpload.java
@@ -54,7 +54,7 @@ public class FileUpload extends FocusWidget implements HasName, HasChangeHandler
    * 
    * This element must already be attached to the document. If the element is
    * removed from the document, you must call
-   * {@link RootPanel#detachNow(Widget)}.
+   * {@link Widget#removeFromParent()}.
    * 
    * @param element the element to be wrapped
    */

--- a/user/src/com/google/gwt/user/client/ui/FormPanel.java
+++ b/user/src/com/google/gwt/user/client/ui/FormPanel.java
@@ -253,7 +253,7 @@ public class FormPanel extends SimplePanel implements FiresFormEvents, FormPanel
    *
    * This element must already be attached to the document. If the element is
    * removed from the document, you must call
-   * {@link RootPanel#detachNow(Widget)}.
+   * {@link Widget#removeFromParent()}.
    *
    * <p>
    * The specified form element's target attribute will not be set, and the
@@ -280,7 +280,7 @@ public class FormPanel extends SimplePanel implements FiresFormEvents, FormPanel
    *
    * This element must already be attached to the document. If the element is
    * removed from the document, you must call
-   * {@link RootPanel#detachNow(Widget)}.
+   * {@link Widget#removeFromParent()}.
    *
    * <p>
    * If the createIFrame parameter is set to <code>true</code>, then the wrapped

--- a/user/src/com/google/gwt/user/client/ui/Frame.java
+++ b/user/src/com/google/gwt/user/client/ui/Frame.java
@@ -52,7 +52,7 @@ public class Frame extends Widget implements HasLoadHandlers {
    * 
    * This element must already be attached to the document. If the element is
    * removed from the document, you must call
-   * {@link RootPanel#detachNow(Widget)}.
+   * {@link Widget#removeFromParent()}.
    * 
    * @param element the element to be wrapped
    */

--- a/user/src/com/google/gwt/user/client/ui/HTML.java
+++ b/user/src/com/google/gwt/user/client/ui/HTML.java
@@ -61,7 +61,7 @@ public class HTML extends Label
    *
    * This element must already be attached to the document. If the element is
    * removed from the document, you must call
-   * {@link RootPanel#detachNow(Widget)}.
+   * {@link Widget#removeFromParent()}.
    *
    * @param element the element to be wrapped
    */

--- a/user/src/com/google/gwt/user/client/ui/HTMLPanel.java
+++ b/user/src/com/google/gwt/user/client/ui/HTMLPanel.java
@@ -50,7 +50,7 @@ public class HTMLPanel extends ComplexPanel {
    *
    * This element must already be attached to the document. If the element is
    * removed from the document, you must call
-   * {@link RootPanel#detachNow(Widget)}.
+   * {@link Widget#removeFromParent()}.
    *
    * @param element the element to be wrapped
    */

--- a/user/src/com/google/gwt/user/client/ui/Hidden.java
+++ b/user/src/com/google/gwt/user/client/ui/Hidden.java
@@ -34,7 +34,7 @@ public class Hidden extends Widget implements HasName, TakesValue<String>, IsEdi
    * 
    * This element must already be attached to the document. If the element is
    * removed from the document, you must call
-   * {@link RootPanel#detachNow(Widget)}.
+   * {@link Widget#removeFromParent()}.
    * 
    * @param element the element to be wrapped
    */

--- a/user/src/com/google/gwt/user/client/ui/Image.java
+++ b/user/src/com/google/gwt/user/client/ui/Image.java
@@ -484,7 +484,7 @@ public class Image extends Widget implements SourcesLoadEvents, HasLoadHandlers,
    * 
    * This element must already be attached to the document. If the element is
    * removed from the document, you must call
-   * {@link RootPanel#detachNow(Widget)}.
+   * {@link Widget#removeFromParent()}.
    * 
    * @param element the element to be wrapped
    */

--- a/user/src/com/google/gwt/user/client/ui/InlineHTML.java
+++ b/user/src/com/google/gwt/user/client/ui/InlineHTML.java
@@ -55,7 +55,7 @@ public class InlineHTML extends HTML {
    *
    * This element must already be attached to the document. If the element is
    * removed from the document, you must call
-   * {@link RootPanel#detachNow(Widget)}.
+   * {@link Widget#removeFromParent()}.
    *
    * @param element the element to be wrapped
    */

--- a/user/src/com/google/gwt/user/client/ui/InlineLabel.java
+++ b/user/src/com/google/gwt/user/client/ui/InlineLabel.java
@@ -46,7 +46,7 @@ public class InlineLabel extends Label {
    *
    * This element must already be attached to the document. If the element is
    * removed from the document, you must call
-   * {@link RootPanel#detachNow(Widget)}.
+   * {@link Widget#removeFromParent()}.
    *
    * @param element the element to be wrapped
    */

--- a/user/src/com/google/gwt/user/client/ui/Label.java
+++ b/user/src/com/google/gwt/user/client/ui/Label.java
@@ -115,7 +115,7 @@ public class Label extends LabelBase<String> implements HasDirectionalText,
    *
    * This element must already be attached to the document. If the element is
    * removed from the document, you must call
-   * {@link RootPanel#detachNow(Widget)}.
+   * {@link Widget#removeFromParent()}.
    *
    * @param element the element to be wrapped
    */

--- a/user/src/com/google/gwt/user/client/ui/ListBox.java
+++ b/user/src/com/google/gwt/user/client/ui/ListBox.java
@@ -99,7 +99,7 @@ public class ListBox extends FocusWidget implements SourcesChangeEvents,
    * 
    * This element must already be attached to the document. If the element is
    * removed from the document, you must call
-   * {@link RootPanel#detachNow(Widget)}.
+   * {@link Widget#removeFromParent()}.
    * 
    * @param element the element to be wrapped
    * @return list box

--- a/user/src/com/google/gwt/user/client/ui/PasswordTextBox.java
+++ b/user/src/com/google/gwt/user/client/ui/PasswordTextBox.java
@@ -46,7 +46,7 @@ public class PasswordTextBox extends TextBox {
    * 
    * This element must already be attached to the document. If the element is
    * removed from the document, you must call
-   * {@link RootPanel#detachNow(Widget)}.
+   * {@link Widget#removeFromParent()}.
    * 
    * @param element the element to be wrapped
    */

--- a/user/src/com/google/gwt/user/client/ui/ResetButton.java
+++ b/user/src/com/google/gwt/user/client/ui/ResetButton.java
@@ -38,7 +38,7 @@ public class ResetButton extends Button {
    * 
    * This element must already be attached to the document. If the element is
    * removed from the document, you must call
-   * {@link RootPanel#detachNow(Widget)}.
+   * {@link Widget#removeFromParent()}.
    * 
    * @param element the element to be wrapped
    */

--- a/user/src/com/google/gwt/user/client/ui/RootPanel.java
+++ b/user/src/com/google/gwt/user/client/ui/RootPanel.java
@@ -89,11 +89,18 @@ public class RootPanel extends AbsolutePanel {
    * This method may only be called per widget, and only for widgets that were
    * originally passed to {@link #detachOnWindowClose(Widget)}.
    * </p>
-   * 
+   * <p>
+   * Note that modern browsers do not have the memory leaks that originally required use of this
+   * feature - it is retained only to support application-specific detach events.
+   * </p>
+   *
    * @param widget the widget that no longer needs to be cleaned up when the
    *          page closes
    * @see #detachOnWindowClose(Widget)
+   * @deprecated Instead, prefer to use the {@code bfcache}, {@code pagehide},
+   * {@code visibilitychange} events, etc.
    */
+  @Deprecated
   public static void detachNow(Widget widget) {
     assert widgetsToDetach.contains(widget) : "detachNow() called on a widget "
         + "not currently in the detach list";
@@ -123,10 +130,17 @@ public class RootPanel extends AbsolutePanel {
    * contained in another widget. This is to ensure that the DOM and Widget
    * hierarchies cannot get into an inconsistent state.
    * </p>
-   * 
+   * <p>
+   * Note that modern browsers do not have the memory leaks that originally required use of this
+   * feature - it is retained only to support application-specific detach events.
+   * </p>
+   *
    * @param widget the widget to be cleaned up when the page closes
    * @see #detachNow(Widget)
+   * @deprecated Instead, prefer to use the {@code bfcache}, {@code pagehide},
+   * {@code visibilitychange} events, etc.
    */
+  @Deprecated
   public static void detachOnWindowClose(Widget widget) {
     assert !widgetsToDetach.contains(widget) : "detachOnUnload() called twice "
         + "for the same widget";
@@ -218,16 +232,36 @@ public class RootPanel extends AbsolutePanel {
 
   /**
    * Determines whether the given widget is in the detach list.
-   * 
+   * <p>
+   * Note that modern browsers do not have the memory leaks that originally required use of this
+   * feature - it is retained only to support application-specific detach events.
+   * </p>
+   *
    * @param widget the widget to be checked
    * @return <code>true</code> if the widget is in the detach list
+   * @deprecated Instead, prefer to use the {@code bfcache}, {@code pagehide},
+   * {@code visibilitychange} events, etc.
    */
+  @Deprecated
   public static boolean isInDetachList(Widget widget) {
     return widgetsToDetach.contains(widget);
   }
 
-  // Package-protected for use by unit tests. Do not call this method directly.
-  static void detachWidgets() {
+  /**
+   * Detaches all widgets that were set to be detached on window close by a call to
+   * {@link #detachOnWindowClose}. Formerly was package-protected, now can be called by projects
+   * that required the old behavior and are willing to set up their own onclose handler on the
+   * window.
+   * <p>
+   * Note that modern browsers do not have the memory leaks that originally required use of this
+   * feature - it is retained only to support application-specific detach events.
+   * </p>
+   *
+   * @deprecated Instead, prefer to use the {@code bfcache}, {@code pagehide},
+   * {@code visibilitychange} events, etc.
+   */
+  @Deprecated
+  public static void detachWidgets() {
     // When the window is closing, detach all widgets that need to be
     // cleaned up. This will cause all of their event listeners
     // to be unhooked, which will avoid potential memory leaks.

--- a/user/src/com/google/gwt/user/client/ui/RootPanel.java
+++ b/user/src/com/google/gwt/user/client/ui/RootPanel.java
@@ -89,16 +89,11 @@ public class RootPanel extends AbsolutePanel {
    * This method may only be called per widget, and only for widgets that were
    * originally passed to {@link #detachOnWindowClose(Widget)}.
    * </p>
-   * <p>
-   * Note that modern browsers do not have the memory leaks that originally required use of this
-   * feature - it is retained only to support application-specific detach events.
-   * </p>
    *
    * @param widget the widget that no longer needs to be cleaned up when the
    *          page closes
    * @see #detachOnWindowClose(Widget)
-   * @deprecated Instead, prefer to use the {@code bfcache}, {@code pagehide},
-   * {@code visibilitychange} events, etc.
+   * @deprecated Instead, use {@link Widget#removeFromParent()}.
    */
   @Deprecated
   public static void detachNow(Widget widget) {
@@ -115,30 +110,28 @@ public class RootPanel extends AbsolutePanel {
   /**
    * Adds a widget to the detach list. This is the list of widgets to be
    * detached when the page unloads.
-   * 
+   *
    * <p>
    * This method must be called for all widgets that have no parent widgets.
    * These are most commonly {@link RootPanel RootPanels}, but can also be any
    * widget used to wrap an existing element on the page. Failing to do this may
    * cause these widgets to leak memory. This method is called automatically by
    * widgets' wrap methods (e.g.
-   * {@link Button#wrap(com.google.gwt.dom.client.Element)}).
+   * {@link Button#wrap(Element)}).
    * </p>
-   * 
+   *
    * <p>
    * This method may <em>not</em> be called on any widget whose element is
    * contained in another widget. This is to ensure that the DOM and Widget
    * hierarchies cannot get into an inconsistent state.
    * </p>
-   * <p>
-   * Note that modern browsers do not have the memory leaks that originally required use of this
-   * feature - it is retained only to support application-specific detach events.
-   * </p>
    *
    * @param widget the widget to be cleaned up when the page closes
    * @see #detachNow(Widget)
-   * @deprecated Instead, prefer to use the {@code bfcache}, {@code pagehide},
-   * {@code visibilitychange} events, etc.
+   * @deprecated While originally introduced to combat memory leaks in old browsers, this is no
+   * longer necessary, and the unload event used by this method is being removed from browsers.
+   * Additionally, it is unreliable as a means to ensure calls to {@link Widget#onUnload()}. See
+   * <a href="https://github.com/gwtproject/gwt/issues/9908">Issue 9908</a> for more information.
    */
   @Deprecated
   public static void detachOnWindowClose(Widget widget) {
@@ -239,8 +232,9 @@ public class RootPanel extends AbsolutePanel {
    *
    * @param widget the widget to be checked
    * @return <code>true</code> if the widget is in the detach list
-   * @deprecated Instead, prefer to use the {@code bfcache}, {@code pagehide},
-   * {@code visibilitychange} events, etc.
+   * @deprecated Use of the detach list requires the unload event, which is planned to be removed
+   * in future browser updates. See notice on {@link #detachOnWindowClose(Widget)} and
+   * <a href="https://github.com/gwtproject/gwt/issues/9908">Issue 9908</a> for more information.
    */
   @Deprecated
   public static boolean isInDetachList(Widget widget) {
@@ -257,8 +251,8 @@ public class RootPanel extends AbsolutePanel {
    * feature - it is retained only to support application-specific detach events.
    * </p>
    *
-   * @deprecated Instead, prefer to use the {@code bfcache}, {@code pagehide},
-   * {@code visibilitychange} events, etc.
+   * @deprecated See notice on {@link #detachOnWindowClose(Widget)} and
+   * <a href="https://github.com/gwtproject/gwt/issues/9908">Issue 9908</a> for more information.
    */
   @Deprecated
   public static void detachWidgets() {

--- a/user/src/com/google/gwt/user/client/ui/RootPanel.java
+++ b/user/src/com/google/gwt/user/client/ui/RootPanel.java
@@ -18,13 +18,10 @@ package com.google.gwt.user.client.ui;
 import com.google.gwt.dom.client.BodyElement;
 import com.google.gwt.dom.client.Document;
 import com.google.gwt.dom.client.Element;
-import com.google.gwt.event.logical.shared.CloseEvent;
-import com.google.gwt.event.logical.shared.CloseHandler;
 import com.google.gwt.i18n.client.BidiUtils;
 import com.google.gwt.i18n.client.HasDirection;
 import com.google.gwt.i18n.client.LocaleInfo;
 import com.google.gwt.user.client.Event;
-import com.google.gwt.user.client.Window;
 
 import java.util.HashMap;
 import java.util.HashSet;
@@ -188,8 +185,6 @@ public class RootPanel extends AbsolutePanel {
     // on the first RootPanel.get(String) or RootPanel.get()
     // call.
     if (rootPanels.size() == 0) {
-      hookWindowClosing();
-
       // If we're in a RTL locale, set the RTL directionality
       // on the entire document.
       if (LocaleInfo.getCurrentLocale().isRTL()) {
@@ -257,15 +252,6 @@ public class RootPanel extends AbsolutePanel {
   private static native Element getRootElement() /*-{
     return $doc;
   }-*/;
-
-  private static void hookWindowClosing() {
-    // Catch the window closing event.
-    Window.addCloseHandler(new CloseHandler<Window>() {
-      public void onClose(CloseEvent<Window> closeEvent) {
-        detachWidgets();
-      }
-    });
-  }
 
   /*
    * Checks to see whether the given element has any parent element that

--- a/user/src/com/google/gwt/user/client/ui/SimpleCheckBox.java
+++ b/user/src/com/google/gwt/user/client/ui/SimpleCheckBox.java
@@ -45,7 +45,7 @@ public class SimpleCheckBox extends FocusWidget implements HasName,
    * 
    * This element must already be attached to the document. If the element is
    * removed from the document, you must call
-   * {@link RootPanel#detachNow(Widget)}.
+   * {@link Widget#removeFromParent()}.
    * 
    * @param element the element to be wrapped
    */

--- a/user/src/com/google/gwt/user/client/ui/SimpleRadioButton.java
+++ b/user/src/com/google/gwt/user/client/ui/SimpleRadioButton.java
@@ -36,7 +36,7 @@ public class SimpleRadioButton extends SimpleCheckBox {
    * 
    * This element must already be attached to the document. If the element is
    * removed from the document, you must call
-   * {@link RootPanel#detachNow(Widget)}.
+   * {@link Widget#removeFromParent()}.
    * 
    * @param element the element to be wrapped
    */

--- a/user/src/com/google/gwt/user/client/ui/SubmitButton.java
+++ b/user/src/com/google/gwt/user/client/ui/SubmitButton.java
@@ -39,7 +39,7 @@ public class SubmitButton extends Button {
    * 
    * This element must already be attached to the document. If the element is
    * removed from the document, you must call
-   * {@link RootPanel#detachNow(Widget)}.
+   * {@link Widget#removeFromParent()}.
    * 
    * @param element the element to be wrapped
    */

--- a/user/src/com/google/gwt/user/client/ui/SuggestBox.java
+++ b/user/src/com/google/gwt/user/client/ui/SuggestBox.java
@@ -635,7 +635,7 @@ public class SuggestBox extends Composite implements HasText, HasFocus,
    *
    * This element must already be attached to the document. If the element is
    * removed from the document, you must call
-   * {@link RootPanel#detachNow(Widget)}.
+   * {@link Widget#removeFromParent()}.
    *
    * @param oracle the suggest box oracle to use
    * @param element the element to be wrapped

--- a/user/src/com/google/gwt/user/client/ui/TextArea.java
+++ b/user/src/com/google/gwt/user/client/ui/TextArea.java
@@ -52,7 +52,7 @@ public class TextArea extends TextBoxBase {
    *
    * This element must already be attached to the document. If the element is
    * removed from the document, you must call
-   * {@link RootPanel#detachNow(Widget)}.
+   * {@link Widget#removeFromParent()}.
    *
    * @param element the element to be wrapped
    */

--- a/user/src/com/google/gwt/user/client/ui/TextBox.java
+++ b/user/src/com/google/gwt/user/client/ui/TextBox.java
@@ -54,7 +54,7 @@ public class TextBox extends TextBoxBase {
    *
    * This element must already be attached to the document. If the element is
    * removed from the document, you must call
-   * {@link RootPanel#detachNow(Widget)}.
+   * {@link Widget#removeFromParent()}.
    *
    * @param element the element to be wrapped
    */

--- a/user/src/com/google/gwt/user/client/ui/ValueBox.java
+++ b/user/src/com/google/gwt/user/client/ui/ValueBox.java
@@ -35,7 +35,7 @@ public class ValueBox<T> extends ValueBoxBase<T> {
    * 
    * This element must already be attached to the document. If the element is
    * removed from the document, you must call
-   * {@link RootPanel#detachNow(Widget)}.
+   * {@link Widget#removeFromParent()}.
    * 
    * @param element the element to be wrapped
    */

--- a/user/src/com/google/gwt/user/client/ui/ValueLabel.java
+++ b/user/src/com/google/gwt/user/client/ui/ValueLabel.java
@@ -45,7 +45,7 @@ public class ValueLabel<T> extends LabelBase<T> implements TakesValue<T>,
    * <p>
    * This element must already be attached to the document. If the element is
    * removed from the document, you must call
-   * {@link RootPanel#detachNow(Widget)}.
+   * {@link Widget#removeFromParent()}.
    * 
    * @param element the element to be wrapped
    * @param renderer the renderer used to render values into the element
@@ -72,7 +72,7 @@ public class ValueLabel<T> extends LabelBase<T> implements TakesValue<T>,
    * <p>
    * This element must already be attached to the document. If the element is
    * removed from the document, you must call
-   * {@link RootPanel#detachNow(Widget)}.
+   * {@link Widget#removeFromParent()}.
    * 
    * @param element the element to be wrapped
    * @param renderer the renderer used to render values into the element

--- a/user/test/com/google/gwt/user/client/ui/ElementWrappingTest.java
+++ b/user/test/com/google/gwt/user/client/ui/ElementWrappingTest.java
@@ -79,6 +79,25 @@ public class ElementWrappingTest extends GWTTestCase {
   }
 
   /**
+   * Tests that {@link Widget#removeFromParent()} can be called more than once and successfully
+   * detaches wrapped widgets.
+   */
+  public void testRemoveFromParentDuplicateSucceeds() {
+    // Testing hosted-mode-only assertion.
+    if (!GWT.isScript()) {
+      // Trying to pass the same widget to RootPanel.detachNow() twice
+      // should fail an assertion.
+      ensureDiv().setInnerHTML(
+          "<a id='foo' href='" + TEST_URL + "'>myAnchor</a>");
+      Anchor a = Anchor.wrap(Document.get().getElementById("foo"));
+      a.removeFromParent(); // success
+      assertFalse(RootPanel.isInDetachList(a));
+      a.removeFromParent(); // no-op
+      assertFalse(RootPanel.isInDetachList(a));
+    }
+  }
+
+  /**
    * Tests that {@link RootPanel#detachOnWindowClose(Widget)} can only be called
    * once per widget.
    */

--- a/user/test/com/google/gwt/user/client/ui/ElementWrappingTest.java
+++ b/user/test/com/google/gwt/user/client/ui/ElementWrappingTest.java
@@ -64,13 +64,13 @@ public class ElementWrappingTest extends GWTTestCase {
   public void testDetachNowTwiceFails() {
     // Testing hosted-mode-only assertion.
     if (!GWT.isScript()) {
+      // Trying to pass the same widget to RootPanel.detachNow() twice
+      // should fail an assertion.
+      ensureDiv().setInnerHTML(
+              "<a id='foo' href='" + TEST_URL + "'>myAnchor</a>");
+      Anchor a = Anchor.wrap(Document.get().getElementById("foo"));
+      RootPanel.detachNow(a); // pass
       try {
-        // Trying to pass the same widget to RootPanel.detachNow() twice
-        // should fail an assertion.
-        ensureDiv().setInnerHTML(
-            "<a id='foo' href='" + TEST_URL + "'>myAnchor</a>");
-        Anchor a = Anchor.wrap(Document.get().getElementById("foo"));
-        RootPanel.detachNow(a); // pass
         RootPanel.detachNow(a); // fail
         throw new Error("Expected assertion failure calling detachNow() twice");
       } catch (AssertionError e) {

--- a/user/test/com/google/gwt/user/client/ui/ImageTest.java
+++ b/user/test/com/google/gwt/user/client/ui/ImageTest.java
@@ -790,13 +790,48 @@ public class ImageTest extends GWTTestCase {
     assertNotNull(image);
 
     // Cleanup.
+    Document.get().getBody().removeChild(div);
     RootPanel.detachNow(image);
   }
 
   /**
-   * Same test, but with removeFromParent
+   * Same test, but don't remove from the dom first
+   */
+  public void testWrapOfSubclassWithoutRemove() {
+    String uid = Document.get().createUniqueId();
+    DivElement div = Document.get().createDivElement();
+    div.setInnerHTML("<img id='" + uid + "' src='counting-forwards.png'>");
+    Document.get().getBody().appendChild(div);
+
+    final TestImage image = TestImage.wrap(Document.get().getElementById(uid));
+    assertNotNull(image);
+
+    // Cleanup.
+    RootPanel.detachNow(image);
+  }
+
+  /**
+   * Same test, but with removeFromParent instead of detachNow
    */
   public void testRemoveFromParent() {
+    String uid = Document.get().createUniqueId();
+    DivElement div = Document.get().createDivElement();
+    div.setInnerHTML("<img id='" + uid + "' src='counting-forwards.png'>");
+    Document.get().getBody().appendChild(div);
+
+    final TestImage image = TestImage.wrap(Document.get().getElementById(uid));
+    assertNotNull(image);
+
+    // Cleanup.
+    Document.get().getBody().removeChild(div);
+    image.removeFromParent();
+  }
+
+  /**
+   * Same test, but with removeFromParent isntead of detachNow, and don't remove the dom manually
+   * first.
+   */
+  public void testRemoveFromParentWithoutRemove() {
     String uid = Document.get().createUniqueId();
     DivElement div = Document.get().createDivElement();
     div.setInnerHTML("<img id='" + uid + "' src='counting-forwards.png'>");

--- a/user/test/com/google/gwt/user/client/ui/ImageTest.java
+++ b/user/test/com/google/gwt/user/client/ui/ImageTest.java
@@ -790,7 +790,6 @@ public class ImageTest extends GWTTestCase {
     assertNotNull(image);
 
     // Cleanup.
-    Document.get().getBody().appendChild(div);
     RootPanel.detachNow(image);
   }
 
@@ -807,7 +806,6 @@ public class ImageTest extends GWTTestCase {
     assertNotNull(image);
 
     // Cleanup.
-    Document.get().getBody().appendChild(div);
     image.removeFromParent();
   }
 

--- a/user/test/com/google/gwt/user/client/ui/ImageTest.java
+++ b/user/test/com/google/gwt/user/client/ui/ImageTest.java
@@ -795,6 +795,23 @@ public class ImageTest extends GWTTestCase {
   }
 
   /**
+   * Same test, but with removeFromParent
+   */
+  public void testRemoveFromParent() {
+    String uid = Document.get().createUniqueId();
+    DivElement div = Document.get().createDivElement();
+    div.setInnerHTML("<img id='" + uid + "' src='counting-forwards.png'>");
+    Document.get().getBody().appendChild(div);
+
+    final TestImage image = TestImage.wrap(Document.get().getElementById(uid));
+    assertNotNull(image);
+
+    // Cleanup.
+    Document.get().getBody().appendChild(div);
+    image.removeFromParent();
+  }
+
+  /**
    * Tests that wrapping an existing DOM element works if you call
    * setUrlAndVisibleRect() on it.
    */

--- a/user/test/com/google/gwt/user/client/ui/RootPanelTest.java
+++ b/user/test/com/google/gwt/user/client/ui/RootPanelTest.java
@@ -96,6 +96,21 @@ public class RootPanelTest extends GWTTestCase {
     assertFalse(RootPanel.isInDetachList(w));
   }
 
+  public void testRemoveFromParentWithErrorOnDetach() {
+    BadWidget w = BadWidget.wrap(createAttachedDivElement());
+    w.setFailOnUnload(true);
+    assertTrue(RootPanel.isInDetachList(w));
+    assertTrue(RootPanel.getBodyElement().isOrHasChild(w.getElement()));
+
+    try {
+      w.removeFromParent();
+      fail("Expected IllegalArgumentException");
+    } catch (IllegalArgumentException e) {
+      // Expected.
+    }
+    assertFalse(RootPanel.isInDetachList(w));
+  }
+
   public void testDetachWidgetsWithErrorOnDetach() {
     BadWidget bad0 = BadWidget.wrap(createAttachedDivElement());
     bad0.setFailOnUnload(true);


### PR DESCRIPTION
Event handling for `unload` and `beforeunload` now is split, so that only explicit calls to `WindowImpl.initWindowCloseHandler()`, `Window.addCloseHandler()`, or `Window.addWindowCloseListener()` can cause the `unload` event handler to be attached - all of which are now deprecated. The `beforeunload` event wiring is now the only event handler set up when `Window.addWindowClosingHandler` etc are called.

RootPanel methods formerly intended to prevent memory leaks during the `unload` event are deprecated, since modern browsers do not leak these handlers, and may prevent correct behavior of apps using bfcache.

Documentation changed on using various static wrap(Element) methods to reflect how to detach, if desired, when the page is closed or no longer in use.

Fixes #9908 