### PR TITLE
Support -strict in test arguments

### DIFF
--- a/user/build.xml
+++ b/user/build.xml
@@ -1,7 +1,7 @@
 <project name="user" default="build" basedir=".">
   <property name="gwt.root" location=".."/>
   <property name="project.tail" value="user"/>
-  <property name="test.args" value="-ea -sourceLevel auto -strict"/>
+  <property name="test.args" value="-ea -sourceLevel auto"/>
   <property name="test.jvmargs" value="-ea"/>
 
   <!-- support old variables names -->

--- a/user/build.xml
+++ b/user/build.xml
@@ -1,7 +1,7 @@
 <project name="user" default="build" basedir=".">
   <property name="gwt.root" location=".."/>
   <property name="project.tail" value="user"/>
-  <property name="test.args" value="-ea -sourceLevel auto"/>
+  <property name="test.args" value="-ea -sourceLevel auto -strict"/>
   <property name="test.jvmargs" value="-ea"/>
 
   <!-- support old variables names -->

--- a/user/src/com/google/gwt/junit/JUnitShell.java
+++ b/user/src/com/google/gwt/junit/JUnitShell.java
@@ -60,6 +60,7 @@ import com.google.gwt.dev.util.arg.ArgHandlerOptimize;
 import com.google.gwt.dev.util.arg.ArgHandlerScriptStyle;
 import com.google.gwt.dev.util.arg.ArgHandlerSetProperties;
 import com.google.gwt.dev.util.arg.ArgHandlerSourceLevel;
+import com.google.gwt.dev.util.arg.ArgHandlerStrict;
 import com.google.gwt.dev.util.arg.ArgHandlerWarDir;
 import com.google.gwt.dev.util.arg.ArgHandlerWorkDirOptional;
 import com.google.gwt.junit.JUnitMessageQueue.ClientStatus;
@@ -299,6 +300,7 @@ public class JUnitShell extends DevMode {
       registerHandler(new ArgHandlerFilterJsInteropExports(options));
       registerHandler(new ArgHandlerSetProperties(options));
       registerHandler(new ArgHandlerClosureFormattedOutput(options));
+      registerHandler(new ArgHandlerStrict(options));
 
       /*
        * ----- Options specific to JUnitShell -----

--- a/user/test/com/google/gwt/junit/JUnitShellTest.java
+++ b/user/test/com/google/gwt/junit/JUnitShellTest.java
@@ -45,7 +45,7 @@ public class JUnitShellTest extends TestCase {
   public void testArgOptimize() throws Exception {
     parseGoodArgs("-optimize", "8", "-XdisableInlineLiteralParameters",
         "-XdisableRemoveDuplicateFunctions", "-XdisableClusterSimilarFunctions",
-        "-XdisableOrdinalizeEnums", "-XdisableOptimizeDataflow");
+        "-XdisableOrdinalizeEnums", "-XdisableOptimizeDataflow", "-strict");
   }
 
   private void parseGoodArgs(String... argsToUse) {


### PR DESCRIPTION
We cannot yet enable this for all of GWT's own tests, see #10038 for that followup. That said, that failure confirms that this feature is working as expected.

Fixes #10037