### PR TITLE
Update nightly snapshot deployment URL

### DIFF
--- a/.github/workflows/full-check.yml
+++ b/.github/workflows/full-check.yml
@@ -103,7 +103,7 @@ jobs:
           set -eux
           # Set the version to deploy (it was also set in the build step above)
           export GWT_VERSION=HEAD-SNAPSHOT
-          export GWT_MAVEN_REPO_URL=https://oss.sonatype.org/content/repositories/snapshots/
+          export GWT_MAVEN_REPO_URL=https://central.sonatype.com/repository/maven-snapshots/
           export GWT_MAVEN_REPO_ID=sonatype-snapshots
           cd gwt
           # With no user input, run the push-gwtproject.sh script to deploy org.gwtproject artifacts

--- a/maven/push-gwtproject.sh
+++ b/maven/push-gwtproject.sh
@@ -6,10 +6,10 @@
 # GWT_MAVEN_REPO_ID = a server id in your .m2/settings.xml with remote repo username and password
 #
 # Sonatype staging repo (promotes to Maven Central)
-#   GWT_MAVEN_REPO_URL=https://oss.sonatype.org/service/local/staging/deploy/maven2/
+#   GWT_MAVEN_REPO_URL=https://ossrh-staging-api.central.sonatype.com/service/local/staging/deploy/maven2/
 #
 # Sonatype Google SNAPSHOTs repo (can only deploy SNAPSHOTs here, and they are immediately public)
-#   GWT_MAVEN_REPO_URL=https://oss.sonatype.org/content/repositories/snapshots/
+#   GWT_MAVEN_REPO_URL=https://central.sonatype.com/repository/maven-snapshots/
 
 pushd $(dirname $0) >/dev/null 2>&1
 

--- a/maven/push-gwtproject.sh
+++ b/maven/push-gwtproject.sh
@@ -8,7 +8,7 @@
 # Sonatype staging repo (promotes to Maven Central)
 #   GWT_MAVEN_REPO_URL=https://ossrh-staging-api.central.sonatype.com/service/local/staging/deploy/maven2/
 #
-# Sonatype Google SNAPSHOTs repo (can only deploy SNAPSHOTs here, and they are immediately public)
+# Sonatype SNAPSHOTs repo (can only deploy SNAPSHOTs here, and they are immediately public)
 #   GWT_MAVEN_REPO_URL=https://central.sonatype.com/repository/maven-snapshots/
 
 pushd $(dirname $0) >/dev/null 2>&1


### PR DESCRIPTION
Release staging URL is set, however we probably want to use the publish API with a zip bundle instead, at least until the project uses Maven/Gradle to build and publish.

Secrets in GitHub Actions have already been changed to work with the new deployment.