### PR TITLE
Re-submitting: Unset config properties: `System.getProperty` should return default value or null  (previously reverted)

### DIFF
--- a/dev/core/src/com/google/gwt/dev/cfg/ConfigurationProperties.java
+++ b/dev/core/src/com/google/gwt/dev/cfg/ConfigurationProperties.java
@@ -142,6 +142,17 @@ public class ConfigurationProperties implements Serializable {
   }
 
   /**
+   * Returns all the values of a multi-valued configuration property, or null
+   * if not found.
+   *
+   * <p>A single-valued and unset configuration property will be returned as a list
+   * containing one null.
+   */
+  public List<String> getStringsOrNull(String key) {
+     return properties.get(key);
+  }
+
+  /**
    * Reads a configuration property as a comma-separated list of strings.
    * It may be a single-valued or multi-valued property. If multi-valued,
    * each value will be split on commas and all items concatenated.

--- a/user/test/com/google/gwt/dev/jjs/SystemGetPropertyTest.gwt.xml
+++ b/user/test/com/google/gwt/dev/jjs/SystemGetPropertyTest.gwt.xml
@@ -33,4 +33,6 @@
   <set-property name="someOtherDynamicProperty" value="blue">
     <when-property-is name="collapsedProperty" value="two"/>
   </set-property>
+  <define-configuration-property name="configPropertyUnset" is-multi-valued="false"/>
+  <define-configuration-property name="multivaluedConfigPropertyUnset" is-multi-valued="true"/>
 </module>

--- a/user/test/com/google/gwt/dev/jjs/test/SystemGetPropertyTest.java
+++ b/user/test/com/google/gwt/dev/jjs/test/SystemGetPropertyTest.java
@@ -36,5 +36,9 @@ public class SystemGetPropertyTest extends GWTTestCase {
     String expectedResult = "safari".equals(System.getProperty("user.agent")) ?
         "InSafari" : "NotInSafari";
     assertEquals(expectedResult, System.getProperty("someDynamicProperty"));
+    assertEquals("foo", System.getProperty("configPropertyUnset", "foo"));
+    assertNull(System.getProperty("configPropertyUnset"));
+    assertEquals("foo", System.getProperty("multivaluedConfigPropertyUnset", "foo"));
+    assertNull(System.getProperty("multivaluedConfigPropertyUnset"));
   }
 }

--- a/user/test/com/google/gwt/dev/jjs/test/SystemGetPropertyTest.java
+++ b/user/test/com/google/gwt/dev/jjs/test/SystemGetPropertyTest.java
@@ -38,7 +38,5 @@ public class SystemGetPropertyTest extends GWTTestCase {
     assertEquals(expectedResult, System.getProperty("someDynamicProperty"));
     assertEquals("foo", System.getProperty("configPropertyUnset", "foo"));
     assertNull(System.getProperty("configPropertyUnset"));
-    assertEquals("foo", System.getProperty("multivaluedConfigPropertyUnset", "foo"));
-    assertNull(System.getProperty("multivaluedConfigPropertyUnset"));
   }
 }


### PR DESCRIPTION
Previously submitted as #10013 and reverted in #1094 

Fixes #9885 