### PR TITLE
Adds ability to add create a document comment, used in UiBinderUtils

### DIFF
--- a/user/src/com/google/gwt/dom/client/DOMImpl.java
+++ b/user/src/com/google/gwt/dom/client/DOMImpl.java
@@ -51,6 +51,10 @@ abstract class DOMImpl {
     return e;
   }-*/;
 
+  public native Node createComment(Document doc, String comment) /*-{
+    return doc.createComment(comment);
+  }-*/;
+
   public native Element createElement(Document doc, String tag) /*-{
     return doc.createElement(tag);
   }-*/;

--- a/user/src/com/google/gwt/dom/client/Document.java
+++ b/user/src/com/google/gwt/dom/client/Document.java
@@ -227,6 +227,16 @@ public class Document extends Node {
   }
 
   /**
+   * Creates a DOM comment
+   *
+   * @param comment
+   * @return the comment node
+   */
+  public final Node createComment(String comment) {
+    return DOMImpl.impl.createComment(this, comment);
+  }
+
+  /**
    * Creates a 'contextmenu' event.
    * 
    * Note: Contextmenu events will not dispatch properly on Firefox 2 and

--- a/user/src/com/google/gwt/uibinder/client/UiBinderUtil.java
+++ b/user/src/com/google/gwt/uibinder/client/UiBinderUtil.java
@@ -95,6 +95,7 @@ public class UiBinderUtil {
     if (hiddenDiv == null) {
       hiddenDiv = Document.get().createDivElement();
       UIObject.setVisible(hiddenDiv, false);
+      RootPanel.getBodyElement().appendChild(Document.get().createComment("Hidden element used internally by UiBinder."));
       RootPanel.getBodyElement().appendChild(hiddenDiv);
     }
   }


### PR DESCRIPTION
Adds the ability to create a comment node in the HTML document, used in UiBinderUtils to explain the hidden div for component developers to understand its origin. See issue #10125 .