### PR TITLE
Avoid "immutable" apis for JNodes, preventing optimizer errors

### DIFF
--- a/dev/core/src/com/google/gwt/dev/jjs/ast/JCaseStatement.java
+++ b/dev/core/src/com/google/gwt/dev/jjs/ast/JCaseStatement.java
@@ -27,7 +27,7 @@ import java.util.List;
  */
 public class JCaseStatement extends JStatement {
 
-  private List<JExpression> exprs;
+  private final List<JExpression> exprs;
 
   public JCaseStatement(SourceInfo info, JExpression expr) {
     super(info);
@@ -69,7 +69,7 @@ public class JCaseStatement extends JStatement {
   @Override
   public void traverse(JVisitor visitor, Context ctx) {
     if (visitor.visit(this, ctx)) {
-      exprs = visitor.acceptWithInsertRemoveImmutable(exprs);
+      visitor.accept(exprs);
     }
     visitor.endVisit(this, ctx);
   }

--- a/dev/core/src/com/google/gwt/dev/jjs/ast/JCaseStatement.java
+++ b/dev/core/src/com/google/gwt/dev/jjs/ast/JCaseStatement.java
@@ -37,7 +37,7 @@ public class JCaseStatement extends JStatement {
 
   public JCaseStatement(SourceInfo info, Collection<JExpression> exprs) {
     super(info);
-    this.exprs = Collections.unmodifiableList(new ArrayList<>(exprs));
+    this.exprs = Lists.newArrayList(exprs);
   }
 
   public boolean isDefault() {
@@ -45,7 +45,7 @@ public class JCaseStatement extends JStatement {
   }
 
   public List<JExpression> getExprs() {
-    return exprs;
+    return Collections.unmodifiableList(exprs);
   }
 
   public JBinaryOperation convertToCompareExpression(JExpression value) {

--- a/dev/core/src/com/google/gwt/dev/jjs/ast/JCaseStatement.java
+++ b/dev/core/src/com/google/gwt/dev/jjs/ast/JCaseStatement.java
@@ -18,7 +18,6 @@ package com.google.gwt.dev.jjs.ast;
 import com.google.gwt.dev.jjs.SourceInfo;
 import com.google.gwt.thirdparty.guava.common.collect.Lists;
 
-import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;

--- a/dev/core/src/com/google/gwt/dev/jjs/ast/JCaseStatement.java
+++ b/dev/core/src/com/google/gwt/dev/jjs/ast/JCaseStatement.java
@@ -16,6 +16,7 @@
 package com.google.gwt.dev.jjs.ast;
 
 import com.google.gwt.dev.jjs.SourceInfo;
+import com.google.gwt.thirdparty.guava.common.collect.Lists;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -31,7 +32,7 @@ public class JCaseStatement extends JStatement {
 
   public JCaseStatement(SourceInfo info, JExpression expr) {
     super(info);
-    this.exprs = Collections.singletonList(expr);
+    this.exprs = Lists.newArrayList(expr);
   }
 
   public JCaseStatement(SourceInfo info, Collection<JExpression> exprs) {
@@ -69,7 +70,7 @@ public class JCaseStatement extends JStatement {
   @Override
   public void traverse(JVisitor visitor, Context ctx) {
     if (visitor.visit(this, ctx)) {
-      exprs = Collections.unmodifiableList(visitor.acceptImmutable(exprs));
+      exprs = visitor.acceptWithInsertRemoveImmutable(exprs);
     }
     visitor.endVisit(this, ctx);
   }

--- a/dev/core/src/com/google/gwt/dev/jjs/ast/JSwitchExpression.java
+++ b/dev/core/src/com/google/gwt/dev/jjs/ast/JSwitchExpression.java
@@ -45,6 +45,10 @@ public class JSwitchExpression extends JExpression {
     return true;
   }
 
+  public void setType(JType type) {
+    this.type = type;
+  }
+
   @Override
   public void traverse(JVisitor visitor, Context ctx) {
     if (visitor.visit(this, ctx)) {

--- a/dev/core/src/com/google/gwt/dev/jjs/impl/UnifyAst.java
+++ b/dev/core/src/com/google/gwt/dev/jjs/impl/UnifyAst.java
@@ -64,6 +64,7 @@ import com.google.gwt.dev.jjs.ast.JPermutationDependentValue;
 import com.google.gwt.dev.jjs.ast.JProgram;
 import com.google.gwt.dev.jjs.ast.JReferenceType;
 import com.google.gwt.dev.jjs.ast.JStringLiteral;
+import com.google.gwt.dev.jjs.ast.JSwitchExpression;
 import com.google.gwt.dev.jjs.ast.JThisRef;
 import com.google.gwt.dev.jjs.ast.JTryStatement;
 import com.google.gwt.dev.jjs.ast.JType;
@@ -340,6 +341,11 @@ public class UnifyAst {
       JClassType stringType = program.getTypeJavaLangString();
       x.resolve(stringType);
       instantiate(stringType);
+    }
+
+    @Override
+    public void endVisit(JSwitchExpression x, Context ctx) {
+      x.setType(translate(x.getType()));
     }
 
     @Override

--- a/user/test-super/com/google/gwt/dev/jjs/super/com/google/gwt/dev/jjs/test/Java17Test.java
+++ b/user/test-super/com/google/gwt/dev/jjs/super/com/google/gwt/dev/jjs/test/Java17Test.java
@@ -459,11 +459,23 @@ public class Java17Test extends GWTTestCase {
           case ZERO -> 5;
         };
       }
+      public static final String select(HasSwitchMethod whichSwitch) {
+        if (Math.random() > 2) {
+          return "none";
+        }
+        return switch(whichSwitch) {
+          case A -> "1";
+          case RED -> "2";
+          case SUNDAY, JANUARY -> "4";
+          case ZERO -> "5";
+        };
+      }
     }
 
     HasSwitchMethod uninlinedValue = Math.random() > 2 ? HasSwitchMethod.A : HasSwitchMethod.RED;
     assertEquals(2, HasSwitchMethod.which(uninlinedValue));
     assertEquals(4, HasSwitchMethod.pick(uninlinedValue));
+    assertEquals("hello 2", "hello " + HasSwitchMethod.select(uninlinedValue));
   }
 
   private static final String ONE = "1";

--- a/user/test-super/com/google/gwt/dev/jjs/super/com/google/gwt/dev/jjs/test/Java17Test.java
+++ b/user/test-super/com/google/gwt/dev/jjs/super/com/google/gwt/dev/jjs/test/Java17Test.java
@@ -447,8 +447,7 @@ public class Java17Test extends GWTTestCase {
         return switch(whichSwitch) {
           case A -> 1;
           case RED -> 2;
-          case SUNDAY -> 3;
-          case JANUARY -> 4;
+          case SUNDAY, JANUARY -> 4;
           case ZERO -> 5;
         };
       }
@@ -456,8 +455,7 @@ public class Java17Test extends GWTTestCase {
         return 2 * switch(whichSwitch) {
           case A -> 1;
           case RED -> 2;
-          case SUNDAY -> 3;
-          case JANUARY -> 4;
+          case SUNDAY, JANUARY -> 4;
           case ZERO -> 5;
         };
       }
@@ -466,5 +464,18 @@ public class Java17Test extends GWTTestCase {
     HasSwitchMethod uninlinedValue = Math.random() > 2 ? HasSwitchMethod.A : HasSwitchMethod.RED;
     assertEquals(2, HasSwitchMethod.which(uninlinedValue));
     assertEquals(4, HasSwitchMethod.pick(uninlinedValue));
+  }
+
+  private static final String ONE = "1";
+  private static final String TWO = "2";
+  private static final String FOUR = "4";
+
+  public void testInlinedStringConstantsInCase() {
+    int value = switch(Math.random() > 2 ? "2" : "4") {
+      case ONE, TWO -> 2;
+      case FOUR -> 4;
+      default -> 0;
+    };
+    assertEquals(4, value);
   }
 }

--- a/user/test/com/google/gwt/dev/jjs/test/Java17Test.java
+++ b/user/test/com/google/gwt/dev/jjs/test/Java17Test.java
@@ -118,6 +118,10 @@ public class Java17Test extends GWTTestCase {
     assertFalse(isGwtSourceLevel17());
   }
 
+  public void testInlinedStringConstantsInCase() {
+    assertFalse(isGwtSourceLevel17());
+  }
+
   private boolean isGwtSourceLevel17() {
     return JUnitShell.getCompilerOptions().getSourceLevel().compareTo(SourceLevel.JAVA17) >= 0;
   }


### PR DESCRIPTION
The immutable APIs for JNodes apparently were never immutable to begin with, and have been watered down since then so that it isn't safe to actually treat them as being immutable. This confusion prevented multiple case expressions from being optimized correctly.

Fixes #10005