### PR TITLE
Bump javac release to 11

### DIFF
--- a/common.ant.xml
+++ b/common.ant.xml
@@ -54,7 +54,7 @@
   <property name="javac.debug" value="true"/>
   <property name="javac.debuglevel" value="lines,vars,source"/>
   <property name="javac.encoding" value="utf-8"/>
-  <property name="javac.release" value="8"/>
+  <property name="javac.release" value="11"/>
   <property name="javac.nowarn" value="true"/>
 
   <!-- javac and errorprone instructions from https://errorprone.info/docs/installation#ant -->

--- a/dev/core/test/com/google/gwt/dev/javac/GeneratedClassnameFinderTest.java
+++ b/dev/core/test/com/google/gwt/dev/javac/GeneratedClassnameFinderTest.java
@@ -105,36 +105,39 @@ public class GeneratedClassnameFinderTest extends TestCase {
     assertEquals(0, new EnumTester().getGeneratedClasses().size());
   }
 
+  /**
+   * This test requires a lot of care and feeding to keep track of which version of Java the test
+   * classes were built with, and what the current release version is.
+   */
   public void testJavacWeirdness() {
     List<String> classNames = new JavacWeirdnessTester().getGeneratedClasses();
-    if (classNames.size() == 4) {
-      // javac8:
-      // JavacWeirdnessTester$1
+    if (classNames.size() == 3) {
+      // javac 11 with --release=11:
+      // javac 17 with --release=11:
+      // javac 21 with --release=11:
       // JavacWeirdnessTester$2
       // JavacWeirdnessTester$2Foo
       // JavacWeirdnessTester$3Foo
       assertFalse(classNames.get(0) + " should not contain Foo",
               classNames.get(0).contains("Foo"));
-      assertFalse(classNames.get(1) + " should not contain Foo",
-              classNames.get(1).contains("Foo"));
+      assertTrue(classNames.get(1) + " should contain Foo", classNames.get(1).contains("Foo"));
       assertTrue(classNames.get(2) + " should contain Foo", classNames.get(2).contains("Foo"));
-      assertTrue(classNames.get(3) + " should contain Foo", classNames.get(3).contains("Foo"));
     } else if (classNames.size() == 5) {
-      // javac22:
+      // javac 22 with --release=11:
       // JavacWeirdnessTester$1
       // JavacWeirdnessTester$2
       // JavacWeirdnessTester$1Foo
       // JavacWeirdnessTester$2Foo
       // JavacWeirdnessTester$3Foo
       assertFalse(classNames.get(0) + " should not contain Foo",
-              classNames.get(0).contains("Foo"));
+          classNames.get(0).contains("Foo"));
       assertFalse(classNames.get(1) + " should not contain Foo",
-              classNames.get(1).contains("Foo"));
+          classNames.get(1).contains("Foo"));
       assertTrue(classNames.get(2) + " should contain Foo", classNames.get(2).contains("Foo"));
       assertTrue(classNames.get(3) + " should contain Foo", classNames.get(2).contains("Foo"));
       assertTrue(classNames.get(4) + " should contain Foo", classNames.get(3).contains("Foo"));
     } else {
-      fail("Expected 4 or 5 classes, found " + classNames);
+      fail("Expected 3 classes, found " + classNames);
     }
   }
 

--- a/doc/build.xml
+++ b/doc/build.xml
@@ -144,7 +144,7 @@
                  sourcepath="${gwt.root}/user/super/com/google/gwt/emul:${gwt.root}/dev/core/super/com/google/gwt/dev/jjs/intrinsic"
                  encoding="UTF-8"
                  access="public"
-                 source="${javac.release}"
+                 source="8"
                  packagenames="${JAVA_PKGS}"
                  docletpath="${project.build}/../build_tools/doctool/bin"
                  doclet="com.google.doctool.custom.JavaEmulSummaryDoclet">


### PR DESCRIPTION
Going forward, GWT builds will contain Java 11 bytecode and be able to use Java 11 language and jre improvements.

The Emulation Summary doclet is left on Java 8, as setting the source level higher causes errors due to redefining classes in java.base etc. 