### PR TITLE
Correct handling for SwitchStatements without a containing Block

### DIFF
--- a/dev/core/test/com/google/gwt/dev/jjs/impl/Java17AstTest.java
+++ b/dev/core/test/com/google/gwt/dev/jjs/impl/Java17AstTest.java
@@ -397,6 +397,65 @@ public class Java17AstTest extends FullCompileTestBase {
           "}");
   }
 
+  // The JDT ast nodes for both switch statements and expressions extend Expression, and specific
+  // ast builder traversals previously. Test switch expressions/statements where statements/blocks
+  // can be encountered.
+  public void testSwitchesWithoutBlocks() throws UnableToCompleteException {
+    compileSnippet("void",
+        "for (int i = 0; i < 10; i++) " +
+            "  switch(i) { " +
+            "    case 1: break;" +
+            "    case 2: " +
+            "    default:" +
+            "  }");
+    compileSnippet("void",
+        "for (int i : new int[] {1, 2, 3, 4}) " +
+            "  switch(i) { " +
+            "    case 1:" +
+            "    case 2:" +
+            "    default:" +
+            "  }");
+    compileSnippet("void",
+        "switch (4) {" +
+            "case 1:" +
+            "  switch (2) {" +
+            "    case 2:" +
+            "    case 4:" +
+            "    default:" +
+            "  }" +
+            "}");
+    compileSnippet("void",
+        "if (true == false) " +
+            "  switch (7) {" +
+            "    case 4: {" +
+            "      break;" +
+            "    }" +
+            "  }" +
+            "else " +
+            "  switch (8) {" +
+            "    case 9:" +
+            "  }");
+
+    compileSnippet("void",
+        "while(true)" +
+            "  switch(99) { " +
+            "    default:" +
+            "  }");
+
+    compileSnippet("void",
+        "do" +
+            "  switch(0) { " +
+            "    default:" +
+            "  }" +
+            "while (false);");
+
+    compileSnippet("void",
+        "foo:" +
+            "  switch(123) { " +
+            "    default:" +
+            "  }");
+  }
+
   @Override
   protected void optimizeJava() {
   }


### PR DESCRIPTION
Also fixed incorrect generics for related code, spotted while auditing other incomplete typechecks.

Fixes #10024
See #10027