### PR TITLE
Allow lambdas in this()/super() to close over outer types

### DIFF
--- a/dev/core/src/com/google/gwt/dev/jjs/impl/GwtAstBuilder.java
+++ b/dev/core/src/com/google/gwt/dev/jjs/impl/GwtAstBuilder.java
@@ -3612,7 +3612,7 @@ public class GwtAstBuilder {
         // Synthetic locals for local classes
         if (targetBinding.syntheticOuterLocalVariables() != null) {
           for (SyntheticArgumentBinding arg : targetBinding.syntheticOuterLocalVariables()) {
-            LocalVariableBinding targetVariable = arg.actualOuterLocalVariable;
+            LocalVariableBinding targetVariable = arg.actualOuterLocalVariable;// this may be wrong too
             VariableBinding[] path = scope.getEmulationPath(targetVariable);
             assert path.length == 1;
             if (curMethod.scope.isInsideInitializer()

--- a/dev/core/src/com/google/gwt/dev/jjs/impl/GwtAstBuilder.java
+++ b/dev/core/src/com/google/gwt/dev/jjs/impl/GwtAstBuilder.java
@@ -1237,31 +1237,27 @@ public class GwtAstBuilder {
 
     @Override
     public boolean visit(LambdaExpression x, BlockScope blockScope) {
-      try {
-        // Fetch the variables 'captured' by this lambda
-        SyntheticArgumentBinding[] synthArgs = x.outerLocalVariables;
-        // Get the parameter names, captured locals + lambda arguments
-        String paramNames[] = computeCombinedParamNames(x, synthArgs);
-        SourceInfo info = makeSourceInfo(x);
-        // JDT synthesizes a method lambda$n(capture1, capture2, ..., lambda_arg1, lambda_arg2, ...)
-        // Here we create a JMethod from this
-        JMethod lambdaMethod = createMethodFromBinding(info, x.binding, paramNames);
-        // Because the lambda implementations is synthesized as a static method in the
-        // enclosing class, it needs to be adjusted if that class happens to be a JsType.
-        lambdaMethod.setJsMemberInfo(JsMemberType.NONE, null, null, false);
-        if (curClass.type.isJsNative()) {
-          lambdaMethod.setJsOverlay();
-        }
-        JMethodBody methodBody = new JMethodBody(info);
-        lambdaMethod.setBody(methodBody);
-        // We need to push this method  on the stack as it introduces a scope, and
-        // expressions in the body need to lookup variable refs like parameters from it
-        pushMethodInfo(new MethodInfo(lambdaMethod, methodBody, x.scope));
-        pushLambdaExpressionLocalsIntoMethodScope(x, synthArgs, lambdaMethod);
-        // now the body of the lambda is processed
-      } catch (Throwable e) {
-        throw translateException(x, e);
+      // Fetch the variables 'captured' by this lambda
+      SyntheticArgumentBinding[] synthArgs = x.outerLocalVariables;
+      // Get the parameter names, captured locals + lambda arguments
+      String paramNames[] = computeCombinedParamNames(x, synthArgs);
+      SourceInfo info = makeSourceInfo(x);
+      // JDT synthesizes a method lambda$n(capture1, capture2, ..., lambda_arg1, lambda_arg2, ...)
+      // Here we create a JMethod from this
+      JMethod lambdaMethod = createMethodFromBinding(info, x.binding, paramNames);
+      // Because the lambda implementations is synthesized as a static method in the
+      // enclosing class, it needs to be adjusted if that class happens to be a JsType.
+      lambdaMethod.setJsMemberInfo(HasJsInfo.JsMemberType.NONE, null, null, false);
+      if (curClass.type.isJsNative()) {
+        lambdaMethod.setJsOverlay();
       }
+      JMethodBody methodBody = new JMethodBody(info);
+      lambdaMethod.setBody(methodBody);
+      // We need to push this method  on the stack as it introduces a scope, and
+      // expressions in the body need to lookup variable refs like parameters from it
+      pushMethodInfo(new MethodInfo(lambdaMethod, methodBody, x.scope));
+      pushLambdaExpressionLocalsIntoMethodScope(x, synthArgs, lambdaMethod);
+      // now the body of the lambda is processed
       return true;
     }
 

--- a/dev/core/src/com/google/gwt/dev/jjs/impl/GwtAstBuilder.java
+++ b/dev/core/src/com/google/gwt/dev/jjs/impl/GwtAstBuilder.java
@@ -1267,7 +1267,12 @@ public class GwtAstBuilder {
       if (syntheticArguments != null) {
         MethodScope scope = x.getScope();
         for (SyntheticArgumentBinding sa : syntheticArguments) {
-          VariableBinding[] path = scope.getEmulationPath(sa);
+          VariableBinding[] path;
+          if (sa.actualOuterLocalVariable == null) {
+            path = scope.getEmulationPath(sa);
+          } else {
+            path = scope.getEmulationPath(sa.actualOuterLocalVariable);
+          }
           assert path.length == 1 && path[0] instanceof LocalVariableBinding;
           JParameter param = it.next();
           curMethod.locals.put((LocalVariableBinding) path[0], param);

--- a/dev/core/src/com/google/gwt/dev/jjs/impl/GwtAstBuilder.java
+++ b/dev/core/src/com/google/gwt/dev/jjs/impl/GwtAstBuilder.java
@@ -1237,27 +1237,31 @@ public class GwtAstBuilder {
 
     @Override
     public boolean visit(LambdaExpression x, BlockScope blockScope) {
-      // Fetch the variables 'captured' by this lambda
-      SyntheticArgumentBinding[] synthArgs = x.outerLocalVariables;
-      // Get the parameter names, captured locals + lambda arguments
-      String paramNames[] = computeCombinedParamNames(x, synthArgs);
-      SourceInfo info = makeSourceInfo(x);
-      // JDT synthesizes a method lambda$n(capture1, capture2, ..., lambda_arg1, lambda_arg2, ...)
-      // Here we create a JMethod from this
-      JMethod lambdaMethod = createMethodFromBinding(info, x.binding, paramNames);
-      // Because the lambda implementations is synthesized as a static method in the
-      // enclosing class, it needs to be adjusted if that class happens to be a JsType.
-      lambdaMethod.setJsMemberInfo(HasJsInfo.JsMemberType.NONE, null, null, false);
-      if (curClass.type.isJsNative()) {
-        lambdaMethod.setJsOverlay();
+      try {
+        // Fetch the variables 'captured' by this lambda
+        SyntheticArgumentBinding[] synthArgs = x.outerLocalVariables;
+        // Get the parameter names, captured locals + lambda arguments
+        String paramNames[] = computeCombinedParamNames(x, synthArgs);
+        SourceInfo info = makeSourceInfo(x);
+        // JDT synthesizes a method lambda$n(capture1, capture2, ..., lambda_arg1, lambda_arg2, ...)
+        // Here we create a JMethod from this
+        JMethod lambdaMethod = createMethodFromBinding(info, x.binding, paramNames);
+        // Because the lambda implementations is synthesized as a static method in the
+        // enclosing class, it needs to be adjusted if that class happens to be a JsType.
+        lambdaMethod.setJsMemberInfo(JsMemberType.NONE, null, null, false);
+        if (curClass.type.isJsNative()) {
+          lambdaMethod.setJsOverlay();
+        }
+        JMethodBody methodBody = new JMethodBody(info);
+        lambdaMethod.setBody(methodBody);
+        // We need to push this method  on the stack as it introduces a scope, and
+        // expressions in the body need to lookup variable refs like parameters from it
+        pushMethodInfo(new MethodInfo(lambdaMethod, methodBody, x.scope));
+        pushLambdaExpressionLocalsIntoMethodScope(x, synthArgs, lambdaMethod);
+        // now the body of the lambda is processed
+      } catch (Throwable e) {
+        throw translateException(x, e);
       }
-      JMethodBody methodBody = new JMethodBody(info);
-      lambdaMethod.setBody(methodBody);
-      // We need to push this method  on the stack as it introduces a scope, and
-      // expressions in the body need to lookup variable refs like parameters from it
-      pushMethodInfo(new MethodInfo(lambdaMethod, methodBody, x.scope));
-      pushLambdaExpressionLocalsIntoMethodScope(x, synthArgs, lambdaMethod);
-      // now the body of the lambda is processed
       return true;
     }
 

--- a/dev/core/src/com/google/gwt/dev/jjs/impl/GwtAstBuilder.java
+++ b/dev/core/src/com/google/gwt/dev/jjs/impl/GwtAstBuilder.java
@@ -3612,7 +3612,7 @@ public class GwtAstBuilder {
         // Synthetic locals for local classes
         if (targetBinding.syntheticOuterLocalVariables() != null) {
           for (SyntheticArgumentBinding arg : targetBinding.syntheticOuterLocalVariables()) {
-            LocalVariableBinding targetVariable = arg.actualOuterLocalVariable;// this may be wrong too
+            LocalVariableBinding targetVariable = arg.actualOuterLocalVariable;
             VariableBinding[] path = scope.getEmulationPath(targetVariable);
             assert path.length == 1;
             if (curMethod.scope.isInsideInitializer()

--- a/dev/core/src/com/google/gwt/dev/jjs/impl/GwtAstBuilder.java
+++ b/dev/core/src/com/google/gwt/dev/jjs/impl/GwtAstBuilder.java
@@ -1271,7 +1271,7 @@ public class GwtAstBuilder {
       if (syntheticArguments != null) {
         MethodScope scope = x.getScope();
         for (SyntheticArgumentBinding sa : syntheticArguments) {
-          VariableBinding[] path = scope.getEmulationPath(sa.actualOuterLocalVariable);
+          VariableBinding[] path = scope.getEmulationPath(sa);
           assert path.length == 1 && path[0] instanceof LocalVariableBinding;
           JParameter param = it.next();
           curMethod.locals.put((LocalVariableBinding) path[0], param);

--- a/user/test/com/google/gwt/dev/jjs/test/Java8Test.java
+++ b/user/test/com/google/gwt/dev/jjs/test/Java8Test.java
@@ -252,6 +252,39 @@ public class Java8Test extends GWTTestCase {
     assertEquals(82, new AcceptsLambda<Integer>().accept(l).intValue());
   }
 
+  class CtorAcceptsLambda {
+    CtorAcceptsLambda() {
+      this(() -> local = -1);
+    }
+    CtorAcceptsLambda(Runnable lambda) {
+      lambda.run();
+    }
+  }
+
+  public void testCompileLambdaOuterFieldCaptureInConstructor() {
+    assertEquals(42, local);
+    new CtorAcceptsLambda();
+    assertEquals(-1, local);
+  }
+
+  abstract class AbstractCtorAcceptsLambda {
+    AbstractCtorAcceptsLambda(Runnable lambda) {
+      lambda.run();
+    }
+  }
+
+  class CtorAcceptsLambdaSubtype extends AbstractCtorAcceptsLambda {
+    CtorAcceptsLambdaSubtype() {
+      super(() -> local = -1);
+    }
+  }
+
+  public void testCompileLambdaOuterFieldCaptureInConstructorSuper() throws Exception {
+    assertEquals(42, local);
+    new CtorAcceptsLambdaSubtype();
+    assertEquals(-1, local);
+  }
+
   public void testCompileLambdaCaptureOuterInnerField() throws Exception {
     new Inner().run();
   }


### PR DESCRIPTION
Prior to JDT 3.32, passing a lambda that closes over outer types to this()/super() constructors would result in a compiler error. As of around 3.32 this is now allowed, but the closed-over instance is passed as an item in a "synthetic outer local variable" collection. Each instance in that collection has a field representing the "actual outer local variable", and in this case, that field is null. 

Added tests to confirm that the generated code seems consistent, and that running such a lambda affects the expected instance.

Fixes #10065