### PR TITLE
Allow JsUtils.uncheckedCast to be inlined away

### DIFF
--- a/dev/core/src/com/google/gwt/dev/jjs/impl/MethodInliner.java
+++ b/dev/core/src/com/google/gwt/dev/jjs/impl/MethodInliner.java
@@ -134,6 +134,22 @@ public class MethodInliner {
         return;
       }
 
+      JMethod.Specialization specialization = getCurrentMethod().getSpecialization();
+      // If we have a specialization, don't inline that away - specializations must be called
+      // so they aren't pruned or type tightened into uselessness.
+      if (specialization != null) {
+        if (specialization.getTargetMethod() == method) {
+          return;
+        }
+        // We might have had a static impl that in turn will have a specialization - ensure we
+        // also don't inline that specialization away. Note that this check looks for it "backwards"
+        // by checking if the inlinable method has an instance method, since current method might
+        // have once had a static method, but it was already removed.
+        if (specialization.getTargetMethod() == program.instanceMethodForStaticImpl(method)) {
+          return;
+        }
+      }
+
       if (tryInlineMethodCall(x, ctx) == InlineResult.BLACKLIST) {
         // Do not try to inline this method again
         cannotInline.add(method);

--- a/user/super/com/google/gwt/emul/java/util/EnumSet.java
+++ b/user/super/com/google/gwt/emul/java/util/EnumSet.java
@@ -21,6 +21,7 @@ import static javaemul.internal.InternalPreconditions.checkNotNull;
 import static javaemul.internal.InternalPreconditions.checkState;
 
 import javaemul.internal.ArrayHelper;
+import javaemul.internal.JsUtils;
 import javaemul.internal.annotations.SpecializeMethod;
 
 /**
@@ -136,7 +137,7 @@ public abstract class EnumSet<E extends Enum<E>> extends AbstractSet<E> {
     @SpecializeMethod(params = Enum.class, target = "containsEnum")
     @Override
     public boolean contains(Object o) {
-      return (o instanceof Enum) && containsEnum((Enum) o);
+      return (o instanceof Enum) && containsEnum(JsUtils.uncheckedCast(o));
     }
 
     private boolean containsEnum(Enum e) {
@@ -151,7 +152,7 @@ public abstract class EnumSet<E extends Enum<E>> extends AbstractSet<E> {
     @SpecializeMethod(params = Enum.class, target = "removeEnum")
     @Override
     public boolean remove(Object o) {
-      return (o instanceof Enum) && removeEnum((Enum) o);
+      return (o instanceof Enum) && removeEnum(JsUtils.uncheckedCast(o));
     }
 
     private boolean removeEnum(Enum e) {

--- a/user/super/com/google/gwt/emul/javaemul/internal/JsUtils.java
+++ b/user/super/com/google/gwt/emul/javaemul/internal/JsUtils.java
@@ -82,9 +82,9 @@ public final class JsUtils {
   }-*/;
 
   @UncheckedCast
-  public static native <T> T uncheckedCast(@DoNotAutobox Object o) /*-{
-    return o;
-  }-*/;
+  public static <T> T uncheckedCast(@DoNotAutobox Object o) {
+    return (T) o;
+  }
 
   @UncheckedCast
   public static native <T> T getProperty(Object map, String key) /*-{

--- a/user/super/com/google/gwt/emul/javaemul/internal/annotations/SpecializeMethod.java
+++ b/user/super/com/google/gwt/emul/javaemul/internal/annotations/SpecializeMethod.java
@@ -22,6 +22,10 @@ import java.lang.annotation.Target;
  * An annotation to mark a given method as being specialized. If the specified
  * parameters and return context match of a JMethodCall, then the call
  * is retargeted at the specialized version.
+ * <p/>
+ * The annotated method must call the target method directly, and the compiler
+ * must not inline the target method to prevent it from being pruned while it
+ * still might be used.
  */
 @Target(ElementType.METHOD)
 @CompilerHint


### PR DESCRIPTION
This will have minimal impacts in cases where JS inlining and static eval passes are able to make improvements, but will improve cases where Java/GWT passes can benefit from this method being removed, such as removing clinits.

The new implementation is effectively what jsinterop-base's Js.uncheckedCast() does, so is unlikely to cause any surprises.

Fixes #10055