### PR TITLE
Don't run full build on schedule, run it for "ready" label

### DIFF
--- a/.github/workflows/full-check.yml
+++ b/.github/workflows/full-check.yml
@@ -4,10 +4,6 @@
 # build, though maven snapshots are not yet deployed.
 name: Full build
 on:
-  schedule:
-    # This time is selected to be early in the morning in NA/SA/EU/ME. This
-    # only runs on the default branch.
-    - cron:  '0 6 * * *'
   push:
     # Build on pushes to main and release branches. For forks, the -test may
     # be helpful to run tests when preparing a merge.
@@ -17,8 +13,11 @@ on:
       - '*-test'
   workflow_dispatch:
     # Allow running manually
+  pull_request:
+    types: [ labeled, synchronized ]  
 jobs:
   build:
+    if: ${{ !github.event.pull_request || contains(github.event.pull_request.labels.*.name, 'ready') }}
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/.github/workflows/full-check.yml
+++ b/.github/workflows/full-check.yml
@@ -14,7 +14,7 @@ on:
   workflow_dispatch:
     # Allow running manually
   pull_request:
-    types: [ labeled, synchronized ]  
+    types: [ labeled, synchronize ]
 jobs:
   build:
     if: ${{ !github.event.pull_request || contains(github.event.pull_request.labels.*.name, 'ready') }}
@@ -84,7 +84,7 @@ jobs:
       - name: Set up sonatype credentials
         # Using the same java version as above, set up a settings.xml file
         uses: actions/setup-java@v4
-        if: ${{ github.event_name == 'schedule' && github.repository_owner == 'gwtproject' && matrix.java-version == '21' }}
+        if: ${{ github.event_name == 'push' && github.ref_name == 'main' && github.repository_owner == 'gwtproject' && matrix.java-version == '21' }}
         with:
           java-version: ${{ matrix.java-version }}
           distribution: 'temurin'
@@ -94,7 +94,7 @@ jobs:
           server-password: SONATYPE_PASSWORD
 
       - name: Nightly builds should be deployed as snapshots to sonatype
-        if: ${{ github.event_name == 'schedule' && github.repository_owner == 'gwtproject' && matrix.java-version == '21' }}
+        if: ${{ github.event_name == 'push' && github.ref_name == 'main' && github.repository_owner == 'gwtproject' && matrix.java-version == '21' }}
         env:
           SONATYPE_USERNAME: ${{ secrets.SONATYPE_USERNAME }}
           SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}


### PR DESCRIPTION
This implements @niloc132 's idea to run full build when a specific label is present. Also removes the scheduled build as it's enough to build each commit to `main` once (over the last year scheduled builds did not detect any flaky issues with GWT itself, they only fail sometimes because of some strange Ant issue).

Demonstration PR: https://github.com/zbynek/gwt/pull/4