### PR TITLE
Fix Window.onClosing() not work in GWT 2.12

### DIFF
--- a/user/src/com/google/gwt/user/client/Window.java
+++ b/user/src/com/google/gwt/user/client/Window.java
@@ -853,7 +853,7 @@ public class Window {
   }
 
   static String onClosing() {
-    if (closeHandlersInitialized) {
+    if (beforeCloseHandlersInitialized) {
       Window.ClosingEvent event = new Window.ClosingEvent();
       fireEvent(event);
       return event.getMessage();


### PR DESCRIPTION
When Window.onClosing(), if beforeCloseHandlersInitialized (not closeHandlersInitialized) is true, fire the ClosingEvent.

Fixes #10072 
See #10074