### PR TITLE
set java 11 as minimum for sample apps templates

### DIFF
--- a/user/src/com/google/gwt/user/tools/templates/ant/build.xmlsrc
+++ b/user/src/com/google/gwt/user/tools/templates/ant/build.xmlsrc
@@ -27,7 +27,7 @@
     <mkdir dir="@warFolder/WEB-INF/classes"/>
     <javac srcdir="@srcFolder" includes="**" encoding="utf-8"
         destdir="@warFolder/WEB-INF/classes"
-        source="1.7" target="1.7" nowarn="true"
+        source="11" target="11" nowarn="true"
         debug="true" debuglevel="lines,vars,source">
       <classpath refid="project.class.path"/>
     </javac>
@@ -70,7 +70,7 @@
 @testTargetsBegin
   <target name="javac.tests" depends="javac" description="Compiles test code">
     <javac srcdir="@testFolder" includes="**" encoding="utf-8"
-      source="1.7" target="1.7" nowarn="true"
+      source="11" target="11" nowarn="true"
       destdir="@warFolder/WEB-INF/classes"
       debug="true" debuglevel="lines,vars,source">
       <classpath location="@junitJar"/>

--- a/user/src/com/google/gwt/user/tools/templates/maven/pom.xmlsrc
+++ b/user/src/com/google/gwt/user/tools/templates/maven/pom.xmlsrc
@@ -15,8 +15,8 @@
     <!-- Setting maven.compiler.source to something different to 1.8
          needs that you configure the sourceLevel in gwt-maven-plugin since
          GWT compiler 2.8 and above requires 1.8 (see gwt-maven-plugin block below) -->
-    <maven.compiler.source>1.8</maven.compiler.source>
-    <maven.compiler.target>1.8</maven.compiler.target>
+    <maven.compiler.source>11</maven.compiler.source>
+    <maven.compiler.target>11</maven.compiler.target>
 
     <!-- Don't let your Mac use a crazy non-standard encoding -->
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -85,7 +85,7 @@
           <failOnError>true</failOnError>
           <!-- GWT compiler 2.8 and above requires 1.8, hence define sourceLevel here if you use
                a different source language for java compilation -->
-          <sourceLevel>1.8</sourceLevel>
+          <sourceLevel>11</sourceLevel>
           <!-- Compiler configuration -->
           <compilerArgs>
             <!-- Ask GWT to create the Story of Your Compile (SOYC) (gwt:compile) -->

--- a/user/src/com/google/gwt/user/tools/templates/maven/pom.xmlsrc
+++ b/user/src/com/google/gwt/user/tools/templates/maven/pom.xmlsrc
@@ -85,7 +85,7 @@
           <failOnError>true</failOnError>
           <!-- GWT compiler 2.12.0 and above requires 11, hence define sourceLevel here if you use
                a different source language for java compilation -->
-          <release>11</release>
+          <sourceLevel>11</sourceLevel>
           <!-- Compiler configuration -->
           <compilerArgs>
             <!-- Ask GWT to create the Story of Your Compile (SOYC) (gwt:compile) -->

--- a/user/src/com/google/gwt/user/tools/templates/maven/pom.xmlsrc
+++ b/user/src/com/google/gwt/user/tools/templates/maven/pom.xmlsrc
@@ -12,9 +12,9 @@
 
   <properties>
 
-    <!-- Setting maven.compiler.source to something different to 1.8
+    <!-- Setting maven.compiler.source to something different to 11
          needs that you configure the sourceLevel in gwt-maven-plugin since
-         GWT compiler 2.8 and above requires 1.8 (see gwt-maven-plugin block below) -->
+         GWT compiler 2.12.0 and above requires 11 (see gwt-maven-plugin block below) -->
     <maven.compiler.source>11</maven.compiler.source>
     <maven.compiler.target>11</maven.compiler.target>
 
@@ -83,9 +83,9 @@
           <moduleName>@moduleName</moduleName>
           <moduleShortName>@moduleShortName</moduleShortName>
           <failOnError>true</failOnError>
-          <!-- GWT compiler 2.8 and above requires 1.8, hence define sourceLevel here if you use
+          <!-- GWT compiler 2.12.0 and above requires 11, hence define sourceLevel here if you use
                a different source language for java compilation -->
-          <sourceLevel>11</sourceLevel>
+          <release>11</release>
           <!-- Compiler configuration -->
           <compilerArgs>
             <!-- Ask GWT to create the Story of Your Compile (SOYC) (gwt:compile) -->

--- a/user/src/com/google/gwt/user/tools/templates/maven/pom.xmlsrc
+++ b/user/src/com/google/gwt/user/tools/templates/maven/pom.xmlsrc
@@ -15,8 +15,7 @@
     <!-- Setting maven.compiler.source to something different to 11
          needs that you configure the sourceLevel in gwt-maven-plugin since
          GWT compiler 2.12.0 and above requires 11 (see gwt-maven-plugin block below) -->
-    <maven.compiler.source>11</maven.compiler.source>
-    <maven.compiler.target>11</maven.compiler.target>
+    <maven.compiler.release>11</maven.compiler.release>
 
     <!-- Don't let your Mac use a crazy non-standard encoding -->
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>


### PR DESCRIPTION
change minimum java source level in the WebAppCreator sample from 1.7, 1.8 to 11
