### PR TITLE
Restore PR annotations

### DIFF
--- a/.github/workflows/quick-check.yml
+++ b/.github/workflows/quick-check.yml
@@ -7,6 +7,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         java-version: ['11', '17', '21', '22']
     steps:

--- a/.github/workflows/quick-check.yml
+++ b/.github/workflows/quick-check.yml
@@ -55,7 +55,7 @@ jobs:
           cd gwt
           for f in build/out/**/checkstyle*.xml ; do
             echo $f
-            reviewdog -f=checkstyle -filter-mode=diff_context -reporter=github-pr-review -level=info < $f
+            reviewdog -f=checkstyle -filter-mode=diff_context -reporter=github-pr-annotations -level=info < $f
           done
       - name: Upload checkstyle xml for manual review
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
Our reviewdog annotations stopped appearing some time ago - they've been fixed once, but broken again. This attempts to repair them again, so PRs with minor style issues don't fail, but do have warnings visible for reviewers to easily comment.