### PR TITLE
Implement Java 8 String.split() semantics

### DIFF
--- a/user/super/com/google/gwt/emul/java/lang/String.java
+++ b/user/super/com/google/gwt/emul/java/lang/String.java
@@ -654,7 +654,7 @@ public final class String implements Comparable<String>, CharSequence,
       } else {
         int matchIndex = matchObj.getIndex();
 
-        if (lastTrail == null && matchIndex == 0) {
+        if (lastTrail == null && matchIndex == 0 && matchObj.asArray()[0].length() == 0) {
           // As of Java 8, we should discard the first zero-length match if it is the beginning of
           // the string. Do not increment the count, and do not add to the output array.
           trail = trail.substring(matchIndex + matchObj.asArray()[0].length(), trail.length());

--- a/user/super/com/google/gwt/emul/java/lang/String.java
+++ b/user/super/com/google/gwt/emul/java/lang/String.java
@@ -647,10 +647,22 @@ public final class String implements Comparable<String>, CharSequence,
       // subgroup handling
       NativeRegExp.Match matchObj = compiled.exec(trail);
       if (matchObj == null || trail == "" || (count == (maxMatch - 1) && maxMatch > 0)) {
+        // At the end of the string, or we have performed the maximum number of matches,
+        // record the remaining string and break
         out[count] = trail;
         break;
       } else {
         int matchIndex = matchObj.getIndex();
+
+        if (lastTrail == null && matchIndex == 0) {
+          // As of Java 8, we should discard the first zero-length match if it is the beginning of
+          // the string. Do not increment the count, and do not add to the output array.
+          trail = trail.substring(matchIndex + matchObj.asArray()[0].length(), trail.length());
+          compiled.lastIndex = 0;
+          lastTrail = trail;
+          continue;
+        }
+
         out[count] = trail.substring(0, matchIndex);
         trail = trail.substring(matchIndex + matchObj.asArray()[0].length(), trail.length());
         // Force the compiled pattern to reset internal state

--- a/user/test/com/google/gwt/emultest/java/lang/CompilerConstantStringTest.java
+++ b/user/test/com/google/gwt/emultest/java/lang/CompilerConstantStringTest.java
@@ -245,15 +245,30 @@ public class CompilerConstantStringTest extends GWTTestCase {
         "b", "", ":and:f"});
     compareList("0:", "boo:and:foo".split(":", 0), new String[] {
         "boo", "and", "foo"});
-  }
+    // issue 2742
+    compareList("issue2742", new String[] {}, "/".split("/", 0));
+
+    // Splitting an empty string should result in an array containing a single
+    // empty string.
+    String[] s = "".split(",");
+    assertTrue(s != null);
+    assertTrue(s.length == 1);
+    assertTrue(s[0] != null);
+    assertTrue(s[0].length() == 0);
+
+    s = "abcada".split("a");
+    assertTrue(s != null);
+    assertEquals(3, s.length);
+    assertEquals("", s[0]);
+    assertEquals("bc", s[1]);
+    assertEquals("d", s[2]);  }
 
   public void testSplit_emptyExpr() {
-    // TODO(rluble):  implement JDK8 string.split semantics and fix test.
-    // See issue 8913.
-    String[] expected = (TestUtils.getJdkVersion() > 7) ?
-        new String[] {"a", "b", "c", "x", "x", "d", "e", "x", "f", "x"} :
-        new String[] {"", "a", "b", "c", "x", "x", "d", "e", "x", "f", "x"};
+    String[] expected = new String[] {"a", "b", "c", "x", "x", "d", "e", "x", "f", "x"};
     compareList("emptyRegexSplit", expected, "abcxxdexfx".split(""));
+
+    String[] arr = ",".split(",");
+    assertEquals(0, arr.length);
   }
 
   public void testStartsWith() {

--- a/user/test/com/google/gwt/emultest/java/lang/CompilerConstantStringTest.java
+++ b/user/test/com/google/gwt/emultest/java/lang/CompilerConstantStringTest.java
@@ -16,7 +16,6 @@
 package com.google.gwt.emultest.java.lang;
 
 import com.google.gwt.junit.client.GWTTestCase;
-import com.google.gwt.testing.TestUtils;
 
 import java.util.Locale;
 

--- a/user/test/com/google/gwt/emultest/java/lang/StringTest.java
+++ b/user/test/com/google/gwt/emultest/java/lang/StringTest.java
@@ -789,11 +789,8 @@ public class StringTest extends GWTTestCase {
   }
 
   public void testSplit_emptyExpr() {
-    // TODO(rluble):  implement JDK8 string.split semantics and fix test.
-    String[] expected = (TestUtils.getJdkVersion() > 7) ?
-        new String[] {"a", "b", "c", "x", "x", "d", "e", "x", "f", "x"} :
-        new String[] {"", "a", "b", "c", "x", "x", "d", "e", "x", "f", "x"};
-    compareList("emptyRegexSplit", expected, "abcxxdexfx".split(""));
+    String[] expected = new String[] {"a", "b", "c", "x", "x", "d", "e", "x", "f", "x"};
+    compareList("emptyRegexSplit", expected, hideFromCompiler("abcxxdexfx").split(""));
   }
 
   public void testStartsWith() {

--- a/user/test/com/google/gwt/emultest/java/lang/StringTest.java
+++ b/user/test/com/google/gwt/emultest/java/lang/StringTest.java
@@ -781,20 +781,30 @@ public class StringTest extends GWTTestCase {
 
     // Splitting an empty string should result in an array containing a single
     // empty string.
-    String[] s = "".split(",");
+    String[] s = hideFromCompiler("").split(",");
     assertTrue(s != null);
     assertTrue(s.length == 1);
     assertTrue(s[0] != null);
     assertTrue(s[0].length() == 0);
+
+    s = hideFromCompiler("abcada").split("a");
+    assertTrue(s != null);
+    assertEquals(3, s.length);
+    assertEquals("", s[0]);
+    assertEquals("bc", s[1]);
+    assertEquals("d", s[2]);
   }
 
   public void testSplit_emptyExpr() {
     String[] expected = new String[] {"a", "b", "c", "x", "x", "d", "e", "x", "f", "x"};
     compareList("emptyRegexSplit", expected, hideFromCompiler("abcxxdexfx").split(""));
+
+    String[] arr = hideFromCompiler(",").split(",");
+    assertEquals(0, arr.length);
   }
 
   public void testStartsWith() {
-    String haystack = "abcdefghi";
+    String haystack = hideFromCompiler("abcdefghi");
     assertTrue(haystack.startsWith("abc"));
     assertTrue(haystack.startsWith("bc", 1));
     assertTrue(haystack.startsWith(haystack));


### PR DESCRIPTION
In Java 8, String.split() changed to not return an initial empty string on a zero-width match. This patch brings GWT's String emulation in compliance with that specification change.

Added additional tests for non-zero-width matches and verifying behavior on all-empty matches. Compile time constant tests also updated to match.

Fixes #8868