### PR TITLE
Add emulation for Java 9 additions to Objects class

### DIFF
--- a/user/super/com/google/gwt/emul/java/util/Objects.java
+++ b/user/super/com/google/gwt/emul/java/util/Objects.java
@@ -153,6 +153,7 @@ public final class Objects {
   }
 
   public static int checkFromIndexSize(int fromIndex, int size, int length) {
+    // in JS fromIndex + size cannot overflow because int is not limited to 32 bits
     if (fromIndex < 0 || size < 0 || fromIndex + size > length) {
       throw new IndexOutOfBoundsException("Range [" + fromIndex + ", " + (fromIndex + size)
           + ") out of bounds for length " + length);

--- a/user/super/com/google/gwt/emul/java/util/Objects.java
+++ b/user/super/com/google/gwt/emul/java/util/Objects.java
@@ -129,6 +129,37 @@ public final class Objects {
     return obj;
   }
 
+  public static <T> T requireNonNullElse(T obj, T defaultObj) {
+    return obj != null ? obj : requireNonNull(defaultObj);
+  }
+
+  public static <T> T requireNonNullElseGet(T obj, Supplier<? extends T> supplier) {
+    return obj != null ? obj : requireNonNull(supplier.get());
+  }
+
+  public static int checkIndex(int index, int length) {
+    if (index < 0 || index >= length) {
+      new IndexOutOfBoundsException("Index " + index + " out of bounds for length " + length);
+    }
+    return index;
+  }
+
+  public static int checkFromToIndex(int fromIndex, int toIndex, int length) {
+    if (fromIndex < 0 || fromIndex > toIndex || toIndex > length) {
+      new IndexOutOfBoundsException("Range [" + fromIndex + ", " + toIndex
+          + ") out of bounds for length " + length);
+    }
+    return fromIndex;
+  }
+
+  public static int checkFromIndexSize(long fromIndex, long size, long length) {
+    if (fromIndex < 0 || size < 0 || fromIndex + size > length) {
+      new IndexOutOfBoundsException("Range [" + fromIndex + ", " + (fromIndex + size)
+          + ") out of bounds for length " + length);
+    }
+    return fromIndex;
+  }
+
   public static String toString(Object o) {
     return String.valueOf(o);
   }

--- a/user/super/com/google/gwt/emul/java/util/Objects.java
+++ b/user/super/com/google/gwt/emul/java/util/Objects.java
@@ -134,7 +134,7 @@ public final class Objects {
   }
 
   public static <T> T requireNonNullElseGet(T obj, Supplier<? extends T> supplier) {
-    return obj != null ? obj : requireNonNull(supplier.get());
+    return obj != null ? obj : requireNonNull(requireNonNull(supplier, "supplier").get());
   }
 
   public static int checkIndex(int index, int length) {

--- a/user/super/com/google/gwt/emul/java/util/Objects.java
+++ b/user/super/com/google/gwt/emul/java/util/Objects.java
@@ -139,22 +139,22 @@ public final class Objects {
 
   public static int checkIndex(int index, int length) {
     if (index < 0 || index >= length) {
-      new IndexOutOfBoundsException("Index " + index + " out of bounds for length " + length);
+      throw new IndexOutOfBoundsException("Index " + index + " out of bounds for length " + length);
     }
     return index;
   }
 
   public static int checkFromToIndex(int fromIndex, int toIndex, int length) {
     if (fromIndex < 0 || fromIndex > toIndex || toIndex > length) {
-      new IndexOutOfBoundsException("Range [" + fromIndex + ", " + toIndex
+      throw new IndexOutOfBoundsException("Range [" + fromIndex + ", " + toIndex
           + ") out of bounds for length " + length);
     }
     return fromIndex;
   }
 
-  public static int checkFromIndexSize(long fromIndex, long size, long length) {
+  public static int checkFromIndexSize(int fromIndex, int size, int length) {
     if (fromIndex < 0 || size < 0 || fromIndex + size > length) {
-      new IndexOutOfBoundsException("Range [" + fromIndex + ", " + (fromIndex + size)
+      throw new IndexOutOfBoundsException("Range [" + fromIndex + ", " + (fromIndex + size)
           + ") out of bounds for length " + length);
     }
     return fromIndex;

--- a/user/test/com/google/gwt/emultest/java/util/ObjectsTest.java
+++ b/user/test/com/google/gwt/emultest/java/util/ObjectsTest.java
@@ -173,7 +173,7 @@ public class ObjectsTest extends GWTTestCase {
       toTest.run();
       fail("Should have failed");
     } catch (Exception ex) {
-      assertEquals(ex.getClass(), thrownCheck);
+      assertEquals(thrownCheck, ex.getClass());
     }
   }
 }

--- a/user/test/com/google/gwt/emultest/java/util/ObjectsTest.java
+++ b/user/test/com/google/gwt/emultest/java/util/ObjectsTest.java
@@ -111,6 +111,7 @@ public class ObjectsTest extends GWTTestCase {
 
   public void testRequireNonNullElse() {
     assertEquals("foo", Objects.requireNonNullElse(hideFromCompiler("foo"), "bar"));
+    assertEquals("bar", Objects.requireNonNullElse(hideFromCompiler(null), "bar"));
     assertThrows(NullPointerException.class,
         () -> Objects.requireNonNullElse(hideFromCompiler(null), null));
   }
@@ -118,6 +119,8 @@ public class ObjectsTest extends GWTTestCase {
   public void testRequireNonNullElseGet() {
     assertEquals("foo",
         Objects.requireNonNullElseGet(hideFromCompiler("foo"), () -> "bar"));
+    assertEquals("bar",
+        Objects.requireNonNullElseGet(hideFromCompiler(null), () -> "bar"));
     assertThrows(NullPointerException.class,
         () -> Objects.requireNonNullElseGet(hideFromCompiler(null), null));
     assertThrows(NullPointerException.class,
@@ -137,10 +140,13 @@ public class ObjectsTest extends GWTTestCase {
         () -> Objects.checkIndex(-5, 5));
     assertThrows(IndexOutOfBoundsException.class,
         () -> Objects.checkIndex(10, 5));
+    assertThrows(IndexOutOfBoundsException.class,
+        () -> Objects.checkIndex(5, 5));
   }
 
   public void testCheckFromToIndex() {
     assertEquals(5, Objects.checkFromToIndex(5, 7, 10));
+    assertEquals(0, Objects.checkFromToIndex(0, 10, 10));
     assertThrows(IndexOutOfBoundsException.class,
         () -> Objects.checkFromToIndex(-5, 1, 5));
     assertThrows(IndexOutOfBoundsException.class,
@@ -151,12 +157,15 @@ public class ObjectsTest extends GWTTestCase {
 
   public void testCheckFromIndexSize() {
     assertEquals(5, Objects.checkFromIndexSize(5, 2, 10));
+    assertEquals(0, Objects.checkFromIndexSize(0, 10, 10));
     assertThrows(IndexOutOfBoundsException.class,
         () -> Objects.checkFromIndexSize(-5, 1, 5));
     assertThrows(IndexOutOfBoundsException.class,
         () -> Objects.checkFromIndexSize(10, 1,  5));
     assertThrows(IndexOutOfBoundsException.class,
         () -> Objects.checkFromIndexSize(1, 10,  5));
+    assertThrows(IndexOutOfBoundsException.class,
+        () -> Objects.checkFromIndexSize(1, -5,  5));
   }
 
   private void assertThrows(Class<? extends Exception> thrownCheck, Runnable toTest) {
@@ -166,6 +175,5 @@ public class ObjectsTest extends GWTTestCase {
     } catch (Exception ex) {
       assertEquals(ex.getClass(), thrownCheck);
     }
-
   }
 }

--- a/user/test/com/google/gwt/emultest/java/util/ObjectsTest.java
+++ b/user/test/com/google/gwt/emultest/java/util/ObjectsTest.java
@@ -102,4 +102,70 @@ public class ObjectsTest extends GWTTestCase {
     Object obj = new Object();
     assertEquals(obj.hashCode(), Objects.hashCode(obj));
   }
+
+  public void testRequireNonNull() {
+    assertEquals("foo", Objects.requireNonNull(hideFromCompiler("foo")));
+    assertThrows(NullPointerException.class,
+        () -> Objects.requireNonNull(hideFromCompiler(null)));
+  }
+
+  public void testRequireNonNullElse() {
+    assertEquals("foo", Objects.requireNonNullElse(hideFromCompiler("foo"), "bar"));
+    assertThrows(NullPointerException.class,
+        () -> Objects.requireNonNullElse(hideFromCompiler(null), null));
+  }
+
+  public void testRequireNonNullElseGet() {
+    assertEquals("foo",
+        Objects.requireNonNullElseGet(hideFromCompiler("foo"), () -> "bar"));
+    assertThrows(NullPointerException.class,
+        () -> Objects.requireNonNullElseGet(hideFromCompiler(null), null));
+    assertThrows(NullPointerException.class,
+        () -> Objects.requireNonNullElseGet(hideFromCompiler(null), () -> null));
+  }
+
+  private String hideFromCompiler(String value) {
+    if (Math.random() > 2) {
+      return "unreachable";
+    }
+    return value;
+  }
+
+  public void testCheckIndex() {
+    assertEquals(5, Objects.checkIndex(5, 10));
+    assertThrows(IndexOutOfBoundsException.class,
+        () -> Objects.checkIndex(-5, 5));
+    assertThrows(IndexOutOfBoundsException.class,
+        () -> Objects.checkIndex(10, 5));
+  }
+
+  public void testCheckFromToIndex() {
+    assertEquals(5, Objects.checkFromToIndex(5, 7, 10));
+    assertThrows(IndexOutOfBoundsException.class,
+        () -> Objects.checkFromToIndex(-5, 1, 5));
+    assertThrows(IndexOutOfBoundsException.class,
+        () -> Objects.checkFromToIndex(10, 1,  5));
+    assertThrows(IndexOutOfBoundsException.class,
+        () -> Objects.checkFromToIndex(1, 10,  5));
+  }
+
+  public void testCheckFromIndexSize() {
+    assertEquals(5, Objects.checkFromIndexSize(5, 2, 10));
+    assertThrows(IndexOutOfBoundsException.class,
+        () -> Objects.checkFromIndexSize(-5, 1, 5));
+    assertThrows(IndexOutOfBoundsException.class,
+        () -> Objects.checkFromIndexSize(10, 1,  5));
+    assertThrows(IndexOutOfBoundsException.class,
+        () -> Objects.checkFromIndexSize(1, 10,  5));
+  }
+
+  private void assertThrows(Class<? extends Exception> thrownCheck, Runnable toTest) {
+    try {
+      toTest.run();
+      fail("Should have failed");
+    } catch (Exception ex) {
+      assertEquals(ex.getClass(), thrownCheck);
+    }
+
+  }
 }


### PR DESCRIPTION
Add emulation for Objects methods
* requireNonNullElse
* requireNonNullElseGet
* checkIndex
* checkFromToIndex
* checkFromIndexSize

Does *not* cover the Java 16 versions of these that accept `long` instead of `int`.