### PR TITLE
JettyLauncher to allow all javax.sql.* classes to be loaded, Issue #9582

### DIFF
--- a/dev/core/src/com/google/gwt/dev/shell/jetty/JettyLauncher.java
+++ b/dev/core/src/com/google/gwt/dev/shell/jetty/JettyLauncher.java
@@ -295,6 +295,7 @@ public class JettyLauncher extends ServletContainerLauncher {
           // Xerces
           "org.apache.xerces.",
           "javax.xml.", // Used by Jetty for jetty-web.xml parsing
+          "javax.sql.*",
       });
 
       public WebAppClassLoaderExtension() throws IOException {


### PR DESCRIPTION
Issue #9582

Latest Jetty launcher with GWT and superdev mode fails without this when loading any classes related to JDBC access.
