### PR TITLE
Unset config properties: `System.getProperty` should return default value or null

### DIFF
--- a/dev/core/src/com/google/gwt/dev/cfg/ConfigurationProperties.java
+++ b/dev/core/src/com/google/gwt/dev/cfg/ConfigurationProperties.java
@@ -142,6 +142,17 @@ public class ConfigurationProperties implements Serializable {
   }
 
   /**
+   * Returns all the values of a multi-valued configuration property, or null
+   * if not found.
+   *
+   * <p>A single-valued and unset configuration property will be returned as a list
+   * containing one null.
+   */
+  public List<String> getStringsOrNull(String key) {
+     return properties.get(key);
+  }
+
+  /**
    * Reads a configuration property as a comma-separated list of strings.
    * It may be a single-valued or multi-valued property. If multi-valued,
    * each value will be split on commas and all items concatenated.

--- a/dev/core/src/com/google/gwt/dev/jjs/impl/ResolvePermutationDependentValues.java
+++ b/dev/core/src/com/google/gwt/dev/jjs/impl/ResolvePermutationDependentValues.java
@@ -47,6 +47,7 @@ import com.google.gwt.thirdparty.guava.common.collect.Multimap;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 
 /**
@@ -76,7 +77,14 @@ public class ResolvePermutationDependentValues {
     private JExpression propertyValueExpression(JPermutationDependentValue x) {
       List<String> propertyValues = props.getConfigurationProperties().getStrings(x.getRequestedValue());
 
-      String propertyValue = propertyValues.isEmpty() ? null : Joiner.on(",").join(propertyValues);
+      if (!propertyValues.isEmpty() && propertyValues.stream().allMatch(Objects::isNull)) {
+        if (x.getDefaultValueExpression() != null) {
+          return x.getDefaultValueExpression();
+        }
+        throw new InternalCompilerException("No default set for configuration property '"
+            + x.getRequestedValue() + "'");
+      }
+      String propertyValue = propertyValues.isEmpty() ? null : Joiner.on(",").skipNulls().join(propertyValues);
 
       if (propertyValue != null) {
         // It is a configuration property.

--- a/user/test/com/google/gwt/dev/jjs/SystemGetPropertyTest.gwt.xml
+++ b/user/test/com/google/gwt/dev/jjs/SystemGetPropertyTest.gwt.xml
@@ -33,4 +33,5 @@
   <set-property name="someOtherDynamicProperty" value="blue">
     <when-property-is name="collapsedProperty" value="two"/>
   </set-property>
+  <define-configuration-property name="configPropertyUnset" is-multi-valued="false"/>
 </module>

--- a/user/test/com/google/gwt/dev/jjs/SystemGetPropertyTest.gwt.xml
+++ b/user/test/com/google/gwt/dev/jjs/SystemGetPropertyTest.gwt.xml
@@ -34,4 +34,5 @@
     <when-property-is name="collapsedProperty" value="two"/>
   </set-property>
   <define-configuration-property name="configPropertyUnset" is-multi-valued="false"/>
+  <define-configuration-property name="multivaluedConfigPropertyUnset" is-multi-valued="true"/>
 </module>

--- a/user/test/com/google/gwt/dev/jjs/test/SystemGetPropertyTest.java
+++ b/user/test/com/google/gwt/dev/jjs/test/SystemGetPropertyTest.java
@@ -37,5 +37,8 @@ public class SystemGetPropertyTest extends GWTTestCase {
         "InSafari" : "NotInSafari";
     assertEquals(expectedResult, System.getProperty("someDynamicProperty"));
     assertEquals("foo", System.getProperty("configPropertyUnset", "foo"));
+    assertNull(System.getProperty("configPropertyUnset"));
+    assertEquals("foo", System.getProperty("multivaluedConfigPropertyUnset", "foo"));
+    assertNull(System.getProperty("multivaluedConfigPropertyUnset"));
   }
 }

--- a/user/test/com/google/gwt/dev/jjs/test/SystemGetPropertyTest.java
+++ b/user/test/com/google/gwt/dev/jjs/test/SystemGetPropertyTest.java
@@ -36,5 +36,6 @@ public class SystemGetPropertyTest extends GWTTestCase {
     String expectedResult = "safari".equals(System.getProperty("user.agent")) ?
         "InSafari" : "NotInSafari";
     assertEquals(expectedResult, System.getProperty("someDynamicProperty"));
+    assertEquals("foo", System.getProperty("configPropertyUnset", "foo"));
   }
 }


### PR DESCRIPTION
Fixes #9885 

If a property has no default value in XML, take default value from call (or null, if no default is set).