### PR TITLE
Remove broken JSNI references from MSIE cleanup

### DIFF
--- a/user/test/com/google/gwt/canvas/client/CanvasTest.java
+++ b/user/test/com/google/gwt/canvas/client/CanvasTest.java
@@ -31,14 +31,6 @@ import com.google.gwt.user.client.ui.RootPanel;
  */
 @DoNotRunWith(Platform.HtmlUnitUnknown)
 public class CanvasTest extends GWTTestCase {
-  private static native boolean isFirefox35OrLater() /*-{
-    var geckoVersion = @com.google.gwt.dom.client.DOMImplMozilla::getGeckoVersion()();
-    return (geckoVersion != -1) && (geckoVersion >= 1009001);
-  }-*/;
-
-  private static native boolean isWebkit525OrBefore() /*-{
-    return @com.google.gwt.dom.client.DOMImplWebkit::isWebkit525OrBefore()();
-  }-*/;
 
   protected Canvas canvas1;
 
@@ -62,12 +54,6 @@ public class CanvasTest extends GWTTestCase {
       return; // don't continue if not supported
     }
 
-    // Safari 3.0 does not support toDataURL(), so the following tests are
-    // disabled for Safari 3.0 and before.
-    if (isWebkit525OrBefore()) {
-      return;
-    }
-
     canvas1.setHeight("0px");
     canvas1.setWidth("0px");
     assertEquals(0, canvas1.getOffsetHeight());
@@ -83,12 +69,6 @@ public class CanvasTest extends GWTTestCase {
   public void testDataUrlWithType() {
     if (canvas1 == null) {
       return; // don't continue if not supported
-    }
-
-    // Safari 3.0 does not support toDataURL(), so the following tests are
-    // disabled for Safari 3.0 and before.
-    if (isWebkit525OrBefore()) {
-      return;
     }
 
     canvas1.setHeight("10px");
@@ -169,10 +149,8 @@ public class CanvasTest extends GWTTestCase {
     }
     // test the isxxxSupported() call if running known-sup or known-not-sup
     // browsers
-    if (isFirefox35OrLater()) {
-      assertTrue(Canvas.isSupported());
-      assertTrue(Canvas.isSupported());
-    }
+    assertTrue(Canvas.isSupported());
+    assertTrue(Canvas.isSupported());
   }
 
   @Override

--- a/user/test/com/google/gwt/canvas/dom/client/Context2dTest.java
+++ b/user/test/com/google/gwt/canvas/dom/client/Context2dTest.java
@@ -41,14 +41,6 @@ public class Context2dTest extends GWTTestCase {
   protected Canvas canvas1;
   protected Canvas canvas2;
 
-  native boolean isGecko190OrBefore() /*-{
-    return @com.google.gwt.dom.client.DOMImplMozilla::isGecko190OrBefore()();
-  }-*/;
-
-  native boolean isWebkit525OrBefore() /*-{
-    return @com.google.gwt.dom.client.DOMImplWebkit::isWebkit525OrBefore()();
-  }-*/;
-
   @Override
   public String getModuleName() {
     return "com.google.gwt.canvas.Canvas";
@@ -100,12 +92,6 @@ public class Context2dTest extends GWTTestCase {
   public void testFillRect() {
     if (canvas1 == null) {
       return; // don't continue if not supported
-    }
-
-    // Safari 3.0 does not support getImageData(), so the following tests are disabled for
-    // Safari 3.0 and before.
-    if (isWebkit525OrBefore()) {
-      return;
     }
 
     canvas1.setHeight("40px");
@@ -232,12 +218,6 @@ public class Context2dTest extends GWTTestCase {
       return; // don't continue if not supported
     }
 
-    // Safari 3.0 does not support getImageData(), so the following tests are disabled for
-    // Safari 3.0 and before.
-    if (isWebkit525OrBefore()) {
-      return;
-    }
-
     canvas1.setHeight("40px");
     canvas1.setWidth("60px");
     canvas1.setCoordinateSpaceHeight(40);
@@ -276,18 +256,6 @@ public class Context2dTest extends GWTTestCase {
   public void testImageData() {
     if (canvas1 == null) {
       return; // don't continue if not supported
-    }
-    
-    // Firefox 3.0 does not support createImageData(), so the following tests are disabled
-    // for FF 3.0 and before.
-    if (isGecko190OrBefore()) {
-      return;
-    }
-
-    // Safari 3.0 does not support getImageData(), so the following tests are disabled for
-    // Safari 3.0 and before.
-    if (isWebkit525OrBefore()) {
-      return;
     }
 
     canvas1.setHeight("40px");
@@ -406,12 +374,6 @@ public class Context2dTest extends GWTTestCase {
       return; // don't continue if not supported
     }
 
-    // Safari 3.0 does not support getImageData(), so the following tests are disabled for
-    // Safari 3.0 and before.
-    if (isWebkit525OrBefore()) {
-      return;
-    }
-
     canvas1.setHeight("40px");
     canvas1.setWidth("60px");
     canvas1.setCoordinateSpaceHeight(40);
@@ -435,12 +397,6 @@ public class Context2dTest extends GWTTestCase {
   public void testShadows() {
     if (canvas1 == null) {
       return; // don't continue if not supported
-    }
-    
-    // Firefox 3.0 returns the incorrect shadowBlur value so the following tests are disabled
-    // for FF 3.0 and before.
-    if (isGecko190OrBefore()) {
-      return;
     }
 
     canvas1.setHeight("40px");

--- a/user/test/com/google/gwt/storage/client/StorageTest.java
+++ b/user/test/com/google/gwt/storage/client/StorageTest.java
@@ -28,15 +28,6 @@ public abstract class StorageTest extends GWTTestCase {
   protected StorageEvent.Handler handler;
   protected StorageEvent.Handler handler2;
 
-  private native boolean isFirefox35OrLater() /*-{
-    var geckoVersion = @com.google.gwt.dom.client.DOMImplMozilla::getGeckoVersion()();
-    return (geckoVersion != -1) && (geckoVersion >= 1009001);
-  }-*/;
-
-  private native boolean isSafari3OrBefore() /*-{
-    return @com.google.gwt.dom.client.DOMImplWebkit::isWebkit525OrBefore()();
-  }-*/;
-
   @Override
   public String getModuleName() {
     return "com.google.gwt.storage.Storage";
@@ -400,18 +391,9 @@ public abstract class StorageTest extends GWTTestCase {
   }
 
   public void testSupported() {
-    // test the isxxxSupported() call
-    if (isFirefox35OrLater()) {
-      assertNotNull(storage);
-      assertTrue(Storage.isLocalStorageSupported());
-      assertTrue(Storage.isSessionStorageSupported());
-      assertTrue(Storage.isSupported());
-    }
-    if (isSafari3OrBefore()) {
-      assertNull(storage);
-      assertFalse(Storage.isLocalStorageSupported());
-      assertFalse(Storage.isSessionStorageSupported());
-      assertFalse(Storage.isSupported());
-    }
+    assertNotNull(storage);
+    assertTrue(Storage.isLocalStorageSupported());
+    assertTrue(Storage.isSessionStorageSupported());
+    assertTrue(Storage.isSupported());
   }
 }


### PR DESCRIPTION
The previous PR broke three tests which still had JSNI references to removed methods - not caught by the "compile.tests" task. This patch finishes removing these checks in tests, so that we never skip certain assertions based on old browsers, which no longer exist.

Follow-up #10014