### PR TITLE
Never attempt to inline switch expressions

### DIFF
--- a/dev/core/src/com/google/gwt/dev/jjs/impl/ImplementRecordComponents.java
+++ b/dev/core/src/com/google/gwt/dev/jjs/impl/ImplementRecordComponents.java
@@ -193,13 +193,16 @@ public class ImplementRecordComponents {
                   myField,
                   otherField);
         } else {
-          // we would like to use Objects.equals here to be more consise, but we would need
+          // We would like to use Objects.equals here to be more concise, but we would need
           // to look up the right impl based on the field - just as simple to insert a null check
           // and get it a little closer to all being inlined away
+
+          // Make another field ref to call equals() on
+          JFieldRef myField2 = new JFieldRef(info, new JThisRef(info, type), field, type);
           equals = new JBinaryOperation(info, JPrimitiveType.BOOLEAN, JBinaryOperator.AND,
                   new JBinaryOperation(info, JPrimitiveType.BOOLEAN, JBinaryOperator.NEQ,
                           myField, JNullLiteral.INSTANCE),
-                  new JMethodCall(info, myField, objectEquals, otherField));
+                  new JMethodCall(info, myField2, objectEquals, otherField));
         }
         if (componentCheck != JBooleanLiteral.TRUE) {
           componentCheck = new JBinaryOperation(info, JPrimitiveType.BOOLEAN,

--- a/dev/core/src/com/google/gwt/dev/jjs/impl/MethodInliner.java
+++ b/dev/core/src/com/google/gwt/dev/jjs/impl/MethodInliner.java
@@ -288,10 +288,11 @@ public class MethodInliner {
         } else if (stmt instanceof JReturnStatement) {
           JReturnStatement returnStatement = (JReturnStatement) stmt;
           JExpression expr = returnStatement.getExpr();
-          if (!CannotBeInlinedVisitor.check(expr)) {
-            return null;
-          }
+
           if (expr != null) {
+            if (!CannotBeInlinedVisitor.check(expr)) {
+              return null;
+            }
             JExpression clone = cloner.cloneExpression(expr);
             clone = maybeCast(clone, body.getMethod().getType());
             expressions.add(clone);

--- a/dev/core/src/com/google/gwt/dev/jjs/impl/MethodInliner.java
+++ b/dev/core/src/com/google/gwt/dev/jjs/impl/MethodInliner.java
@@ -76,6 +76,31 @@ public class MethodInliner {
   }
 
   /**
+   * Determines if the given expression can be inlined. Any switch expression will fail this check.
+   */
+  private static class CannotBeInlinedVisitor extends JVisitor {
+    private boolean succeed = true;
+    public static boolean check(JExpression expr) {
+      CannotBeInlinedVisitor v = new CannotBeInlinedVisitor();
+      v.accept(expr);
+      return v.succeed;
+    }
+
+    @Override
+    public boolean visit(JStatement x, Context ctx) {
+      // To ensure we didn't miss an important case, throw if we see a statement, as those cannot
+      // be inlined.
+      throw new IllegalStateException("Should never visit statements");
+    }
+
+    @Override
+    public boolean visit(JSwitchExpression x, Context ctx) {
+      succeed = false;
+      return false;
+    }
+  }
+
+  /**
    * Method inlining visitor.
    */
   private class InliningVisitor extends JChangeTrackingVisitor {
@@ -148,6 +173,7 @@ public class MethodInliner {
       if (expressions == null) {
         // If it will never be possible to inline the method, add it to a
         // blacklist
+
         return InlineResult.BLACKLIST;
       }
 
@@ -242,6 +268,9 @@ public class MethodInliner {
           if (initializer == null) {
             continue;
           }
+          if (!CannotBeInlinedVisitor.check(initializer)) {
+            return null;
+          }
           JLocal local = (JLocal) declStatement.getVariableRef().getTarget();
           JExpression clone = new JBinaryOperation(stmt.getSourceInfo(), local.getType(),
               JBinaryOperator.ASG,
@@ -251,9 +280,7 @@ public class MethodInliner {
         } else if (stmt instanceof JExpressionStatement) {
           JExpressionStatement exprStmt = (JExpressionStatement) stmt;
           JExpression expr = exprStmt.getExpr();
-          if (expr instanceof JSwitchExpression) {
-            // Switch expressions can't be cloned in this way, though we wouldn't want to inline
-            // such a large block anyway.
+          if (!CannotBeInlinedVisitor.check(expr)) {
             return null;
           }
           JExpression clone = cloner.cloneExpression(expr);
@@ -261,6 +288,9 @@ public class MethodInliner {
         } else if (stmt instanceof JReturnStatement) {
           JReturnStatement returnStatement = (JReturnStatement) stmt;
           JExpression expr = returnStatement.getExpr();
+          if (!CannotBeInlinedVisitor.check(expr)) {
+            return null;
+          }
           if (expr != null) {
             JExpression clone = cloner.cloneExpression(expr);
             clone = maybeCast(clone, body.getMethod().getType());

--- a/user/test-super/com/google/gwt/dev/jjs/super/com/google/gwt/dev/jjs/test/Java17Test.java
+++ b/user/test-super/com/google/gwt/dev/jjs/super/com/google/gwt/dev/jjs/test/Java17Test.java
@@ -439,4 +439,32 @@ public class Java17Test extends GWTTestCase {
             : 4.0;
     assertTrue(notCalled);
   }
+
+  public void testSwitchExprInlining() {
+    enum HasSwitchMethod {
+      A, RED, SUNDAY, JANUARY, ZERO;
+      public static final int which(HasSwitchMethod whichSwitch) {
+        return switch(whichSwitch) {
+          case A -> 1;
+          case RED -> 2;
+          case SUNDAY -> 3;
+          case JANUARY -> 4;
+          case ZERO -> 5;
+        };
+      }
+      public static final int pick(HasSwitchMethod whichSwitch) {
+        return 2 * switch(whichSwitch) {
+          case A -> 1;
+          case RED -> 2;
+          case SUNDAY -> 3;
+          case JANUARY -> 4;
+          case ZERO -> 5;
+        };
+      }
+    }
+
+    HasSwitchMethod uninlinedValue = Math.random() > 2 ? HasSwitchMethod.A : HasSwitchMethod.RED;
+    assertEquals(2, HasSwitchMethod.which(uninlinedValue));
+    assertEquals(4, HasSwitchMethod.pick(uninlinedValue));
+  }
 }

--- a/user/test/com/google/gwt/dev/jjs/test/Java17Test.java
+++ b/user/test/com/google/gwt/dev/jjs/test/Java17Test.java
@@ -114,6 +114,10 @@ public class Java17Test extends GWTTestCase {
     assertFalse(isGwtSourceLevel17());
   }
 
+  public void testSwitchExprInlining() {
+    assertFalse(isGwtSourceLevel17());
+  }
+
   private boolean isGwtSourceLevel17() {
     return JUnitShell.getCompilerOptions().getSourceLevel().compareTo(SourceLevel.JAVA17) >= 0;
   }


### PR DESCRIPTION
The original check wasn't specific enough - couldn't handle nested expressions, or expressions in different types of wrapper statements.

Also includes a fix preventing record equals methods from being made static.

Fixes #10005