### PR TITLE
Fix console log uses debug

### DIFF
--- a/user/src/com/google/gwt/logging/client/ConsoleLogHandler.java
+++ b/user/src/com/google/gwt/logging/client/ConsoleLogHandler.java
@@ -57,7 +57,7 @@ public class ConsoleLogHandler extends Handler {
     } else if (val >= Level.INFO.intValue()) {
       info(msg);
     } else {
-      log(msg);
+      logVerbose(msg);
     }
   }
 
@@ -77,7 +77,8 @@ public class ConsoleLogHandler extends Handler {
     window.console.info(message);
   }-*/;
 
-  private native void log(String message) /*-{
-    window.console.log(message);
+  private native void logVerbose(String message) /*-{
+    // use console.debug to show FINE and FINEST messages only when "Verbose" is enabled in inspector
+    window.console.debug(message);
   }-*/;
 }

--- a/user/src/com/google/gwt/logging/client/ConsoleLogHandler.java
+++ b/user/src/com/google/gwt/logging/client/ConsoleLogHandler.java
@@ -78,7 +78,8 @@ public class ConsoleLogHandler extends Handler {
   }-*/;
 
   private native void logVerbose(String message) /*-{
-    // use console.debug to show FINE and FINEST messages only when "Verbose" is enabled in inspector
+    // use console.debug to show FINE and FINEST messages
+    // only when "Verbose" is enabled in inspector
     window.console.debug(message);
   }-*/;
 }

--- a/user/src/com/google/gwt/logging/client/ConsoleLogHandler.java
+++ b/user/src/com/google/gwt/logging/client/ConsoleLogHandler.java
@@ -57,7 +57,7 @@ public class ConsoleLogHandler extends Handler {
     } else if (val >= Level.INFO.intValue()) {
       info(msg);
     } else {
-      logVerbose(msg);
+      debug(msg);
     }
   }
 
@@ -77,9 +77,7 @@ public class ConsoleLogHandler extends Handler {
     window.console.info(message);
   }-*/;
 
-  private native void logVerbose(String message) /*-{
-    // use console.debug to show FINE and FINEST messages
-    // only when "Verbose" is enabled in inspector
+  private native void debug(String message) /*-{
     window.console.debug(message);
   }-*/;
 }


### PR DESCRIPTION
This patch updates ConsoleLogHandler to use console.debug() instead of console.log() for log levels FINE, FINER, and FINEST, ensuring that these messages are only shown in the "Verbose" tab in browser developer tools. This aligns with standard browser behavior for log levels.