### PR TITLE
Add permissions for publishing JUnit report

### DIFF
--- a/.github/workflows/full-check.yml
+++ b/.github/workflows/full-check.yml
@@ -15,6 +15,9 @@ on:
     # Allow running manually
   pull_request:
     types: [ labeled, synchronize ]
+permissions:
+  # allow publishing JUnit report for PRs
+  checks: write 
 jobs:
   build:
     if: ${{ !github.event.pull_request || contains(github.event.pull_request.labels.*.name, 'ready') }}


### PR DESCRIPTION
Based on suggestion in https://github.com/mikepenz/action-junit-report?tab=readme-ov-file#pr-run-permissions

Recent PRs marked as `ready` run the JUnit step, but are missing the report because of permissions. This PR should fix that.