### PR TITLE
Enhance AstDumper for debugging and testing

### DIFF
--- a/dev/core/src/com/google/gwt/dev/jjs/JavaToJavaScriptCompiler.java
+++ b/dev/core/src/com/google/gwt/dev/jjs/JavaToJavaScriptCompiler.java
@@ -1000,6 +1000,8 @@ public final class JavaToJavaScriptCompiler {
       // Save the stats to print out after optimizers finish.
       allOptimizerStats.add(stats);
 
+      AstDumper.maybeDumpAST(jsProgram);
+
       optimizeJsEvent.end();
       if ((optimizationLevel < OptionOptimize.OPTIMIZE_LEVEL_MAX && counter > optimizationLevel)
           || !stats.didChange()) {

--- a/dev/core/src/com/google/gwt/dev/jjs/ast/JNode.java
+++ b/dev/core/src/com/google/gwt/dev/jjs/ast/JNode.java
@@ -54,12 +54,12 @@ public abstract class JNode implements HasSourceInfo, Serializable {
   public abstract void traverse(JVisitor visitor, Context ctx);
 
   // Causes source generation to delegate to the one visitor
-  // toSource should be customized in ToStringGenerationVisitor, do not remove final.
+  // toSource should be customized in SourceGenerationVisitor, do not remove final.
   public final String toSource() {
     DefaultTextOutput out = new DefaultTextOutput(false);
     SourceGenerationVisitor v = new SourceGenerationVisitor(out);
     v.accept(this);
-    return out.toString();
+    return out.toString().trim();
   }
 
   // Causes source generation to delegate to the one visitor.

--- a/dev/core/src/com/google/gwt/dev/jjs/impl/AstDumper.java
+++ b/dev/core/src/com/google/gwt/dev/jjs/impl/AstDumper.java
@@ -16,13 +16,71 @@
 
 package com.google.gwt.dev.jjs.impl;
 
+import com.google.gwt.dev.jjs.HasSourceInfo;
+import com.google.gwt.dev.jjs.ast.Context;
+import com.google.gwt.dev.jjs.ast.JClassType;
+import com.google.gwt.dev.jjs.ast.JInterfaceType;
+import com.google.gwt.dev.jjs.ast.JMethod;
+import com.google.gwt.dev.jjs.ast.JNode;
 import com.google.gwt.dev.jjs.ast.JProgram;
+import com.google.gwt.dev.jjs.ast.JVisitor;
+import com.google.gwt.dev.js.JsSourceGenerationVisitor;
+import com.google.gwt.dev.js.ast.JsArrayAccess;
+import com.google.gwt.dev.js.ast.JsArrayLiteral;
+import com.google.gwt.dev.js.ast.JsBinaryOperation;
+import com.google.gwt.dev.js.ast.JsBlock;
+import com.google.gwt.dev.js.ast.JsBooleanLiteral;
+import com.google.gwt.dev.js.ast.JsBreak;
+import com.google.gwt.dev.js.ast.JsCase;
+import com.google.gwt.dev.js.ast.JsCatch;
+import com.google.gwt.dev.js.ast.JsConditional;
+import com.google.gwt.dev.js.ast.JsContext;
+import com.google.gwt.dev.js.ast.JsContinue;
+import com.google.gwt.dev.js.ast.JsDebugger;
+import com.google.gwt.dev.js.ast.JsDefault;
+import com.google.gwt.dev.js.ast.JsDoWhile;
+import com.google.gwt.dev.js.ast.JsEmpty;
+import com.google.gwt.dev.js.ast.JsExprStmt;
+import com.google.gwt.dev.js.ast.JsFor;
+import com.google.gwt.dev.js.ast.JsForIn;
+import com.google.gwt.dev.js.ast.JsFunction;
+import com.google.gwt.dev.js.ast.JsIf;
+import com.google.gwt.dev.js.ast.JsInvocation;
+import com.google.gwt.dev.js.ast.JsLabel;
+import com.google.gwt.dev.js.ast.JsNameOf;
+import com.google.gwt.dev.js.ast.JsNameRef;
+import com.google.gwt.dev.js.ast.JsNew;
+import com.google.gwt.dev.js.ast.JsNode;
+import com.google.gwt.dev.js.ast.JsNullLiteral;
+import com.google.gwt.dev.js.ast.JsNumberLiteral;
+import com.google.gwt.dev.js.ast.JsNumericEntry;
+import com.google.gwt.dev.js.ast.JsObjectLiteral;
+import com.google.gwt.dev.js.ast.JsParameter;
+import com.google.gwt.dev.js.ast.JsPositionMarker;
+import com.google.gwt.dev.js.ast.JsPostfixOperation;
+import com.google.gwt.dev.js.ast.JsPrefixOperation;
+import com.google.gwt.dev.js.ast.JsProgram;
+import com.google.gwt.dev.js.ast.JsProgramFragment;
+import com.google.gwt.dev.js.ast.JsPropertyInitializer;
+import com.google.gwt.dev.js.ast.JsRegExp;
+import com.google.gwt.dev.js.ast.JsReturn;
+import com.google.gwt.dev.js.ast.JsStringLiteral;
+import com.google.gwt.dev.js.ast.JsSwitch;
+import com.google.gwt.dev.js.ast.JsThisRef;
+import com.google.gwt.dev.js.ast.JsThrow;
+import com.google.gwt.dev.js.ast.JsTry;
+import com.google.gwt.dev.js.ast.JsVars;
+import com.google.gwt.dev.js.ast.JsVisitor;
+import com.google.gwt.dev.js.ast.JsWhile;
 import com.google.gwt.dev.util.AbstractTextOutput;
 import com.google.gwt.dev.util.TextOutput;
 
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.PrintWriter;
+import java.util.Arrays;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 /**
  * A simple utility to dump a JProgram to a temp file, which can be called
@@ -45,6 +103,10 @@ public class AstDumper {
    */
   public static void maybeDumpAST(JProgram jprogram) {
     maybeDumpAST(jprogram, null, true);
+  }
+
+  public static void maybeDumpAST(JsProgram jsProgram) {
+    maybeDumpAST(jsProgram, null, true);
   }
 
   /**
@@ -80,6 +142,7 @@ public class AstDumper {
 
   private static void maybeDumpAST(JProgram jprogram, String fileExtension, boolean append) {
     String dumpFile = System.getProperty("gwt.jjs.dumpAst");
+    String dumpFilter = System.getProperty("gwt.jjs.dumpAst.filter");
     if (dumpFile != null) {
       if (fileExtension != null) {
         dumpFile += fileExtension;
@@ -92,8 +155,427 @@ public class AstDumper {
             setPrintWriter(pw);
           }
         };
-        SourceGenerationVisitor v = new SourceGenerationVisitor(out);
+        JVisitor v = new SourceGenerationVisitor(out);
+        if (dumpFilter != null) {
+          Set<FilterRange> files = Arrays.stream(dumpFilter.split(","))
+              .map(s -> s.trim())
+              .map(FilterRange::new)
+              .collect(Collectors.toSet());
+          v = new JFilteredAstVisitor(v, files);
+        }
         v.accept(jprogram);
+        pw.close();
+      } catch (IOException e) {
+        System.out.println("Could not dump AST");
+        e.printStackTrace();
+      }
+    }
+  }
+
+  private static class FilterRange {
+    private final String fileName;
+    private final int startLine;
+    private final int endLine;
+
+    private FilterRange(String fileName, int startLine, int endLine) {
+      this.fileName = fileName;
+      this.startLine = startLine;
+      this.endLine = endLine;
+    }
+    private FilterRange(String directive) {
+      if (directive.contains(":")) {
+        String[] parts = directive.split(":");
+        this.fileName = parts[0];
+        String[] lineParts = parts[1].split("-");
+        this.startLine = Integer.parseInt(lineParts[0]);
+        if (lineParts.length > 1) {
+          this.endLine = Integer.parseInt(lineParts[1]);
+        } else {
+          this.endLine = this.startLine;
+        }
+      } else {
+        this.fileName = directive;
+        this.startLine = 0;
+        this.endLine = Integer.MAX_VALUE;
+      }
+    }
+    public boolean matches(HasSourceInfo node) {
+      String nodeFile = node.getSourceInfo().getFileName();
+      int nodeLine = node.getSourceInfo().getStartLine();
+      return nodeFile.equals(fileName) && nodeLine >= startLine && nodeLine <= endLine;
+    }
+  }
+
+  /**
+   * Filters the AST by type, method to determine what the delegate can see, by checking if any
+   * code is present from the requested files. Any class/interface that needs to be written will be
+   * visited directly (only via visit/endVisit, not accept/traverse), and only after at least one
+   * member is found that needs to be visited.
+   */
+  private static class JFilteredAstVisitor extends JVisitor {
+    private final JVisitor delegate;
+    private final Set<FilterRange> sourceFiles;
+
+    private JClassType currentClass = null;
+    private JInterfaceType currentInterface = null;
+    private boolean visitedCurrentType = false;
+    private boolean shouldVisitCurrentMethod = false;
+
+    private JFilteredAstVisitor(JVisitor delegate, Set<FilterRange> sourceFiles) {
+      this.delegate = delegate;
+      this.sourceFiles = sourceFiles;
+    }
+
+    @Override
+    public boolean visit(JNode x, Context ctx) {
+      shouldVisitCurrentMethod |= sourceFiles.stream().anyMatch(s -> s.matches(x));
+
+      // If we're already looking at this method, no need to keep checking
+      return !shouldVisitCurrentMethod;
+    }
+
+    @Override
+    public boolean visit(JInterfaceType x, Context ctx) {
+      currentInterface = x;
+      visitedCurrentType = false;
+      return true;
+    }
+
+    @Override
+    public void endVisit(JInterfaceType x, Context ctx) {
+      if (visitedCurrentType) {
+        delegate.endVisit(x, ctx);
+      }
+      currentInterface = null;
+    }
+
+    @Override
+    public boolean visit(JClassType x, Context ctx) {
+      currentClass = x;
+      visitedCurrentType = false;
+      return true;
+    }
+
+    @Override
+    public void endVisit(JClassType x, Context ctx) {
+      if (visitedCurrentType) {
+        delegate.endVisit(x, ctx);
+      }
+      currentClass = null;
+    }
+
+    @Override
+    public boolean visit(JMethod x, Context ctx) {
+      // Reset for each method
+      shouldVisitCurrentMethod = sourceFiles.stream().anyMatch(s -> s.matches(x));
+
+      // If we're already looking at this method, no need to keep checking
+      return !shouldVisitCurrentMethod;
+    }
+
+    @Override
+    public void endVisit(JMethod x, Context ctx) {
+      if (shouldVisitCurrentMethod) {
+        if (!visitedCurrentType) {
+          if (currentClass != null) {
+            delegate.visit(currentClass, ctx);
+          } else {
+            assert currentInterface != null;
+            delegate.visit(currentInterface, ctx);
+          }
+          visitedCurrentType = true;
+        }
+
+        delegate.accept(x);
+        shouldVisitCurrentMethod = false;
+      }
+    }
+
+    @Override
+    public boolean visit(JProgram x, Context ctx) {
+      // As SourceGenerationVisitor visits all types (not just ones that are reference-only),
+      // we need to as well.
+      for (int i = 0; i < x.getDeclaredTypes().size(); i++) {
+        accept(x.getDeclaredTypes().get(i));
+      }
+      return false;
+    }
+  }
+
+  private static class JsFilteredAstVisitor extends JsVisitor {
+    private final JsVisitor delegate;
+    private final Set<FilterRange> sourceFiles;
+
+    private boolean shouldVisitCurrentTopLevelStatement = false;
+
+
+    public JsFilteredAstVisitor(JsVisitor delegate, Set<FilterRange> sourceFiles) {
+      this.delegate = delegate;
+      this.sourceFiles = sourceFiles;
+    }
+
+    /**
+     * Tests if we should print the node and its surrounding top-level statement. Returns true
+     * if we should continue visiting children, false to skip them (because we already know we
+     * will print contents).
+     */
+    private boolean test(JsNode node) {
+      shouldVisitCurrentTopLevelStatement |= sourceFiles.stream().anyMatch(s -> s.matches(node));
+
+      return !shouldVisitCurrentTopLevelStatement;
+    }
+
+    @Override
+    public boolean visit(JsArrayAccess x, JsContext ctx) {
+      return test(x);
+    }
+
+    @Override
+    public boolean visit(JsArrayLiteral x, JsContext ctx) {
+      return test(x);
+    }
+
+    @Override
+    public boolean visit(JsBinaryOperation x, JsContext ctx) {
+      return test(x);
+    }
+
+    @Override
+    public boolean visit(JsBlock x, JsContext ctx) {
+      if (x.isGlobalBlock()) {
+        // Iterate children directly, so we can track what is top-level or not
+        for (JsNode child : x.getStatements()) {
+          accept(child);
+
+          // If any part of the node should be visited, handle it all
+          if (shouldVisitCurrentTopLevelStatement) {
+            delegate.accept(child);
+
+            // Reset after each top-level statement
+            shouldVisitCurrentTopLevelStatement = false;
+          }
+        }
+        return false;
+      }
+      return test(x);
+    }
+
+    @Override
+    public boolean visit(JsBooleanLiteral x, JsContext ctx) {
+      return test(x);
+    }
+
+    @Override
+    public boolean visit(JsBreak x, JsContext ctx) {
+      return test(x);
+    }
+
+    @Override
+    public boolean visit(JsCase x, JsContext ctx) {
+      return test(x);
+    }
+
+    @Override
+    public boolean visit(JsCatch x, JsContext ctx) {
+      return test(x);
+    }
+
+    @Override
+    public boolean visit(JsConditional x, JsContext ctx) {
+      return test(x);
+    }
+
+    @Override
+    public boolean visit(JsContinue x, JsContext ctx) {
+      return test(x);
+    }
+
+    @Override
+    public boolean visit(JsDebugger x, JsContext ctx) {
+      return test(x);
+    }
+
+    @Override
+    public boolean visit(JsDefault x, JsContext ctx) {
+      return test(x);
+    }
+
+    @Override
+    public boolean visit(JsDoWhile x, JsContext ctx) {
+      return test(x);
+    }
+
+    @Override
+    public boolean visit(JsEmpty x, JsContext ctx) {
+      return test(x);
+    }
+
+    @Override
+    public boolean visit(JsExprStmt x, JsContext ctx) {
+      return test(x);
+    }
+
+    @Override
+    public boolean visit(JsFor x, JsContext ctx) {
+      return test(x);
+    }
+
+    @Override
+    public boolean visit(JsForIn x, JsContext ctx) {
+      return test(x);
+    }
+
+    @Override
+    public boolean visit(JsFunction x, JsContext ctx) {
+      return test(x);
+    }
+
+    @Override
+    public boolean visit(JsIf x, JsContext ctx) {
+      return test(x);
+    }
+
+    @Override
+    public boolean visit(JsInvocation x, JsContext ctx) {
+      return test(x);
+    }
+
+    @Override
+    public boolean visit(JsLabel x, JsContext ctx) {
+      return test(x);
+    }
+
+    @Override
+    public boolean visit(JsNameOf x, JsContext ctx) {
+      return test(x);
+    }
+
+    @Override
+    public boolean visit(JsNameRef x, JsContext ctx) {
+      return test(x);
+    }
+
+    @Override
+    public boolean visit(JsNew x, JsContext ctx) {
+      return test(x);
+    }
+
+    @Override
+    public boolean visit(JsNullLiteral x, JsContext ctx) {
+      return test(x);
+    }
+
+    @Override
+    public boolean visit(JsNumberLiteral x, JsContext ctx) {
+      return test(x);
+    }
+
+    @Override
+    public boolean visit(JsNumericEntry x, JsContext ctx) {
+      return test(x);
+    }
+
+    @Override
+    public boolean visit(JsObjectLiteral x, JsContext ctx) {
+      return test(x);
+    }
+
+    @Override
+    public boolean visit(JsParameter x, JsContext ctx) {
+      return test(x);
+    }
+
+    @Override
+    public boolean visit(JsPostfixOperation x, JsContext ctx) {
+      return test(x);
+    }
+
+    @Override
+    public boolean visit(JsPrefixOperation x, JsContext ctx) {
+      return test(x);
+    }
+
+    @Override
+    public boolean visit(JsPropertyInitializer x, JsContext ctx) {
+      return test(x);
+    }
+
+    @Override
+    public boolean visit(JsRegExp x, JsContext ctx) {
+      return test(x);
+    }
+
+    @Override
+    public boolean visit(JsReturn x, JsContext ctx) {
+      return test(x);
+    }
+
+    @Override
+    public boolean visit(JsStringLiteral x, JsContext ctx) {
+      return test(x);
+    }
+
+    @Override
+    public boolean visit(JsSwitch x, JsContext ctx) {
+      return test(x);
+    }
+
+    @Override
+    public boolean visit(JsThisRef x, JsContext ctx) {
+      return test(x);
+    }
+
+    @Override
+    public boolean visit(JsThrow x, JsContext ctx) {
+      return test(x);
+    }
+
+    @Override
+    public boolean visit(JsTry x, JsContext ctx) {
+      return test(x);
+    }
+
+    @Override
+    public boolean visit(JsVars.JsVar x, JsContext ctx) {
+      return test(x);
+    }
+
+    @Override
+    public boolean visit(JsVars x, JsContext ctx) {
+      return test(x);
+    }
+
+    @Override
+    public boolean visit(JsWhile x, JsContext ctx) {
+      return test(x);
+    }
+  }
+
+  private static void maybeDumpAST(JsProgram jsProgram, String fileExtension, boolean append) {
+    String dumpFile = System.getProperty("gwt.jjs.dumpAst");
+    String dumpFilter = System.getProperty("gwt.jjs.dumpAst.filter");
+    if (dumpFile != null) {
+      if (fileExtension != null) {
+        dumpFile += fileExtension;
+      }
+      try {
+        FileOutputStream os = new FileOutputStream(dumpFile, append);
+        final PrintWriter pw = new PrintWriter(os);
+        TextOutput out = new AbstractTextOutput(false) {
+          {
+            setPrintWriter(pw);
+          }
+        };
+        JsVisitor v = new JsSourceGenerationVisitor(out);
+        if (dumpFilter != null) {
+          Set<FilterRange> files = Arrays.stream(dumpFilter.split(","))
+              .map(s -> s.trim())
+              .map(FilterRange::new)
+              .collect(Collectors.toSet());
+          v = new JsFilteredAstVisitor(v, files);
+        }
+
+        v.accept(jsProgram);
         pw.close();
       } catch (IOException e) {
         System.out.println("Could not dump AST");

--- a/dev/core/src/com/google/gwt/dev/jjs/impl/AstDumper.java
+++ b/dev/core/src/com/google/gwt/dev/jjs/impl/AstDumper.java
@@ -156,7 +156,8 @@ public class AstDumper {
     return files;
   }
 
-  private static PrintWriterTextOutput createWriter(String dumpFile, String fileExtension, boolean append) throws IOException {
+  private static PrintWriterTextOutput createWriter(String dumpFile, String fileExtension,
+                                                    boolean append) throws IOException {
     if (fileExtension != null) {
       dumpFile += fileExtension;
     }
@@ -303,8 +304,7 @@ public class AstDumper {
 
     private boolean shouldVisitCurrentTopLevelStatement = false;
 
-
-    public JsFilteredAstVisitor(JsVisitor delegate, Set<FilterRange> sourceFiles) {
+    private JsFilteredAstVisitor(JsVisitor delegate, Set<FilterRange> sourceFiles) {
       this.delegate = delegate;
       this.sourceFiles = sourceFiles;
     }

--- a/dev/core/src/com/google/gwt/dev/jjs/impl/AstDumper.java
+++ b/dev/core/src/com/google/gwt/dev/jjs/impl/AstDumper.java
@@ -25,53 +25,12 @@ import com.google.gwt.dev.jjs.ast.JNode;
 import com.google.gwt.dev.jjs.ast.JProgram;
 import com.google.gwt.dev.jjs.ast.JVisitor;
 import com.google.gwt.dev.js.JsSourceGenerationVisitor;
-import com.google.gwt.dev.js.ast.JsArrayAccess;
-import com.google.gwt.dev.js.ast.JsArrayLiteral;
-import com.google.gwt.dev.js.ast.JsBinaryOperation;
 import com.google.gwt.dev.js.ast.JsBlock;
-import com.google.gwt.dev.js.ast.JsBooleanLiteral;
-import com.google.gwt.dev.js.ast.JsBreak;
-import com.google.gwt.dev.js.ast.JsCase;
-import com.google.gwt.dev.js.ast.JsCatch;
-import com.google.gwt.dev.js.ast.JsConditional;
 import com.google.gwt.dev.js.ast.JsContext;
-import com.google.gwt.dev.js.ast.JsContinue;
-import com.google.gwt.dev.js.ast.JsDebugger;
-import com.google.gwt.dev.js.ast.JsDefault;
-import com.google.gwt.dev.js.ast.JsDoWhile;
-import com.google.gwt.dev.js.ast.JsEmpty;
-import com.google.gwt.dev.js.ast.JsExprStmt;
-import com.google.gwt.dev.js.ast.JsFor;
-import com.google.gwt.dev.js.ast.JsForIn;
-import com.google.gwt.dev.js.ast.JsFunction;
-import com.google.gwt.dev.js.ast.JsIf;
-import com.google.gwt.dev.js.ast.JsInvocation;
-import com.google.gwt.dev.js.ast.JsLabel;
-import com.google.gwt.dev.js.ast.JsNameOf;
-import com.google.gwt.dev.js.ast.JsNameRef;
-import com.google.gwt.dev.js.ast.JsNew;
 import com.google.gwt.dev.js.ast.JsNode;
-import com.google.gwt.dev.js.ast.JsNullLiteral;
-import com.google.gwt.dev.js.ast.JsNumberLiteral;
-import com.google.gwt.dev.js.ast.JsNumericEntry;
-import com.google.gwt.dev.js.ast.JsObjectLiteral;
-import com.google.gwt.dev.js.ast.JsParameter;
-import com.google.gwt.dev.js.ast.JsPositionMarker;
-import com.google.gwt.dev.js.ast.JsPostfixOperation;
-import com.google.gwt.dev.js.ast.JsPrefixOperation;
 import com.google.gwt.dev.js.ast.JsProgram;
-import com.google.gwt.dev.js.ast.JsProgramFragment;
-import com.google.gwt.dev.js.ast.JsPropertyInitializer;
-import com.google.gwt.dev.js.ast.JsRegExp;
-import com.google.gwt.dev.js.ast.JsReturn;
-import com.google.gwt.dev.js.ast.JsStringLiteral;
-import com.google.gwt.dev.js.ast.JsSwitch;
-import com.google.gwt.dev.js.ast.JsThisRef;
-import com.google.gwt.dev.js.ast.JsThrow;
-import com.google.gwt.dev.js.ast.JsTry;
-import com.google.gwt.dev.js.ast.JsVars;
+import com.google.gwt.dev.js.ast.JsSuperVisitor;
 import com.google.gwt.dev.js.ast.JsVisitor;
-import com.google.gwt.dev.js.ast.JsWhile;
 import com.google.gwt.dev.util.AbstractTextOutput;
 import com.google.gwt.dev.util.TextOutput;
 
@@ -302,7 +261,7 @@ public class AstDumper {
     }
   }
 
-  private static class JsFilteredAstVisitor extends JsVisitor {
+  private static class JsFilteredAstVisitor extends JsSuperVisitor {
     private final JsVisitor delegate;
     private final Set<FilterRange> sourceFiles;
 
@@ -312,6 +271,11 @@ public class AstDumper {
     public JsFilteredAstVisitor(JsVisitor delegate, Set<FilterRange> sourceFiles) {
       this.delegate = delegate;
       this.sourceFiles = sourceFiles;
+    }
+
+    @Override
+    public boolean visit(JsNode x, JsContext ctx) {
+      return test(x);
     }
 
     /**
@@ -326,28 +290,13 @@ public class AstDumper {
     }
 
     @Override
-    public boolean visit(JsArrayAccess x, JsContext ctx) {
-      return test(x);
-    }
-
-    @Override
-    public boolean visit(JsArrayLiteral x, JsContext ctx) {
-      return test(x);
-    }
-
-    @Override
-    public boolean visit(JsBinaryOperation x, JsContext ctx) {
-      return test(x);
-    }
-
-    @Override
     public boolean visit(JsBlock x, JsContext ctx) {
       if (x.isGlobalBlock()) {
         // Iterate children directly, so we can track what is top-level or not
         for (JsNode child : x.getStatements()) {
           accept(child);
 
-          // If any part of the node should be visited, handle it all
+          // If any part of that node should be visited, pass to the delegate and reset
           if (shouldVisitCurrentTopLevelStatement) {
             delegate.accept(child);
 
@@ -357,196 +306,6 @@ public class AstDumper {
         }
         return false;
       }
-      return test(x);
-    }
-
-    @Override
-    public boolean visit(JsBooleanLiteral x, JsContext ctx) {
-      return test(x);
-    }
-
-    @Override
-    public boolean visit(JsBreak x, JsContext ctx) {
-      return test(x);
-    }
-
-    @Override
-    public boolean visit(JsCase x, JsContext ctx) {
-      return test(x);
-    }
-
-    @Override
-    public boolean visit(JsCatch x, JsContext ctx) {
-      return test(x);
-    }
-
-    @Override
-    public boolean visit(JsConditional x, JsContext ctx) {
-      return test(x);
-    }
-
-    @Override
-    public boolean visit(JsContinue x, JsContext ctx) {
-      return test(x);
-    }
-
-    @Override
-    public boolean visit(JsDebugger x, JsContext ctx) {
-      return test(x);
-    }
-
-    @Override
-    public boolean visit(JsDefault x, JsContext ctx) {
-      return test(x);
-    }
-
-    @Override
-    public boolean visit(JsDoWhile x, JsContext ctx) {
-      return test(x);
-    }
-
-    @Override
-    public boolean visit(JsEmpty x, JsContext ctx) {
-      return test(x);
-    }
-
-    @Override
-    public boolean visit(JsExprStmt x, JsContext ctx) {
-      return test(x);
-    }
-
-    @Override
-    public boolean visit(JsFor x, JsContext ctx) {
-      return test(x);
-    }
-
-    @Override
-    public boolean visit(JsForIn x, JsContext ctx) {
-      return test(x);
-    }
-
-    @Override
-    public boolean visit(JsFunction x, JsContext ctx) {
-      return test(x);
-    }
-
-    @Override
-    public boolean visit(JsIf x, JsContext ctx) {
-      return test(x);
-    }
-
-    @Override
-    public boolean visit(JsInvocation x, JsContext ctx) {
-      return test(x);
-    }
-
-    @Override
-    public boolean visit(JsLabel x, JsContext ctx) {
-      return test(x);
-    }
-
-    @Override
-    public boolean visit(JsNameOf x, JsContext ctx) {
-      return test(x);
-    }
-
-    @Override
-    public boolean visit(JsNameRef x, JsContext ctx) {
-      return test(x);
-    }
-
-    @Override
-    public boolean visit(JsNew x, JsContext ctx) {
-      return test(x);
-    }
-
-    @Override
-    public boolean visit(JsNullLiteral x, JsContext ctx) {
-      return test(x);
-    }
-
-    @Override
-    public boolean visit(JsNumberLiteral x, JsContext ctx) {
-      return test(x);
-    }
-
-    @Override
-    public boolean visit(JsNumericEntry x, JsContext ctx) {
-      return test(x);
-    }
-
-    @Override
-    public boolean visit(JsObjectLiteral x, JsContext ctx) {
-      return test(x);
-    }
-
-    @Override
-    public boolean visit(JsParameter x, JsContext ctx) {
-      return test(x);
-    }
-
-    @Override
-    public boolean visit(JsPostfixOperation x, JsContext ctx) {
-      return test(x);
-    }
-
-    @Override
-    public boolean visit(JsPrefixOperation x, JsContext ctx) {
-      return test(x);
-    }
-
-    @Override
-    public boolean visit(JsPropertyInitializer x, JsContext ctx) {
-      return test(x);
-    }
-
-    @Override
-    public boolean visit(JsRegExp x, JsContext ctx) {
-      return test(x);
-    }
-
-    @Override
-    public boolean visit(JsReturn x, JsContext ctx) {
-      return test(x);
-    }
-
-    @Override
-    public boolean visit(JsStringLiteral x, JsContext ctx) {
-      return test(x);
-    }
-
-    @Override
-    public boolean visit(JsSwitch x, JsContext ctx) {
-      return test(x);
-    }
-
-    @Override
-    public boolean visit(JsThisRef x, JsContext ctx) {
-      return test(x);
-    }
-
-    @Override
-    public boolean visit(JsThrow x, JsContext ctx) {
-      return test(x);
-    }
-
-    @Override
-    public boolean visit(JsTry x, JsContext ctx) {
-      return test(x);
-    }
-
-    @Override
-    public boolean visit(JsVars.JsVar x, JsContext ctx) {
-      return test(x);
-    }
-
-    @Override
-    public boolean visit(JsVars x, JsContext ctx) {
-      return test(x);
-    }
-
-    @Override
-    public boolean visit(JsWhile x, JsContext ctx) {
       return test(x);
     }
   }

--- a/dev/core/src/com/google/gwt/dev/jjs/impl/SourceGenerationVisitor.java
+++ b/dev/core/src/com/google/gwt/dev/jjs/impl/SourceGenerationVisitor.java
@@ -128,7 +128,7 @@ public class SourceGenerationVisitor extends ToStringGenerationVisitor {
 
     openBlock();
 
-    return false;
+    return true;
   }
 
   @Override

--- a/dev/core/src/com/google/gwt/dev/jjs/impl/SourceGenerationVisitor.java
+++ b/dev/core/src/com/google/gwt/dev/jjs/impl/SourceGenerationVisitor.java
@@ -18,11 +18,13 @@ package com.google.gwt.dev.jjs.impl;
 import com.google.gwt.dev.jjs.ast.Context;
 import com.google.gwt.dev.jjs.ast.JClassType;
 import com.google.gwt.dev.jjs.ast.JDeclaredType;
+import com.google.gwt.dev.jjs.ast.JEnumType;
 import com.google.gwt.dev.jjs.ast.JField;
 import com.google.gwt.dev.jjs.ast.JInterfaceType;
 import com.google.gwt.dev.jjs.ast.JMethod;
 import com.google.gwt.dev.jjs.ast.JMethodBody;
 import com.google.gwt.dev.jjs.ast.JProgram;
+import com.google.gwt.dev.jjs.ast.JRecordType;
 import com.google.gwt.dev.util.TextOutput;
 
 /**
@@ -31,15 +33,8 @@ import com.google.gwt.dev.util.TextOutput;
  * subclass delves into the bodies of classes, interfaces, and methods to
  * produce the whole source tree.
  *
- * The goal is not to generate the input source tree. Rather, the goal is to
- * produce a set of classes that can be pasted into an enclosing class and
- * compiled with a standard Java compiler. In practice, there are cases that
- * require hand-editing to actually get a full compilation, due to Java's
- * built-in reliance on particular built-in types.
- *
- * Known to be broken: Our generated String, Class, and Throwable are not
- * compatible with the real ones, which breaks string literals, class literals,
- * try/catch/throw, and overrides of Object methods.
+ * The goal is not to generate the input source tree, or even properly compilable sources.
+ * Instead, this provides a way to log the AST in a human-readable way.
  */
 public class SourceGenerationVisitor extends ToStringGenerationVisitor {
 
@@ -51,7 +46,13 @@ public class SourceGenerationVisitor extends ToStringGenerationVisitor {
   public boolean visit(JClassType x, Context ctx) {
     printAbstractFlag(x);
     printFinalFlag(x);
-    print(CHARS_CLASS);
+    if (x instanceof JEnumType) {
+      print(CHARS_ENUM);
+    } else if (x instanceof JRecordType) {
+      print(CHARS_RECORD);
+    } else {
+      print(CHARS_CLASS);
+    }
     printTypeName(x);
     space();
     if (x.getSuperClass() != null) {
@@ -72,27 +73,40 @@ public class SourceGenerationVisitor extends ToStringGenerationVisitor {
     }
     openBlock();
 
-    for (JField field : x.getFields()) {
-      accept(field);
-      semi();
-      newline();
-      newline();
-    }
-    for (JMethod method : x.getMethods()) {
-      if (JProgram.isClinit(method)) {
-        // Suppress empty clinit.
-        JMethodBody body = (JMethodBody) method.getBody();
-        if (body.getBlock().getStatements().isEmpty()) {
-          continue;
-        }
-      }
-      accept(method);
-      newline();
-      newline();
-    }
+    return true;
+  }
 
+  @Override
+  public void endVisit(JDeclaredType x, Context ctx) {
     closeBlock();
-    return false;
+
+    newline();
+    newline();
+  }
+
+  @Override
+  public void endVisit(JField x, Context ctx) {
+    semi();
+    newline();
+    newline();
+  }
+
+  @Override
+  public boolean visit(JMethod x, Context ctx) {
+    if (JProgram.isClinit(x)) {
+      // Suppress empty clinit.
+      JMethodBody body = (JMethodBody) x.getBody();
+      if (body.getBlock().getStatements().isEmpty()) {
+        return false;
+      }
+    }
+    return super.visit(x, ctx);
+  }
+
+  @Override
+  public void endVisit(JMethod x, Context ctx) {
+    newline();
+    newline();
   }
 
   @Override
@@ -114,25 +128,6 @@ public class SourceGenerationVisitor extends ToStringGenerationVisitor {
 
     openBlock();
 
-    for (JField field : x.getFields()) {
-      accept(field);
-      newline();
-      newline();
-    }
-    for (JMethod method : x.getMethods()) {
-      if (JProgram.isClinit(method)) {
-        // Suppress empty clinit.
-        JMethodBody body = (JMethodBody) method.getBody();
-        if (body.getBlock().getStatements().isEmpty()) {
-          continue;
-        }
-      }
-      accept(method);
-      newline();
-      newline();
-    }
-
-    closeBlock();
     return false;
   }
 
@@ -141,8 +136,6 @@ public class SourceGenerationVisitor extends ToStringGenerationVisitor {
     for (int i = 0; i < x.getDeclaredTypes().size(); ++i) {
       JDeclaredType type = x.getDeclaredTypes().get(i);
       accept(type);
-      newline();
-      newline();
     }
     return false;
   }

--- a/dev/core/src/com/google/gwt/dev/jjs/impl/SourceGenerationVisitor.java
+++ b/dev/core/src/com/google/gwt/dev/jjs/impl/SourceGenerationVisitor.java
@@ -32,7 +32,7 @@ import com.google.gwt.dev.util.TextOutput;
  * relatively short toString() results, for easy viewing in a debugger. This
  * subclass delves into the bodies of classes, interfaces, and methods to
  * produce the whole source tree.
- *
+ * <p>
  * The goal is not to generate the input source tree, or even properly compilable sources.
  * Instead, this provides a way to log the AST in a human-readable way.
  */

--- a/dev/core/src/com/google/gwt/dev/jjs/impl/SourceGenerationVisitor.java
+++ b/dev/core/src/com/google/gwt/dev/jjs/impl/SourceGenerationVisitor.java
@@ -52,6 +52,7 @@ public class SourceGenerationVisitor extends ToStringGenerationVisitor {
     printAbstractFlag(x);
     printFinalFlag(x);
     print(CHARS_CLASS);
+    printTypeName(x);
     space();
     if (x.getSuperClass() != null) {
       print(CHARS_EXTENDS);
@@ -73,6 +74,7 @@ public class SourceGenerationVisitor extends ToStringGenerationVisitor {
 
     for (JField field : x.getFields()) {
       accept(field);
+      semi();
       newline();
       newline();
     }

--- a/dev/core/src/com/google/gwt/dev/jjs/impl/ToStringGenerationVisitor.java
+++ b/dev/core/src/com/google/gwt/dev/jjs/impl/ToStringGenerationVisitor.java
@@ -414,6 +414,7 @@ public class ToStringGenerationVisitor extends TextOutputVisitor {
   @Override
   public boolean visit(JDeclarationStatement x, Context ctx) {
     if (!(x.getVariableRef().getTarget() instanceof JField)) {
+      printFinalFlag(x.getVariableRef().getTarget());
       printType(x.getVariableRef().getTarget());
       space();
     }

--- a/dev/core/src/com/google/gwt/dev/jjs/impl/ToStringGenerationVisitor.java
+++ b/dev/core/src/com/google/gwt/dev/jjs/impl/ToStringGenerationVisitor.java
@@ -413,11 +413,11 @@ public class ToStringGenerationVisitor extends TextOutputVisitor {
 
   @Override
   public boolean visit(JDeclarationStatement x, Context ctx) {
-    if (!suppressType) {
-      accept(x.getVariableRef().getTarget());
-    } else {
-      accept(x.getVariableRef());
+    if (!(x.getVariableRef().getTarget() instanceof JField)) {
+      printType(x.getVariableRef().getTarget());
+      space();
     }
+    printName(x.getVariableRef().getTarget());
     JExpression initializer = x.getInitializer();
     if (initializer != null) {
       print(" = ");

--- a/dev/core/src/com/google/gwt/dev/jjs/impl/ToStringGenerationVisitor.java
+++ b/dev/core/src/com/google/gwt/dev/jjs/impl/ToStringGenerationVisitor.java
@@ -155,8 +155,6 @@ public class ToStringGenerationVisitor extends TextOutputVisitor {
 
   private boolean needSemi = true;
 
-  private boolean suppressType = false;
-
   public ToStringGenerationVisitor(TextOutput textOutput) {
     super(textOutput);
   }
@@ -505,13 +503,11 @@ public class ToStringGenerationVisitor extends TextOutputVisitor {
       JStatement stmt = iter.next();
       accept(stmt);
     }
-    suppressType = true;
     while (iter.hasNext()) {
       print(CHARS_COMMA);
       JStatement stmt = iter.next();
       accept(stmt);
     }
-    suppressType = false;
 
     semi();
     space();

--- a/dev/core/src/com/google/gwt/dev/jjs/impl/ToStringGenerationVisitor.java
+++ b/dev/core/src/com/google/gwt/dev/jjs/impl/ToStringGenerationVisitor.java
@@ -35,6 +35,7 @@ import com.google.gwt.dev.jjs.ast.JCastMap;
 import com.google.gwt.dev.jjs.ast.JCastOperation;
 import com.google.gwt.dev.jjs.ast.JCharLiteral;
 import com.google.gwt.dev.jjs.ast.JClassLiteral;
+import com.google.gwt.dev.jjs.ast.JClassType;
 import com.google.gwt.dev.jjs.ast.JConditional;
 import com.google.gwt.dev.jjs.ast.JConstructor;
 import com.google.gwt.dev.jjs.ast.JContinueStatement;
@@ -145,6 +146,7 @@ public class ToStringGenerationVisitor extends TextOutputVisitor {
   protected static final char[] CHARS_SWITCH = "switch ".toCharArray();
   protected static final char[] CHARS_THIS = "this".toCharArray();
   protected static final char[] CHARS_THROW = "throw".toCharArray();
+  protected static final char[] CHARS_THROWS = "throws ".toCharArray();
   protected static final char[] CHARS_TRUE = "true".toCharArray();
   protected static final char[] CHARS_TRY = "try ".toCharArray();
   protected static final char[] CHARS_UNCHECKED_CAST = "(/* @unchecked cast to ".toCharArray();
@@ -1091,6 +1093,16 @@ public class ToStringGenerationVisitor extends TextOutputVisitor {
 
     // Parameters
     printParameterList(x);
+
+    // Declared exceptions
+    if (!x.getThrownExceptions().isEmpty()) {
+      space();
+      print(CHARS_THROWS);
+      for (JClassType thrownException : x.getThrownExceptions()) {
+        printTypeName(thrownException);
+        space();
+      }
+    }
   }
 
   private void printAccess(AccessModifier access) {

--- a/dev/core/src/com/google/gwt/dev/jjs/impl/ToStringGenerationVisitor.java
+++ b/dev/core/src/com/google/gwt/dev/jjs/impl/ToStringGenerationVisitor.java
@@ -116,6 +116,7 @@ public class ToStringGenerationVisitor extends TextOutputVisitor {
   protected static final char[] CHARS_DO = "do".toCharArray();
   protected static final char[] CHARS_DOTCLASS = ".class".toCharArray();
   protected static final char[] CHARS_ELSE = "else".toCharArray();
+  protected static final char[] CHARS_ENUM = "enum ".toCharArray();
   protected static final char[] CHARS_EXTENDS = "extends ".toCharArray();
   protected static final char[] CHARS_FALSE = "false".toCharArray();
   protected static final char[] CHARS_FINAL = "final ".toCharArray();
@@ -133,6 +134,7 @@ public class ToStringGenerationVisitor extends TextOutputVisitor {
   protected static final char[] CHARS_PRIVATE = "private ".toCharArray();
   protected static final char[] CHARS_PROTECTED = "protected ".toCharArray();
   protected static final char[] CHARS_PUBLIC = "public ".toCharArray();
+  protected static final char[] CHARS_RECORD = "record ".toCharArray();
   protected static final char[] CHARS_RETURN = "return".toCharArray();
   protected static final char[] CHARS_RUNTIMETYPEREFERENCE =
       " JRuntimeTypeReference ".toCharArray();

--- a/dev/core/src/com/google/gwt/dev/jjs/impl/TypeTightener.java
+++ b/dev/core/src/com/google/gwt/dev/jjs/impl/TypeTightener.java
@@ -255,7 +255,7 @@ public class TypeTightener {
       if (!x.hasInitializer() || canUninitializedValueBeObserved.apply(x)) {
         addAssignment(x, x.getType().getDefaultValue());
       }
-      currentMethod = null;
+      assert currentMethod == null;
     }
 
     @Override

--- a/dev/core/src/com/google/gwt/dev/js/ast/JsSuperVisitor.java
+++ b/dev/core/src/com/google/gwt/dev/js/ast/JsSuperVisitor.java
@@ -393,7 +393,6 @@ public class JsSuperVisitor extends JsVisitor {
     return visit((JsExpression) x, ctx);
   }
 
-  @SuppressWarnings("unused")
   public boolean visit(JsNode x, JsContext ctx) {
     return true;
   }

--- a/dev/core/src/com/google/gwt/dev/util/PrintWriterTextOutput.java
+++ b/dev/core/src/com/google/gwt/dev/util/PrintWriterTextOutput.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2008 Google Inc.
+ * Copyright 2025 GWT Project Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -16,24 +16,21 @@
 package com.google.gwt.dev.util;
 
 import java.io.PrintWriter;
-import java.io.StringWriter;
 
 /**
- * Adapts {@link TextOutput} to an internal text buffer.
+ * TextOutput implementation that writes to a provided PrintWriter.
  */
-public class DefaultTextOutput extends AbstractTextOutput {
-
-  private final StringWriter sw = new StringWriter();
+public class PrintWriterTextOutput extends AbstractTextOutput implements AutoCloseable {
   private final PrintWriter out;
 
-  public DefaultTextOutput(boolean compact) {
+  public PrintWriterTextOutput(PrintWriter out, boolean compact) {
     super(compact);
-    setPrintWriter(out = new PrintWriter(sw));
+    this.out = out;
+    setPrintWriter(out);
   }
 
   @Override
-  public String toString() {
-    out.flush();
-    return sw.toString();
+  public void close() throws Exception {
+    out.close();
   }
 }

--- a/dev/core/test/com/google/gwt/dev/jjs/impl/CompileTimeConstantsReplacerTest.java
+++ b/dev/core/test/com/google/gwt/dev/jjs/impl/CompileTimeConstantsReplacerTest.java
@@ -62,7 +62,7 @@ public class CompileTimeConstantsReplacerTest extends OptimizerTestBase {
     result.into("int i = 1; int[] a = new int[] {1, 2, 3}; a[1] = 1;");
     JDeclaredType bType = result.findClass("test.EntryPoint.B");
     assertTrue("f1 not found as l-value of declaration statement",
-        findMethod(bType, "$clinit").getBody().toString().contains("final static int f1 = 1"));
+        findMethod(bType, "$clinit").getBody().toString().contains("f1 = 1"));
     assertTrue("f1 in condition was not replaced",
         findMethod(bType, "m").getBody().toString().contains("1 == 1"));
     assertEquals("incorrect modifiers for f1",

--- a/dev/core/test/com/google/gwt/dev/jjs/impl/Java10AstTest.java
+++ b/dev/core/test/com/google/gwt/dev/jjs/impl/Java10AstTest.java
@@ -71,7 +71,7 @@ public class Java10AstTest extends FullCompileTestBase {
 
   public void testLocalVarType_EnhancedForLoopArray() throws Exception {
     assertEqualBlock(
-          "for(final String[] s$array=new String[]{},s$index=0,s$max=s$array.length;"
+          "for(final String[] s$array=new String[]{},int s$index=0,final int s$max=s$array.length;"
         + "          s$index<s$max;++s$index){"
         + "  String s=s$array[s$index];"
         + "}"

--- a/dev/core/test/com/google/gwt/dev/jjs/impl/PrunerTest.java
+++ b/dev/core/test/com/google/gwt/dev/jjs/impl/PrunerTest.java
@@ -168,9 +168,9 @@ public class PrunerTest extends OptimizerTestBase {
 
     assertEquals(
         "interface EntryPoint$UsedInterface {\n" +
-        "  final static int usedConstant\n\n" +
+        "  final static int usedConstant;\n\n" +
         "  private static final void $clinit(){\n" +
-        "    final static int usedConstant = 3;\n" +
+        "    usedConstant = 3;\n" +
         "  }\n" +
         "\n" +
         "}",

--- a/dev/core/test/com/google/gwt/dev/jjs/impl/PrunerTest.java
+++ b/dev/core/test/com/google/gwt/dev/jjs/impl/PrunerTest.java
@@ -162,7 +162,7 @@ public class PrunerTest extends OptimizerTestBase {
         ((JsniMethodBody) result.findMethod("usedNativeMethod").getBody())
             .getJsniFieldRefs().toString());
     assertEquals(
-        "[public final null nullMethod(), public void method2()]",
+        "[public native final null nullMethod(), public void method2()]",
         ((JsniMethodBody) result.findMethod("usedNativeMethod").getBody())
             .getJsniMethodRefs().toString());
 


### PR DESCRIPTION
Enhances the AstDumper utility class with the aim of bringing back some of the functionality previously removed in 64f9b00adb7e29f9247b95bd0706823de1472e6b, where individual methods could be traced from source Java all the way to JS output. This is a small step in that direction that nevertheless provides more insight into what the compiler is doing, through a series of changes:
 * Improve printed Java output - classes should list their name, enums and records should be labeled as such, etc. AST traversal is made more visitor-like to make filtering easier.
 * JS AST should also be printed, rather than ending with the Java optimization loops, allowing insight into JS passes.
 * A filter can be applied to the ast at any stage, resulting in only printing code from the specified files or lines, to more easily follow specific changes through a program.

More improvement remains - multiple permutations may end up mixed in the same file, different compiler passes are not individually listed or labeled, arguments are re-parsed every time they are used, but impact to the API is minimal for now. 