### PR TITLE
Ignore all annotations in all scopes if source is missing

### DIFF
--- a/dev/core/src/com/google/gwt/dev/javac/BinaryTypeReferenceRestrictionsChecker.java
+++ b/dev/core/src/com/google/gwt/dev/javac/BinaryTypeReferenceRestrictionsChecker.java
@@ -25,6 +25,7 @@ import org.eclipse.jdt.internal.compiler.ast.SingleMemberAnnotation;
 import org.eclipse.jdt.internal.compiler.impl.Constant;
 import org.eclipse.jdt.internal.compiler.lookup.BinaryTypeBinding;
 import org.eclipse.jdt.internal.compiler.lookup.BlockScope;
+import org.eclipse.jdt.internal.compiler.lookup.ClassScope;
 import org.eclipse.jdt.internal.compiler.lookup.SourceTypeBinding;
 
 import java.util.ArrayList;
@@ -80,7 +81,19 @@ public class BinaryTypeReferenceRestrictionsChecker {
     }
 
     @Override
+    public boolean visit(MarkerAnnotation annotation, ClassScope scope) {
+      // Ignore annotations
+      return false;
+    }
+
+    @Override
     public boolean visit(NormalAnnotation annotation, BlockScope scope) {
+      // Ignore annotations
+      return false;
+    }
+
+    @Override
+    public boolean visit(NormalAnnotation annotation, ClassScope scope) {
       // Ignore annotations
       return false;
     }
@@ -92,14 +105,19 @@ public class BinaryTypeReferenceRestrictionsChecker {
     }
 
     @Override
+    public boolean visit(SingleMemberAnnotation annotation, ClassScope scope) {
+      // Ignore annotations
+      return false;
+    }
+
+    @Override
     protected void onBinaryTypeRef(BinaryTypeBinding binding,
         CompilationUnitDeclaration unitOfReferrer, Expression expression) {
       if (expression.constant != null && expression.constant != Constant.NotAConstant) {
         // Allow compile time constants from classes provided only in binary form.
         return;
       }
-      binaryTypeReferenceSites.add(new BinaryTypeReferenceSite(expression,
-          binding));
+      binaryTypeReferenceSites.add(new BinaryTypeReferenceSite(expression, binding));
     }
 
     @Override

--- a/dev/core/test/com/google/gwt/dev/jjs/impl/AnnotationCompilerTest.java
+++ b/dev/core/test/com/google/gwt/dev/jjs/impl/AnnotationCompilerTest.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2024 GWT Project Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.gwt.dev.jjs.impl;
+
+import com.google.gwt.core.ext.UnableToCompleteException;
+import com.google.gwt.thirdparty.guava.common.base.Joiner;
+
+public class AnnotationCompilerTest extends FullCompileTestBase {
+  @Override
+  protected void optimizeJava() {
+  }
+
+  public void testUseAnnotationWithoutSource() throws UnableToCompleteException {
+    // The JDT represents annotations as three kinds: markers, which have no members,
+    // single-member, which have only one member, and normal, which have more than one.
+    // This test validates that all three work in two cases each: block scope, and class
+    // scope.
+
+    String annotations = Joiner.on(" ").join(
+        "@SampleBytecodeOnlyMarkerAnnotation",
+        "@SampleBytecodeOnlySingleMemberAnnotation(\"abc\")",
+        "@SampleBytecodeOnlyNormalAnnotation(a=1, b=2)"
+    );
+
+    String code = Joiner.on('\n').join(
+        "package test;",
+        "import com.google.gwt.dev.jjs.impl.*;",
+        "public class EntryPoint<T extends " + annotations + " Object> {",
+        "  public static void onModuleLoad() {",
+        "  }",
+        "  " + annotations + " public String foo() {",
+        "  return \"\";",
+        "  }",
+        "}");
+
+    compileSnippetToJS(code);
+  }
+}

--- a/dev/core/test/com/google/gwt/dev/jjs/impl/SampleBytecodeOnlyMarkerAnnotation.java
+++ b/dev/core/test/com/google/gwt/dev/jjs/impl/SampleBytecodeOnlyMarkerAnnotation.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2024 GWT Project Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.gwt.dev.jjs.impl;
+
+/**
+ * Annotation with no bytecode for GWT, and no members.
+ */
+public @interface SampleBytecodeOnlyMarkerAnnotation {
+}

--- a/dev/core/test/com/google/gwt/dev/jjs/impl/SampleBytecodeOnlyNormalAnnotation.java
+++ b/dev/core/test/com/google/gwt/dev/jjs/impl/SampleBytecodeOnlyNormalAnnotation.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2024 GWT Project Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.gwt.dev.jjs.impl;
+
+/**
+ * Annotation with no bytecode for GWT, and multiple members.
+ */
+public @interface SampleBytecodeOnlyNormalAnnotation {
+  int a();
+  int b();
+}

--- a/dev/core/test/com/google/gwt/dev/jjs/impl/SampleBytecodeOnlySingleMemberAnnotation.java
+++ b/dev/core/test/com/google/gwt/dev/jjs/impl/SampleBytecodeOnlySingleMemberAnnotation.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2024 GWT Project Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.gwt.dev.jjs.impl;
+
+/**
+ * Annotation with no bytecode for GWT, and a single member.
+ */
+public @interface SampleBytecodeOnlySingleMemberAnnotation {
+  String value();
+}


### PR DESCRIPTION
JDT supports three kinds of annotations, and the ASTVisitor lets them be encountered in two different scopes. This patch ensures that all six cases are handled, and adds a test that uses each of the six cases - removing any one of the `visit` implementations will fail the test by incorrectly reporting the annotation as not having sources available.

Fixes #10020