### PR TITLE
Use INSECURE_DELETE to support MacOS filesystems

### DIFF
--- a/dev/codeserver/java/com/google/gwt/dev/codeserver/OutboxDir.java
+++ b/dev/codeserver/java/com/google/gwt/dev/codeserver/OutboxDir.java
@@ -20,6 +20,7 @@ import com.google.gwt.core.ext.TreeLogger;
 import com.google.gwt.core.ext.TreeLogger.Type;
 import com.google.gwt.core.ext.UnableToCompleteException;
 import com.google.gwt.thirdparty.guava.common.io.MoreFiles;
+import com.google.gwt.thirdparty.guava.common.io.RecursiveDeleteOption;
 
 import java.io.File;
 import java.io.IOException;
@@ -87,7 +88,7 @@ class OutboxDir {
     // (This is not guaranteed to delete all directories on Windows if a directory is locked.)
     for (File candidate : children) {
       if (candidate.getName().startsWith(COMPILE_DIR_PREFIX)) {
-        MoreFiles.deleteRecursively(candidate.toPath());
+        MoreFiles.deleteRecursively(candidate.toPath(), RecursiveDeleteOption.ALLOW_INSECURE);
         if (candidate.exists()) {
           logger.log(Type.WARN, "unable to delete '" + candidate + "' (skipped)");
         }

--- a/dev/core/src/com/google/gwt/dev/CompileTaskOptionsImpl.java
+++ b/dev/core/src/com/google/gwt/dev/CompileTaskOptionsImpl.java
@@ -20,6 +20,7 @@ import com.google.gwt.core.ext.TreeLogger.Type;
 import com.google.gwt.core.ext.UnableToCompleteException;
 import com.google.gwt.dev.cfg.Properties;
 import com.google.gwt.thirdparty.guava.common.io.MoreFiles;
+import com.google.gwt.thirdparty.guava.common.io.RecursiveDeleteOption;
 
 import java.io.File;
 import java.io.IOException;
@@ -61,7 +62,8 @@ class CompileTaskOptionsImpl implements CompileTaskOptions {
     File compilerWorkDir = getCompilerWorkDir(moduleName);
     if (compilerWorkDir.exists()) {
       try {
-        MoreFiles.deleteDirectoryContents(compilerWorkDir.toPath());
+        MoreFiles.deleteDirectoryContents(compilerWorkDir.toPath(),
+            RecursiveDeleteOption.ALLOW_INSECURE);
       } catch (IOException e) {
         logger.log(TreeLogger.ERROR, "Unable to delete contents of " + compilerWorkDir, e);
         throw new UnableToCompleteException();

--- a/dev/core/src/com/google/gwt/dev/Compiler.java
+++ b/dev/core/src/com/google/gwt/dev/Compiler.java
@@ -40,6 +40,7 @@ import com.google.gwt.dev.util.log.speedtracer.SpeedTracerLogger;
 import com.google.gwt.dev.util.log.speedtracer.SpeedTracerLogger.Event;
 import com.google.gwt.thirdparty.guava.common.collect.Sets;
 import com.google.gwt.thirdparty.guava.common.io.MoreFiles;
+import com.google.gwt.thirdparty.guava.common.io.RecursiveDeleteOption;
 
 import java.io.File;
 import java.io.IOException;
@@ -247,7 +248,8 @@ public class Compiler {
     } finally {
       if (tempWorkDir) {
         try {
-          MoreFiles.deleteRecursively(options.getWorkDir().toPath());
+          MoreFiles.deleteRecursively(options.getWorkDir().toPath(),
+              RecursiveDeleteOption.ALLOW_INSECURE);
         } catch (IOException e) {
           logger.log(TreeLogger.WARN, "Unable to delete temporary work directory: "
               + options.getWorkDir(), e);

--- a/dev/core/src/com/google/gwt/dev/DevMode.java
+++ b/dev/core/src/com/google/gwt/dev/DevMode.java
@@ -50,6 +50,7 @@ import com.google.gwt.dev.util.log.speedtracer.DevModeEventType;
 import com.google.gwt.dev.util.log.speedtracer.SpeedTracerLogger;
 import com.google.gwt.dev.util.log.speedtracer.SpeedTracerLogger.Event;
 import com.google.gwt.thirdparty.guava.common.io.MoreFiles;
+import com.google.gwt.thirdparty.guava.common.io.RecursiveDeleteOption;
 import com.google.gwt.util.tools.ArgHandlerFlag;
 import com.google.gwt.util.tools.ArgHandlerString;
 
@@ -494,7 +495,8 @@ public class DevMode extends DevModeBase implements RestartServerCallback {
 
     if (tempWorkDir) {
       try {
-        MoreFiles.deleteRecursively(options.getWorkDir().toPath());
+        MoreFiles.deleteRecursively(options.getWorkDir().toPath(),
+            RecursiveDeleteOption.ALLOW_INSECURE);
       } catch (IOException e) {
         getTopLogger().log(TreeLogger.ERROR,
             "Unable to delete temporary work directory " + options.getWorkDir().getAbsolutePath(),

--- a/dev/core/src/com/google/gwt/dev/Link.java
+++ b/dev/core/src/com/google/gwt/dev/Link.java
@@ -56,6 +56,7 @@ import com.google.gwt.dev.util.log.speedtracer.SpeedTracerLogger;
 import com.google.gwt.dev.util.log.speedtracer.SpeedTracerLogger.Event;
 import com.google.gwt.thirdparty.guava.common.collect.Sets;
 import com.google.gwt.thirdparty.guava.common.io.MoreFiles;
+import com.google.gwt.thirdparty.guava.common.io.RecursiveDeleteOption;
 
 import java.io.BufferedInputStream;
 import java.io.File;
@@ -345,7 +346,7 @@ public class Link {
     } else {
       File target = new File(dirOrJar, pathPrefix);
       if (target.exists()) {
-        MoreFiles.deleteDirectoryContents(target.toPath());
+        MoreFiles.deleteDirectoryContents(target.toPath(), RecursiveDeleteOption.ALLOW_INSECURE);
       }
       return new OutputFileSetOnDirectory(dirOrJar, pathPrefix);
     }

--- a/dev/core/test/com/google/gwt/core/ext/linker/SourceMapTest.java
+++ b/dev/core/test/com/google/gwt/core/ext/linker/SourceMapTest.java
@@ -32,6 +32,7 @@ import com.google.gwt.thirdparty.guava.common.collect.Lists;
 import com.google.gwt.thirdparty.guava.common.collect.Maps;
 import com.google.gwt.thirdparty.guava.common.collect.Sets;
 import com.google.gwt.thirdparty.guava.common.io.MoreFiles;
+import com.google.gwt.thirdparty.guava.common.io.RecursiveDeleteOption;
 import com.google.gwt.thirdparty.guava.common.primitives.Ints;
 import com.google.gwt.thirdparty.json.JSONArray;
 import com.google.gwt.thirdparty.json.JSONException;
@@ -528,7 +529,7 @@ public class SourceMapTest extends TestCase {
       testSoycCorrespondence(new File(parentDir + "/soycReport/"));
 
     } finally {
-      MoreFiles.deleteRecursively(work.toPath());
+      MoreFiles.deleteRecursively(work.toPath(), RecursiveDeleteOption.ALLOW_INSECURE);
     }
   }
 }

--- a/dev/core/test/com/google/gwt/core/ext/linker/SymbolMapTest.java
+++ b/dev/core/test/com/google/gwt/core/ext/linker/SymbolMapTest.java
@@ -27,6 +27,7 @@ import com.google.gwt.thirdparty.guava.common.collect.Maps;
 import com.google.gwt.thirdparty.guava.common.collect.Multimap;
 import com.google.gwt.thirdparty.guava.common.io.MoreFiles;
 
+import com.google.gwt.thirdparty.guava.common.io.RecursiveDeleteOption;
 import junit.framework.TestCase;
 
 import java.io.BufferedReader;
@@ -242,7 +243,7 @@ public class SymbolMapTest extends TestCase {
         assertSymbolUniquenessForMethods(symbolDataByJsniIdentifier);
       }
     } finally {
-      MoreFiles.deleteRecursively(work.toPath());
+      MoreFiles.deleteRecursively(work.toPath(), RecursiveDeleteOption.ALLOW_INSECURE);
     }
   }
 

--- a/dev/core/test/com/google/gwt/core/ext/linker/SymbolMapTest.java
+++ b/dev/core/test/com/google/gwt/core/ext/linker/SymbolMapTest.java
@@ -26,8 +26,8 @@ import com.google.gwt.thirdparty.guava.common.collect.Iterables;
 import com.google.gwt.thirdparty.guava.common.collect.Maps;
 import com.google.gwt.thirdparty.guava.common.collect.Multimap;
 import com.google.gwt.thirdparty.guava.common.io.MoreFiles;
-
 import com.google.gwt.thirdparty.guava.common.io.RecursiveDeleteOption;
+
 import junit.framework.TestCase;
 
 import java.io.BufferedReader;

--- a/dev/core/test/com/google/gwt/dev/CompilerTest.java
+++ b/dev/core/test/com/google/gwt/dev/CompilerTest.java
@@ -37,6 +37,7 @@ import com.google.gwt.thirdparty.guava.common.collect.ImmutableList;
 import com.google.gwt.thirdparty.guava.common.collect.Lists;
 import com.google.gwt.thirdparty.guava.common.collect.Sets;
 import com.google.gwt.thirdparty.guava.common.io.MoreFiles;
+import com.google.gwt.thirdparty.guava.common.io.RecursiveDeleteOption;
 
 import java.io.File;
 import java.io.IOException;
@@ -2505,7 +2506,7 @@ public class CompilerTest extends ArgProcessorTestBase {
       // is clean to avoid confusion when returning the output JS.
       File outputDir = new File(applicationDir.getPath() + File.separator + moduleName);
       if (outputDir.exists()) {
-        MoreFiles.deleteDirectoryContents(outputDir.toPath());
+        MoreFiles.deleteDirectoryContents(outputDir.toPath(), RecursiveDeleteOption.ALLOW_INSECURE);
       }
 
       // Fake out the resource loader to read resources both from the normal classpath as well as
@@ -2537,7 +2538,7 @@ public class CompilerTest extends ArgProcessorTestBase {
       // Run the compiler once here.
       Compiler.compile(logger, options);
     } finally {
-      MoreFiles.deleteRecursively(compileWorkDir.toPath());
+      MoreFiles.deleteRecursively(compileWorkDir.toPath(), RecursiveDeleteOption.ALLOW_INSECURE);
       if (oldPersistentUnitCacheValue == null) {
         System.clearProperty(UnitCacheSingleton.GWT_PERSISTENTUNITCACHE);
       } else {
@@ -2584,8 +2585,8 @@ public class CompilerTest extends ArgProcessorTestBase {
       } else {
         System.setProperty(UnitCacheSingleton.GWT_PERSISTENTUNITCACHE, oldPersistentUnitCacheValue);
       }
-      MoreFiles.deleteRecursively(firstCompileWorkDir.toPath());
-      MoreFiles.deleteRecursively(secondCompileWorkDir.toPath());
+      MoreFiles.deleteRecursively(firstCompileWorkDir.toPath(), RecursiveDeleteOption.ALLOW_INSECURE);
+      MoreFiles.deleteRecursively(secondCompileWorkDir.toPath(), RecursiveDeleteOption.ALLOW_INSECURE);
     }
   }
 
@@ -2689,7 +2690,7 @@ public class CompilerTest extends ArgProcessorTestBase {
     // clean to avoid confusion when returning the output JS.
     File outputDir = new File(applicationDir.getPath() + File.separator + moduleName);
     if (outputDir.exists()) {
-      MoreFiles.deleteDirectoryContents(outputDir.toPath());
+      MoreFiles.deleteDirectoryContents(outputDir.toPath(), RecursiveDeleteOption.ALLOW_INSECURE);
     }
 
     // Fake out the resource loader to read resources both from the normal classpath as well as this

--- a/dev/core/test/com/google/gwt/dev/SoycTest.java
+++ b/dev/core/test/com/google/gwt/dev/SoycTest.java
@@ -20,6 +20,7 @@ import com.google.gwt.core.ext.UnableToCompleteException;
 import com.google.gwt.dev.util.log.PrintWriterTreeLogger;
 import com.google.gwt.thirdparty.guava.common.io.MoreFiles;
 
+import com.google.gwt.thirdparty.guava.common.io.RecursiveDeleteOption;
 import junit.framework.TestCase;
 
 import java.io.File;
@@ -52,7 +53,7 @@ public class SoycTest extends TestCase {
 
       assertFalse(new File(options.getExtraDir() + "/hello/soycReport/compile-report/index2.html").exists());
     } finally {
-      MoreFiles.deleteRecursively(work.toPath());
+      MoreFiles.deleteRecursively(work.toPath(), RecursiveDeleteOption.ALLOW_INSECURE);
     }
   }
 }

--- a/dev/core/test/com/google/gwt/dev/SoycTest.java
+++ b/dev/core/test/com/google/gwt/dev/SoycTest.java
@@ -19,8 +19,8 @@ import com.google.gwt.core.ext.TreeLogger;
 import com.google.gwt.core.ext.UnableToCompleteException;
 import com.google.gwt.dev.util.log.PrintWriterTreeLogger;
 import com.google.gwt.thirdparty.guava.common.io.MoreFiles;
-
 import com.google.gwt.thirdparty.guava.common.io.RecursiveDeleteOption;
+
 import junit.framework.TestCase;
 
 import java.io.File;

--- a/dev/core/test/com/google/gwt/dev/javac/PersistentUnitCacheTest.java
+++ b/dev/core/test/com/google/gwt/dev/javac/PersistentUnitCacheTest.java
@@ -19,6 +19,7 @@ import com.google.gwt.core.ext.TreeLogger;
 import com.google.gwt.core.ext.TreeLogger.Type;
 import com.google.gwt.core.ext.UnableToCompleteException;
 import com.google.gwt.thirdparty.guava.common.io.MoreFiles;
+import com.google.gwt.thirdparty.guava.common.io.RecursiveDeleteOption;
 import com.google.gwt.thirdparty.guava.common.util.concurrent.Futures;
 
 import junit.framework.TestCase;
@@ -69,7 +70,7 @@ public class PersistentUnitCacheTest extends TestCase {
   public void tearDown() {
     if (lastParentDir != null) {
       try {
-        MoreFiles.deleteRecursively(lastParentDir.toPath());
+        MoreFiles.deleteRecursively(lastParentDir.toPath(), RecursiveDeleteOption.ALLOW_INSECURE);
       } catch (IOException e) {
         throw new UncheckedIOException(e);
       }

--- a/dev/core/test/com/google/gwt/dev/shell/StandardGeneratorContextTest.java
+++ b/dev/core/test/com/google/gwt/dev/shell/StandardGeneratorContextTest.java
@@ -32,6 +32,7 @@ import com.google.gwt.dev.javac.StandardGeneratorContext;
 import com.google.gwt.dev.resource.Resource;
 import com.google.gwt.thirdparty.guava.common.io.MoreFiles;
 
+import com.google.gwt.thirdparty.guava.common.io.RecursiveDeleteOption;
 import junit.framework.TestCase;
 
 import java.io.ByteArrayOutputStream;
@@ -291,7 +292,7 @@ public class StandardGeneratorContextTest extends TestCase {
   protected void tearDown() throws Exception {
     for (int i = toDelete.size() - 1; i >= 0; --i) {
       File f = toDelete.get(i);
-      MoreFiles.deleteRecursively(f.toPath());
+      MoreFiles.deleteRecursively(f.toPath(), RecursiveDeleteOption.ALLOW_INSECURE);
       assertFalse("Unable to delete " + f.getAbsolutePath(), f.exists());
     }
   }

--- a/dev/core/test/com/google/gwt/dev/shell/StandardGeneratorContextTest.java
+++ b/dev/core/test/com/google/gwt/dev/shell/StandardGeneratorContextTest.java
@@ -31,8 +31,8 @@ import com.google.gwt.dev.javac.CompilationStateBuilder;
 import com.google.gwt.dev.javac.StandardGeneratorContext;
 import com.google.gwt.dev.resource.Resource;
 import com.google.gwt.thirdparty.guava.common.io.MoreFiles;
-
 import com.google.gwt.thirdparty.guava.common.io.RecursiveDeleteOption;
+
 import junit.framework.TestCase;
 
 import java.io.ByteArrayOutputStream;

--- a/dev/core/test/com/google/gwt/dev/util/OutputFileSetOnDirectoryTest.java
+++ b/dev/core/test/com/google/gwt/dev/util/OutputFileSetOnDirectoryTest.java
@@ -14,8 +14,8 @@
 package com.google.gwt.dev.util;
 
 import com.google.gwt.thirdparty.guava.common.io.MoreFiles;
-
 import com.google.gwt.thirdparty.guava.common.io.RecursiveDeleteOption;
+
 import junit.framework.TestCase;
 
 import java.io.File;

--- a/dev/core/test/com/google/gwt/dev/util/OutputFileSetOnDirectoryTest.java
+++ b/dev/core/test/com/google/gwt/dev/util/OutputFileSetOnDirectoryTest.java
@@ -15,6 +15,7 @@ package com.google.gwt.dev.util;
 
 import com.google.gwt.thirdparty.guava.common.io.MoreFiles;
 
+import com.google.gwt.thirdparty.guava.common.io.RecursiveDeleteOption;
 import junit.framework.TestCase;
 
 import java.io.File;
@@ -45,7 +46,7 @@ public class OutputFileSetOnDirectoryTest extends TestCase {
       assertTrue(new File(work, "to/file").exists());
 
     } finally {
-      MoreFiles.deleteRecursively(work.toPath());
+      MoreFiles.deleteRecursively(work.toPath(), RecursiveDeleteOption.ALLOW_INSECURE);
     }
   }
 
@@ -62,7 +63,7 @@ public class OutputFileSetOnDirectoryTest extends TestCase {
       assertTrue(secondStream instanceof FileOutputStream);
       secondStream.close();
     } finally {
-      MoreFiles.deleteRecursively(work.toPath());
+      MoreFiles.deleteRecursively(work.toPath(), RecursiveDeleteOption.ALLOW_INSECURE);
     }
   }
 
@@ -79,7 +80,7 @@ public class OutputFileSetOnDirectoryTest extends TestCase {
       assertFalse(secondStream instanceof FileOutputStream);
       secondStream.close();
     } finally {
-      MoreFiles.deleteRecursively(work.toPath());
+      MoreFiles.deleteRecursively(work.toPath(), RecursiveDeleteOption.ALLOW_INSECURE);
     }
   }
 }


### PR DESCRIPTION
This use case is only "insecure" insofar as any attacker who can already edit compiled output or temp/cache locations that the compiler is potentially now able to influence files that are deleted as well.

Fixes #10174