### PR TITLE
Make MAX_STRING_NODE_LENGTH configurable

### DIFF
--- a/user/src/com/google/gwt/user/server/rpc/impl/ServerSerializationStreamWriter.java
+++ b/user/src/com/google/gwt/user/server/rpc/impl/ServerSerializationStreamWriter.java
@@ -345,7 +345,7 @@ public final class ServerSerializationStreamWriter extends
    * This exists to work around a Rhino parser bug in the hosted mode client
    * that limits string node lengths to 64KB.
    */
-  private static final int MAX_STRING_NODE_LENGTH =  = Integer.getInteger("gwt.rpc.maxStringNodeLength", 0xFFFF);
+  private static final int MAX_STRING_NODE_LENGTH =  Integer.getInteger("gwt.rpc.maxStringNodeLength", 0xFFFF);
 
   static {
     /*

--- a/user/src/com/google/gwt/user/server/rpc/impl/ServerSerializationStreamWriter.java
+++ b/user/src/com/google/gwt/user/server/rpc/impl/ServerSerializationStreamWriter.java
@@ -345,7 +345,7 @@ public final class ServerSerializationStreamWriter extends
    * This exists to work around a Rhino parser bug in the hosted mode client
    * that limits string node lengths to 64KB.
    */
-  private static final int MAX_STRING_NODE_LENGTH = 0xFFFF;
+  private static final int MAX_STRING_NODE_LENGTH =  = Integer.getInteger("gwt.rpc.maxStringNodeLength", 0xFFFF);
 
   static {
     /*

--- a/user/src/com/google/gwt/user/server/rpc/impl/ServerSerializationStreamWriter.java
+++ b/user/src/com/google/gwt/user/server/rpc/impl/ServerSerializationStreamWriter.java
@@ -345,7 +345,8 @@ public final class ServerSerializationStreamWriter extends
    * This exists to work around a Rhino parser bug in the hosted mode client
    * that limits string node lengths to 64KB.
    */
-  private static final int MAX_STRING_NODE_LENGTH =  Integer.getInteger("gwt.rpc.maxStringNodeLength", 0xFFFF);
+  private static final int MAX_STRING_NODE_LENGTH =
+      Integer.getInteger("gwt.rpc.maxStringNodeLength", 0xFFFF);
 
   static {
     /*


### PR DESCRIPTION
Make `ServerSerializationStreamWriter.MAX_STRING_NODE_LENGTH` configurable, to better work around #9578 and allow real JSON in all cases. 
This PR is a follow-up to #9961 (making the rpc serialization chunk size configurable).

Workaround #9578 
Followup #9961