### PR TITLE
Checkstyle: use SuppressWarnings instead of inline comments

### DIFF
--- a/dev/core/src/com/google/gwt/core/linker/CrossSiteIframeLinker.java
+++ b/dev/core/src/com/google/gwt/core/linker/CrossSiteIframeLinker.java
@@ -118,7 +118,6 @@ public class CrossSiteIframeLinker extends SelectionScriptLinker {
         }
       }
       if (failIfScriptTags) {
-        // CHECKSTYLE_OFF
         String msg =
             "The " + getDescription()
                 + " linker does not support <script> tags in the gwt.xml files, but the"
@@ -129,7 +128,6 @@ public class CrossSiteIframeLinker extends SelectionScriptLinker {
                 + " this error, you will need to remove the script tags from the"
                 + " gwt.xml file, or add this property to the gwt.xml file:"
                 + " <set-configuration-property name='xsiframe.failIfScriptTag' value='FALSE'/>";
-        // CHECKSTYLE_ON
         logger.log(TreeLogger.ERROR, msg);
         throw new UnableToCompleteException();
       } else {
@@ -602,6 +600,7 @@ public class CrossSiteIframeLinker extends SelectionScriptLinker {
 
   // Output compilation-mappings.txt
   @Override
+  @SuppressWarnings("checkstyle:SpaceAfterColon")
   protected void maybeOutputPropertyMap(TreeLogger logger, LinkerContext context,
       ArtifactSet toReturn) {
     if (permutationsUtil.getPermutationsMap() == null
@@ -617,9 +616,7 @@ public class CrossSiteIframeLinker extends SelectionScriptLinker {
     EmittedArtifact serializedMap;
     try {
       String mappings = mappingArtifact.getSerialized();
-      // CHECKSTYLE_OFF
       mappings = mappings.concat("Devmode:" + getHostedFilename());
-      // CHECKSTYLE_ON
       serializedMap = emitString(logger, mappings, "compilation-mappings.txt");
       // TODO(unnurg): make this Deploy
       serializedMap.setVisibility(Visibility.Public);
@@ -681,7 +678,6 @@ public class CrossSiteIframeLinker extends SelectionScriptLinker {
       // only needed in SSSS, breaks WebWorker linker if done all the time
       out.append("if (" + context.getModuleFunctionName() + ".succeeded) {\n");
     }
-
 
     if (shouldInstallCode(context)) {
       // Rewrite the code so it can be installed with

--- a/dev/core/src/com/google/gwt/core/linker/CrossSiteIframeLinker.java
+++ b/dev/core/src/com/google/gwt/core/linker/CrossSiteIframeLinker.java
@@ -434,13 +434,15 @@ public class CrossSiteIframeLinker extends SelectionScriptLinker {
     out.print("function __gwtStartLoadingFragment(frag) {");
     out.newlineOpt();
     String fragDir = getFragmentSubdir(logger, context) + '/';
-    out.print("var fragFile = '" + fragDir + "' + $strongName + '/' + frag + '" + FRAGMENT_EXTENSION + "';");
+    out.print("var fragFile = '" + fragDir + "' + $strongName + '/' + frag + '"
+        + FRAGMENT_EXTENSION + "';");
     out.newlineOpt();
     out.print("return __gwtModuleFunction.__startLoadingFragment(fragFile);");
     out.newlineOpt();
     out.print("}");
     out.newlineOpt();
-    out.print("function __gwtInstallCode(code) {return __gwtModuleFunction.__installRunAsyncCode(code);}");
+    out.print("function __gwtInstallCode(code) {"
+        + "return __gwtModuleFunction.__installRunAsyncCode(code);}");
     out.newlineOpt();
 
     // The functions for property access are set up in the bootstrap script however
@@ -600,7 +602,6 @@ public class CrossSiteIframeLinker extends SelectionScriptLinker {
 
   // Output compilation-mappings.txt
   @Override
-  @SuppressWarnings("checkstyle:SpaceAfterColon")
   protected void maybeOutputPropertyMap(TreeLogger logger, LinkerContext context,
       ArtifactSet toReturn) {
     if (permutationsUtil.getPermutationsMap() == null
@@ -616,7 +617,9 @@ public class CrossSiteIframeLinker extends SelectionScriptLinker {
     EmittedArtifact serializedMap;
     try {
       String mappings = mappingArtifact.getSerialized();
-      mappings = mappings.concat("Devmode:" + getHostedFilename());
+      @SuppressWarnings("checkstyle:SpaceAfterColon")
+      String str = "Devmode:" + getHostedFilename();
+      mappings = mappings.concat(str);
       serializedMap = emitString(logger, mappings, "compilation-mappings.txt");
       // TODO(unnurg): make this Deploy
       serializedMap.setVisibility(Visibility.Public);

--- a/dev/core/src/com/google/gwt/dev/cfg/ModuleDefSchema.java
+++ b/dev/core/src/com/google/gwt/dev/cfg/ModuleDefSchema.java
@@ -43,11 +43,10 @@ import java.util.regex.Pattern;
 
 import javax.lang.model.SourceVersion;
 
-// CHECKSTYLE_NAMING_OFF
-
 /**
  * Configures a module definition object using XML.
  */
+@SuppressWarnings({"checkstyle:MemberName", "checkstyle:MethodName"})
 public class ModuleDefSchema extends Schema {
 
   private final class BodySchema extends Schema {
@@ -299,7 +298,7 @@ public class ModuleDefSchema extends Schema {
       return null;
     }
 
-    @SuppressWarnings("unused") // called reflectively
+    @SuppressWarnings({"unused", "checkstyle:ParameterName"}) // called reflectively
     protected Schema __define_configuration_property_begin(PropertyName name,
         String is_multi_valued) throws UnableToCompleteException {
       boolean isMultiValued = toPrimitiveBoolean(is_multi_valued);
@@ -1513,4 +1512,3 @@ public class ModuleDefSchema extends Schema {
     return fn;
   }
 }
-// CHECKSTYLE_NAMING_ON

--- a/dev/core/src/com/google/gwt/dev/jjs/impl/MethodInliner.java
+++ b/dev/core/src/com/google/gwt/dev/jjs/impl/MethodInliner.java
@@ -439,9 +439,8 @@ public class MethodInliner {
               return InlineResult.DO_NOT_BLACKLIST;
             }
           }
-          // CHECKSTYLE_OFF: Fall through!
+          // fall through!
         case CORRECT_ORDER:
-          // CHECKSTYLE_ON
         default:
           if (!x.hasSideEffects()) {
             markCallsAsSideEffectFree(bodyAsExpressionList);

--- a/dev/core/src/com/google/gwt/dev/js/JsToStringGenerationVisitor.java
+++ b/dev/core/src/com/google/gwt/dev/js/JsToStringGenerationVisitor.java
@@ -84,6 +84,7 @@ import java.util.Set;
 /**
  * Produces text output from a JavaScript AST.
  */
+@SuppressWarnings("checkstyle:MethodName")
 public class JsToStringGenerationVisitor extends JsVisitor {
 
   private static final char[] CHARS_BREAK = "break".toCharArray();
@@ -888,8 +889,6 @@ public class JsToStringGenerationVisitor extends JsVisitor {
     return false;
   }
 
-//CHECKSTYLE_NAMING_OFF
-
   protected void _newline() {
     p.newline();
   }
@@ -1307,8 +1306,6 @@ public class JsToStringGenerationVisitor extends JsVisitor {
   private void _while() {
     p.print(CHARS_WHILE);
   }
-
-// CHECKSTYLE_NAMING_ON
 
   private void indent() {
     p.indentIn();

--- a/dev/core/src/com/google/gwt/soyc/MakeTopLevelHtmlForPerm.java
+++ b/dev/core/src/com/google/gwt/soyc/MakeTopLevelHtmlForPerm.java
@@ -49,6 +49,7 @@ import java.util.regex.Pattern;
 /**
  * A utility to make all the HTML files for one permutation.
  */
+@SuppressWarnings("checkstyle:SpaceAfterColon")
 public class MakeTopLevelHtmlForPerm {
   /**
    * A dependency linker for the initial code download. It links to the
@@ -376,7 +377,8 @@ public class MakeTopLevelHtmlForPerm {
           + "See why it's live</a></li>\");");
       outFile.println("    for (var sp = 1; sp <= "
           + globalInformation.getNumFragments() + "; sp++) {");
-      outFile.println("      var d2 = 'methodDependencies-sp' + sp + '-" + getPermutationId() + ".html';");
+      outFile.println("      var d2 = 'methodDependencies-sp' + sp + '-"
+          + getPermutationId() + ".html';");
       outFile.println("      document.write(\"<li><a href='\" + d2 + \"#\" + className +\"'>"
           + " See why it's not exclusive to s.p. #\" + sp + \" (\" + spl[sp - 1] + \")"
           + "</a></li>\");");
@@ -786,10 +788,8 @@ public class MakeTopLevelHtmlForPerm {
           outFile.println("<td>" + className + "</a></td>");
           outFile.println("<td class=\"soyc-bargraph-col\">");
           outFile.println("<div class=\"soyc-bar-graph goog-inline-block\">");
-          // CHECKSTYLE_OFF
           outFile.println("<div style=\"width:" + (perc * 100.0)
               + "%;\" class=\"soyc-bar-graph-fill goog-inline-block\"></div>");
-          // CHECKSTYLE_ON
           outFile.println("</div>");
           outFile.println("</td>");
           outFile.println("<td class=\"soyc-numerical-col\">");
@@ -1137,10 +1137,8 @@ public class MakeTopLevelHtmlForPerm {
             }
             outFile.println("<td class=\"soyc-bargraph-col\">");
             outFile.println("<div class=\"soyc-bar-graph goog-inline-block\">");
-            // CHECKSTYLE_OFF
             outFile.println("<div style=\"width:" + (perc * 100.0)
                 + "%;\" class=\"soyc-bar-graph-fill goog-inline-block\"></div>");
-            // CHECKSTYLE_ON
             outFile.println("</div>");
             outFile.println("</td>");
             outFile.println("<td class=\"soyc-numerical-col\">");
@@ -1314,10 +1312,8 @@ public class MakeTopLevelHtmlForPerm {
             + "</a></td>");
         outFile.println("<td class=\"soyc-bargraph-col\">");
         outFile.println("<div class=\"soyc-bar-graph goog-inline-block\">");
-        // CHECKSTYLE_OFF
         outFile.println("<div style=\"width:" + (perc * 100.0)
             + "%;\" class=\"soyc-bar-graph-fill goog-inline-block\"></div>");
-        // CHECKSTYLE_ON
         outFile.println("</div>");
         outFile.println("</td>");
         outFile.println("<td class=\"soyc-numerical-col\">");
@@ -1391,7 +1387,8 @@ public class MakeTopLevelHtmlForPerm {
   private String[] getUnreferencedTypes(
       PrecompilationMetricsArtifact precompilationMetrics) {
     List<String> astTypes = Lists.newArrayList(precompilationMetrics.getAstTypes());
-    Set<String> unreferencedTypes = Sets.newHashSet(precompilationMetrics.getFinalTypeOracleTypes());
+    Set<String> unreferencedTypes = Sets.newHashSet(
+        precompilationMetrics.getFinalTypeOracleTypes());
     unreferencedTypes.removeAll(astTypes);
     String[] results = unreferencedTypes.toArray(new String[unreferencedTypes.size()]);
     Arrays.sort(results);
@@ -1515,10 +1512,8 @@ public class MakeTopLevelHtmlForPerm {
             + "\" target=\"_top\">" + codeType + "</a></td>");
         outFile.println("<td class=\"soyc-bargraph-col\">");
         outFile.println("<div class=\"soyc-bar-graph goog-inline-block\">");
-        // CHECKSTYLE_OFF
         outFile.println("<div style=\"width:" + (perc * 100.0)
             + "%;\" class=\"soyc-bar-graph-fill goog-inline-block\"></div>");
-        // CHECKSTYLE_ON
         outFile.println("</div>");
         outFile.println("</td>");
         outFile.println("<td class=\"soyc-numerical-col\">");
@@ -1814,10 +1809,8 @@ public class MakeTopLevelHtmlForPerm {
             + "\" target=\"_top\">" + packageName + "</a></td>");
         outFile.println("<td class=\"soyc-bargraph-col\">");
         outFile.println("<div class=\"soyc-bar-graph goog-inline-block\">");
-        // CHECKSTYLE_OFF
         outFile.println("<div style=\"width:" + (perc * 100.0)
             + "%;\" class=\"soyc-bar-graph-fill goog-inline-block\"></div>");
-        // CHECKSTYLE_ON
         outFile.println("</div>");
         outFile.println("</td>");
         outFile.println("<td class=\"soyc-numerical-col\">");

--- a/dev/core/src/com/google/gwt/soyc/MakeTopLevelHtmlForPerm.java
+++ b/dev/core/src/com/google/gwt/soyc/MakeTopLevelHtmlForPerm.java
@@ -49,7 +49,6 @@ import java.util.regex.Pattern;
 /**
  * A utility to make all the HTML files for one permutation.
  */
-@SuppressWarnings("checkstyle:SpaceAfterColon")
 public class MakeTopLevelHtmlForPerm {
   /**
    * A dependency linker for the initial code download. It links to the
@@ -788,8 +787,7 @@ public class MakeTopLevelHtmlForPerm {
           outFile.println("<td>" + className + "</a></td>");
           outFile.println("<td class=\"soyc-bargraph-col\">");
           outFile.println("<div class=\"soyc-bar-graph goog-inline-block\">");
-          outFile.println("<div style=\"width:" + (perc * 100.0)
-              + "%;\" class=\"soyc-bar-graph-fill goog-inline-block\"></div>");
+          outFile.println(getProgressBarHtml(perc));
           outFile.println("</div>");
           outFile.println("</td>");
           outFile.println("<td class=\"soyc-numerical-col\">");
@@ -1137,8 +1135,7 @@ public class MakeTopLevelHtmlForPerm {
             }
             outFile.println("<td class=\"soyc-bargraph-col\">");
             outFile.println("<div class=\"soyc-bar-graph goog-inline-block\">");
-            outFile.println("<div style=\"width:" + (perc * 100.0)
-                + "%;\" class=\"soyc-bar-graph-fill goog-inline-block\"></div>");
+            outFile.println(getProgressBarHtml(perc));
             outFile.println("</div>");
             outFile.println("</td>");
             outFile.println("<td class=\"soyc-numerical-col\">");
@@ -1312,8 +1309,7 @@ public class MakeTopLevelHtmlForPerm {
             + "</a></td>");
         outFile.println("<td class=\"soyc-bargraph-col\">");
         outFile.println("<div class=\"soyc-bar-graph goog-inline-block\">");
-        outFile.println("<div style=\"width:" + (perc * 100.0)
-            + "%;\" class=\"soyc-bar-graph-fill goog-inline-block\"></div>");
+        outFile.println(getProgressBarHtml(perc));
         outFile.println("</div>");
         outFile.println("</td>");
         outFile.println("<td class=\"soyc-numerical-col\">");
@@ -1329,6 +1325,12 @@ public class MakeTopLevelHtmlForPerm {
     outFile.println("</div>");
     addStandardHtmlEnding(outFile);
     outFile.close();
+  }
+
+  @SuppressWarnings("checkstyle:SpaceAfterColon")
+  private String getProgressBarHtml(float perc) {
+    return "<div style=\"width:" + (perc * 100.0)
+        + "%;\" class=\"soyc-bar-graph-fill goog-inline-block\"></div>";
   }
 
   private void addPopup(PrintWriter outFile, String popupName,
@@ -1512,8 +1514,7 @@ public class MakeTopLevelHtmlForPerm {
             + "\" target=\"_top\">" + codeType + "</a></td>");
         outFile.println("<td class=\"soyc-bargraph-col\">");
         outFile.println("<div class=\"soyc-bar-graph goog-inline-block\">");
-        outFile.println("<div style=\"width:" + (perc * 100.0)
-            + "%;\" class=\"soyc-bar-graph-fill goog-inline-block\"></div>");
+        outFile.println(getProgressBarHtml(perc));
         outFile.println("</div>");
         outFile.println("</td>");
         outFile.println("<td class=\"soyc-numerical-col\">");
@@ -1809,8 +1810,7 @@ public class MakeTopLevelHtmlForPerm {
             + "\" target=\"_top\">" + packageName + "</a></td>");
         outFile.println("<td class=\"soyc-bargraph-col\">");
         outFile.println("<div class=\"soyc-bar-graph goog-inline-block\">");
-        outFile.println("<div style=\"width:" + (perc * 100.0)
-            + "%;\" class=\"soyc-bar-graph-fill goog-inline-block\"></div>");
+        outFile.println(getProgressBarHtml(perc));
         outFile.println("</div>");
         outFile.println("</td>");
         outFile.println("<td class=\"soyc-numerical-col\">");

--- a/dev/core/super/com/google/gwt/dev/jjs/intrinsic/com/google/gwt/lang/Cast.java
+++ b/dev/core/super/com/google/gwt/dev/jjs/intrinsic/com/google/gwt/lang/Cast.java
@@ -21,8 +21,6 @@ import com.google.gwt.core.client.JavaScriptObject;
 
 import javaemul.internal.annotations.HasNoSideEffects;
 
-// CHECKSTYLE_NAMING_OFF: Uses legacy conventions of underscore prefixes.
-
 /**
  * This is a magic class the compiler uses to perform any cast operations that require code.<br />
  *
@@ -30,6 +28,7 @@ import javaemul.internal.annotations.HasNoSideEffects;
  * be used directly by user code. The compiler takes care to record most cast operations in user
  * code so that it can build limited but accurate castableTypeMaps.
  */
+@SuppressWarnings("checkstyle:MethodName")
 final class Cast {
 
   /**
@@ -393,5 +392,3 @@ final class Cast {
         || @JavaScriptObject::class;
   }-*/;
 }
-
-// CHECKSTYLE_NAMING_ON

--- a/dev/core/super/com/google/gwt/dev/jjs/intrinsic/com/google/gwt/lang/Exceptions.java
+++ b/dev/core/super/com/google/gwt/dev/jjs/intrinsic/com/google/gwt/lang/Exceptions.java
@@ -23,6 +23,7 @@ import javaemul.internal.annotations.DoNotInline;
 /**
  * This is a magic class the compiler uses to throw and check exceptions.
  */
+@SuppressWarnings("checkstyle:MethodName")
 final class Exceptions {
 
   @DoNotInline // This frame can be useful in understanding the native stack
@@ -59,7 +60,6 @@ final class Exceptions {
    * We use nonstandard naming here so it's easy for the compiler to map to
    * method names based on primitive type name.
    */
-  // CHECKSTYLE_OFF
   static AssertionError makeAssertionError_boolean(boolean message) {
     return new AssertionError(message);
   }
@@ -131,5 +131,4 @@ final class Exceptions {
     }
     return mainException;
   }
-  // CHECKSTYLE_ON
 }

--- a/eclipse/settings/code-style/gwt-checkstyle-tests.xml
+++ b/eclipse/settings/code-style/gwt-checkstyle-tests.xml
@@ -11,7 +11,7 @@ A more lenient set of style checks for test cases, needed because test often nee
 <module name="Checker">
     <property name="severity" value="warning"/>
     <module name="RegexpHeader">
-       <property name="fileExtensions" value="java"/> 
+       <property name="fileExtensions" value="java"/>
        <property name="severity" value="error"/>
        <property name="header" value="^/\*[ ]*$\n^ \* Copyright 20(0[6789]|[12][0-9]) (Google Inc\.|GWT Project Authors)$\n^ \*[ ]*$\n^ \* Licensed under the Apache License, Version 2\.0 \(the &quot;License&quot;\); you may not( use this file except)?$\n^ \* (use this file except )?in compliance with the License\. You may obtain a copy of( the License at)?$\n^ \* the License at$\n^ \*[ ]*$\n^ \* http://www\.apache\.org/licenses/LICENSE-2\.0$\n^ \*[ ]*\n \* Unless required by applicable law or agreed to in writing, software( distributed under the License)?$\n^ \* (distributed under the License )?is distributed on an &quot;AS IS&quot; BASIS, WITHOUT( WARRANTIES OR CONDITIONS OF ANY KIND, either express)?$\n^ \* (WARRANTIES OR CONDITIONS OF ANY KIND, either express )?or implied\. See the( License for the specific language governing permissions and limitations under)?$\n^ \* License for the specific language governing permissions and limitations under$\n^ \* the License\.$\n^ \*/$"/>
        <property name="multiLines" value="6,13"/>
@@ -22,7 +22,8 @@ A more lenient set of style checks for test cases, needed because test often nee
         <property name="severity" value="error"/>
     </module>
     <module name="TreeWalker">
-        <property name="fileExtensions" value="java"/> 
+        <property name="fileExtensions" value="java"/>
+        <module name="SuppressWarningsHolder" />
         <module name="InterfaceIsType">
             <metadata name="com.atlassw.tools.eclipse.checkstyle.lastEnabledSeverity" value="error"/>
             <property name="severity" value="ignore"/>
@@ -53,7 +54,7 @@ A more lenient set of style checks for test cases, needed because test often nee
         <module name="LocalVariableName">
             <metadata name="com.atlassw.tools.eclipse.checkstyle.lastEnabledSeverity" value="error"/>
             <property name="severity" value="ignore"/>
-            <property name="tokens" value="PARAMETER_DEF,VARIABLE_DEF"/>
+            <property name="tokens" value="VARIABLE_DEF"/>
         </module>
         <module name="LeftCurly"/>
         <module name="RightCurly"/>
@@ -118,13 +119,6 @@ A more lenient set of style checks for test cases, needed because test often nee
             <metadata name="com.atlassw.tools.eclipse.checkstyle.lastEnabledSeverity" value="error"/>
             <property name="severity" value="ignore"/>
             <property name="classes" value="Boolean"/>
-        </module>
-        <module name="Regexp">
-            <metadata name="com.atlassw.tools.eclipse.checkstyle.comment" value="check that a space is left after a colon with an assembled error message"/>
-            <property name="severity" value="info"/>
-            <property name="format" value="[^:^&quot;]:&quot; .*+"/>
-            <property name="message" value="check that a space is left after a colon on an assembled error message"/>
-            <property name="illegalPattern" value="true"/>
         </module>
         <module name="Regexp">
             <metadata name="com.atlassw.tools.eclipse.checkstyle.comment" value="more than one blank line"/>
@@ -211,24 +205,6 @@ A more lenient set of style checks for test cases, needed because test often nee
         </module>
         <module name="RedundantModifier"/>
         <module name="EqualsHashCode"/>
-        <module name="SuppressionCommentFilter">
-            <metadata name="com.atlassw.tools.eclipse.checkstyle.comment" value="Avoid name checking"/>
-            <property name="offCommentFormat" value="CHECKSTYLE_NAMING_OFF"/>
-            <property name="onCommentFormat" value="CHECKSTYLE_NAMING_ON"/>
-            <property name="checkFormat" value="MethodName"/>
-        </module>
-        <module name="SuppressionCommentFilter">
-            <metadata name="com.atlassw.tools.eclipse.checkstyle.comment" value="Avoid name checking"/>
-            <property name="offCommentFormat" value="CHECKSTYLE_NAMING_OFF"/>
-            <property name="onCommentFormat" value="CHECKSTYLE_NAMING_ON"/>
-            <property name="checkFormat" value="MemberName"/>
-        </module>
-        <module name="SuppressionCommentFilter">
-            <metadata name="com.atlassw.tools.eclipse.checkstyle.comment" value="Avoid name checking"/>
-            <property name="offCommentFormat" value="CHECKSTYLE_NAMING_OFF"/>
-            <property name="onCommentFormat" value="CHECKSTYLE_NAMING_ON"/>
-            <property name="checkFormat" value="ParameterName"/>
-        </module>
     </module>
     <module name="SuppressWithPlainTextCommentFilter">
         <property name="offCommentFormat" value="CHECKSTYLE_OFF"/>
@@ -237,4 +213,5 @@ A more lenient set of style checks for test cases, needed because test often nee
     <module name="JavadocPackage">
         <property name="severity" value="ignore"/>
     </module>
+    <module name="SuppressWarningsFilter" />
 </module>

--- a/eclipse/settings/code-style/gwt-checkstyle.xml
+++ b/eclipse/settings/code-style/gwt-checkstyle.xml
@@ -117,6 +117,7 @@ Description:
             <metadata name="com.atlassw.tools.eclipse.checkstyle.comment" value="check that a space is left after a colon with an assembled error message"/>
             <property name="severity" value="info"/>
             <property name="id" value="SpaceAfterColon"/>
+            <property name="ignoreComments" value="true"/>
             <property name="format" value="[^:^&quot;]:&quot; .*+"/>
             <property name="message" value="check that a space is left after a colon on an assembled error message"/>
             <property name="illegalPattern" value="true"/>

--- a/eclipse/settings/code-style/gwt-checkstyle.xml
+++ b/eclipse/settings/code-style/gwt-checkstyle.xml
@@ -27,7 +27,8 @@ Description:
     </module>
     <module name="TreeWalker">
         <property name="fileExtensions" value="java"/>
-       <module name="InterfaceIsType">
+        <module name="SuppressWarningsHolder" />
+        <module name="InterfaceIsType">
             <property name="severity" value="ignore"/>
         </module>
         <module name="RedundantImport">
@@ -115,6 +116,7 @@ Description:
         <module name="Regexp">
             <metadata name="com.atlassw.tools.eclipse.checkstyle.comment" value="check that a space is left after a colon with an assembled error message"/>
             <property name="severity" value="info"/>
+            <property name="id" value="SpaceAfterColon"/>
             <property name="format" value="[^:^&quot;]:&quot; .*+"/>
             <property name="message" value="check that a space is left after a colon on an assembled error message"/>
             <property name="illegalPattern" value="true"/>
@@ -195,25 +197,6 @@ Description:
         </module>
         <module name="RedundantModifier"/>
         <module name="EqualsHashCode"/>
-
-        <module name="SuppressionCommentFilter">
-            <metadata name="com.atlassw.tools.eclipse.checkstyle.comment" value="Avoid name checking"/>
-            <property name="offCommentFormat" value="CHECKSTYLE_NAMING_OFF"/>
-            <property name="onCommentFormat" value="CHECKSTYLE_NAMING_ON"/>
-            <property name="checkFormat" value="MethodName"/>
-        </module>
-        <module name="SuppressionCommentFilter">
-            <metadata name="com.atlassw.tools.eclipse.checkstyle.comment" value="Avoid name checking"/>
-            <property name="offCommentFormat" value="CHECKSTYLE_NAMING_OFF"/>
-            <property name="onCommentFormat" value="CHECKSTYLE_NAMING_ON"/>
-            <property name="checkFormat" value="MemberName"/>
-        </module>
-        <module name="SuppressionCommentFilter">
-            <metadata name="com.atlassw.tools.eclipse.checkstyle.comment" value="Avoid name checking"/>
-            <property name="offCommentFormat" value="CHECKSTYLE_NAMING_OFF"/>
-            <property name="onCommentFormat" value="CHECKSTYLE_NAMING_ON"/>
-            <property name="checkFormat" value="ParameterName"/>
-        </module>
     </module>
     <module name="SuppressWithPlainTextCommentFilter">
         <property name="offCommentFormat" value="CHECKSTYLE_OFF"/>
@@ -222,4 +205,5 @@ Description:
     <module name="JavadocPackage">
         <property name="severity" value="ignore"/>
     </module>
+    <module name="SuppressWarningsFilter" />
 </module>

--- a/samples/dynatablerf/src/main/java/com/google/gwt/sample/dynatablerf/client/widgets/ZipPlusFourBox.java
+++ b/samples/dynatablerf/src/main/java/com/google/gwt/sample/dynatablerf/client/widgets/ZipPlusFourBox.java
@@ -52,12 +52,9 @@ public class ZipPlusFourBox extends ValueBox<String> {
       switch (text.length()) {
         case 9:
           text = text.subSequence(0, 5) + "-" + text.subSequence(5, 9);
-          // Fall-though intentional
-          // CHECKSTYLE_OFF
+          /* fall-through intentional */
         case 5:
-          // Fall-through intentional
         case 10:
-          // CHECKSTYLE_ON
           if (PATTERN.test(text.toString())) {
             return text.toString();
           } else {

--- a/samples/validation/src/main/java/com/google/gwt/sample/validation/client/ValidationMessages.java
+++ b/samples/validation/src/main/java/com/google/gwt/sample/validation/client/ValidationMessages.java
@@ -33,7 +33,6 @@ public interface ValidationMessages extends
   @DefaultStringValue("Name must be at least {min} characters long.")
   @Key("custom.name.size.message")
 
-// CHECKSTYLE_NAMING_OFF
+  @SuppressWarnings("checkstyle:MethodName")
   String custom_name_size_message();
-// CHECKSTYLE_NAMING_ON
 }

--- a/user/src/com/google/gwt/core/client/JsDate.java
+++ b/user/src/com/google/gwt/core/client/JsDate.java
@@ -106,17 +106,15 @@ public class JsDate extends JavaScriptObject {
     return Date.parse(dateString);
   }-*/;
 
-  // CHECKSTYLE_OFF: Matching the spec.
   /**
    * Returns the internal millisecond representation of the specified UTC date
    * and time.
    */
+  @SuppressWarnings("checkstyle:MethodName")
   public static native double UTC(int year, int month, int dayOfMonth, int hours,
       int minutes, int seconds, int millis) /*-{
     return Date.UTC(year, month, dayOfMonth, hours, minutes, seconds, millis);
   }-*/;
-
-  // CHECKSTYLE_ON
 
   /**
    * Non directly instantiable, use one of the {@link #create()} methods.

--- a/user/src/com/google/gwt/i18n/client/DateTimeFormatInfoAdapter.java
+++ b/user/src/com/google/gwt/i18n/client/DateTimeFormatInfoAdapter.java
@@ -32,8 +32,6 @@ class DateTimeFormatInfoAdapter extends DefaultDateTimeFormatInfo {
     this.dtc = dtc;
   }
 
-  // CHECKSTYLE_OFF
-
   @Override
   public String[] ampms() {
     return dtc.ampms();

--- a/user/src/com/google/gwt/i18n/shared/DateTimeFormat.java
+++ b/user/src/com/google/gwt/i18n/shared/DateTimeFormat.java
@@ -1906,10 +1906,9 @@ public class DateTimeFormat {
           cal.setTzOffset(0);
           return true;
         }
-        // CHECKSTYLE_OFF: Fall through
+        // fall through
       case 'z': // time zone offset
       case 'v': // time zone generic
-        // CHECKSTYLE_ON
         return subParseTimeZoneInGMT(text, start, pos, cal);
       default:
         return false;

--- a/user/src/com/google/gwt/resources/rebind/context/InlineResourceContext.java
+++ b/user/src/com/google/gwt/resources/rebind/context/InlineResourceContext.java
@@ -32,6 +32,7 @@ class InlineResourceContext extends StaticResourceContext {
   }
 
   @Override
+  @SuppressWarnings("checkstyle:SpaceAfterColon")
   public String deploy(String suggestedFileName, String mimeType, byte[] data,
       boolean forceExternal) throws UnableToCompleteException {
     TreeLogger logger = getLogger();
@@ -42,10 +43,8 @@ class InlineResourceContext extends StaticResourceContext {
 
       String base64Contents = toBase64(data);
 
-      // CHECKSTYLE_OFF
       String encoded = "\"data:" + mimeType.replaceAll("\"", "\\\\\"")
           + ";base64," + base64Contents + "\"";
-      // CHECKSTYLE_ON
 
       /*
        * We know that the encoded format will be one byte per character, since

--- a/user/src/com/google/gwt/resources/rebind/context/InlineResourceContext.java
+++ b/user/src/com/google/gwt/resources/rebind/context/InlineResourceContext.java
@@ -32,7 +32,6 @@ class InlineResourceContext extends StaticResourceContext {
   }
 
   @Override
-  @SuppressWarnings("checkstyle:SpaceAfterColon")
   public String deploy(String suggestedFileName, String mimeType, byte[] data,
       boolean forceExternal) throws UnableToCompleteException {
     TreeLogger logger = getLogger();
@@ -42,7 +41,7 @@ class InlineResourceContext extends StaticResourceContext {
       logger.log(TreeLogger.DEBUG, "Inlining", null);
 
       String base64Contents = toBase64(data);
-
+      @SuppressWarnings("checkstyle:SpaceAfterColon")
       String encoded = "\"data:" + mimeType.replaceAll("\"", "\\\\\"")
           + ";base64," + base64Contents + "\"";
 

--- a/user/src/com/google/gwt/resources/rebind/context/MhtmlClientBundleGenerator.java
+++ b/user/src/com/google/gwt/resources/rebind/context/MhtmlClientBundleGenerator.java
@@ -49,6 +49,7 @@ public class MhtmlClientBundleGenerator extends AbstractClientBundleGenerator {
   }
 
   @Override
+  @SuppressWarnings("checkstyle:SpaceAfterColon")
   protected void doAddFieldsAndRequirements(TreeLogger logger,
       GeneratorContext generatorContext, FieldsImpl fields,
       ClientBundleRequirements requirements) throws UnableToCompleteException {
@@ -67,9 +68,7 @@ public class MhtmlClientBundleGenerator extends AbstractClientBundleGenerator {
         "GWT.getModuleBaseURL().startsWith(\"https\")", true, true);
     resourceContext.setIsHttpsIdent(isHttpsIdent);
 
-    // CHECKSTYLE_OFF
     // "mhtml:" + GWT.getModuleBaseURL() + "partialPath!cid:"
-    // CHECKSTYLE_ON
     bundleBaseIdent = fields.define(stringType, "bundleBase", null, true, true);
     resourceContext.setBundleBaseIdent(bundleBaseIdent);
   }

--- a/user/src/com/google/gwt/resources/rebind/context/MhtmlClientBundleGenerator.java
+++ b/user/src/com/google/gwt/resources/rebind/context/MhtmlClientBundleGenerator.java
@@ -49,7 +49,6 @@ public class MhtmlClientBundleGenerator extends AbstractClientBundleGenerator {
   }
 
   @Override
-  @SuppressWarnings("checkstyle:SpaceAfterColon")
   protected void doAddFieldsAndRequirements(TreeLogger logger,
       GeneratorContext generatorContext, FieldsImpl fields,
       ClientBundleRequirements requirements) throws UnableToCompleteException {

--- a/user/src/com/google/gwt/resources/rebind/context/MhtmlResourceContext.java
+++ b/user/src/com/google/gwt/resources/rebind/context/MhtmlResourceContext.java
@@ -64,6 +64,7 @@ public class MhtmlResourceContext extends StaticResourceContext {
   }
 
   @Override
+  @SuppressWarnings("checkstyle:SpaceAfterColon")
   public String deploy(String suggestedFileName, String mimeType, byte[] data,
       boolean forceExternal) throws UnableToCompleteException {
 
@@ -104,9 +105,7 @@ public class MhtmlResourceContext extends StaticResourceContext {
 
     pw.println("--" + BOUNDARY);
     pw.println("Content-Id:<" + location + ">");
-    // CHECKSTYLE_OFF
     pw.println("Content-Type:" + mimeType);
-    // CHECKSTYLE_ON
     pw.println("Content-Transfer-Encoding:base64");
     pw.println();
     pw.println(base64);

--- a/user/src/com/google/gwt/resources/rebind/context/MhtmlResourceContext.java
+++ b/user/src/com/google/gwt/resources/rebind/context/MhtmlResourceContext.java
@@ -64,7 +64,6 @@ public class MhtmlResourceContext extends StaticResourceContext {
   }
 
   @Override
-  @SuppressWarnings("checkstyle:SpaceAfterColon")
   public String deploy(String suggestedFileName, String mimeType, byte[] data,
       boolean forceExternal) throws UnableToCompleteException {
 
@@ -105,7 +104,9 @@ public class MhtmlResourceContext extends StaticResourceContext {
 
     pw.println("--" + BOUNDARY);
     pw.println("Content-Id:<" + location + ">");
-    pw.println("Content-Type:" + mimeType);
+    @SuppressWarnings("checkstyle:SpaceAfterColon")
+    String contentTypeHeader = "Content-Type:" + mimeType;
+    pw.println(contentTypeHeader);
     pw.println("Content-Transfer-Encoding:base64");
     pw.println();
     pw.println(base64);

--- a/user/src/com/google/web/bindery/requestfactory/shared/impl/BaseProxyCategory.java
+++ b/user/src/com/google/web/bindery/requestfactory/shared/impl/BaseProxyCategory.java
@@ -31,9 +31,8 @@ public class BaseProxyCategory {
    * Sniff all return values and ensure that if the current bean is a mutable
    * EntityProxy, that its return values are mutable.
    */
-  // CHECKSTYLE_OFF
+  @SuppressWarnings("checkstyle:MethodName")
   public static <T> T __intercept(AutoBean<?> bean, T returnValue) {
-    // CHECKSTYLE_ON
 
     AbstractRequestContext context = requestContext(bean);
 

--- a/user/super/com/google/gwt/emul/java/io/Serializable.java
+++ b/user/super/com/google/gwt/emul/java/io/Serializable.java
@@ -25,8 +25,9 @@ import jsinterop.annotations.JsMethod;
  * The Java serialization protocol is explicitly not supported.
  */
 public interface Serializable {
-  // CHECKSTYLE_OFF: Utility methods.
+
   @JsMethod
+  @SuppressWarnings("checkstyle:MethodName")
   static boolean $isInstance(HasSerializableTypeMarker instance) {
     if (instance == null) {
       return false;
@@ -40,5 +41,4 @@ public interface Serializable {
         // Arrays are implicitly instances of Serializable (JLS 10.7).
         || ArrayHelper.isArray(instance);
   }
-  // CHECKSTYLE_ON: end utility methods
 }

--- a/user/super/com/google/gwt/emul/java/lang/CharSequence.java
+++ b/user/super/com/google/gwt/emul/java/lang/CharSequence.java
@@ -90,8 +90,8 @@ public interface CharSequence {
     return cs1.toString().compareTo(cs2.toString());
   }
 
-  // CHECKSTYLE_OFF: Utility methods.
   @JsMethod
+  @SuppressWarnings("checkstyle:MethodName")
   static boolean $isInstance(HasCharSequenceTypeMarker instance) {
     if (JsUtils.typeOf(instance).equals("string")) {
       return true;
@@ -99,5 +99,4 @@ public interface CharSequence {
 
     return instance != null && instance.getTypeMarker() == true;
   }
-  // CHECKSTYLE_ON: end utility methods
 }

--- a/user/super/com/google/gwt/emul/java/lang/Comparable.java
+++ b/user/super/com/google/gwt/emul/java/lang/Comparable.java
@@ -28,8 +28,8 @@ import jsinterop.annotations.JsMethod;
 public interface Comparable<T> {
   int compareTo(T other);
 
-  // CHECKSTYLE_OFF: Utility methods.
   @JsMethod
+  @SuppressWarnings("checkstyle:MethodName")
   static boolean $isInstance(HasComparableTypeMarker instance) {
     String type = JsUtils.typeOf(instance);
     if (type.equals("boolean") || type.equals("number") || type.equals("string")) {
@@ -38,5 +38,4 @@ public interface Comparable<T> {
 
     return instance != null && instance.getTypeMarker() == true;
   }
-  // CHECKSTYLE_ON: end utility methods
 }

--- a/user/super/com/google/gwt/emul/java/lang/Number.java
+++ b/user/super/com/google/gwt/emul/java/lang/Number.java
@@ -24,6 +24,7 @@ import jsinterop.annotations.JsType;
 /**
  * Abstract base class for numeric wrapper classes.
  */
+@SuppressWarnings("checkstyle:MethodName")
 public abstract class Number implements Serializable {
 
   /**
@@ -31,9 +32,8 @@ public abstract class Number implements Serializable {
    */
   private static NativeRegExp floatRegex;
 
-  // CHECKSTYLE_OFF: A special need to use unusual identifiers to avoid
-  // introducing name collisions.
-
+  // A special need to use unusual identifiers to avoid introducing name collisions.
+  @SuppressWarnings("checkstyle:ClassName")
   static class __Decode {
     public final String payload;
     public final int radix;
@@ -289,7 +289,7 @@ public abstract class Number implements Serializable {
     if (head > 0) {
       // accumulate negative numbers, as -Long.MAX_VALUE == Long.MIN_VALUE + 1
       // (in other words, -Long.MIN_VALUE overflows, see issue 7308)
-      toReturn = - JsUtils.parseInt(s.substring(0, head), radix);
+      toReturn = -JsUtils.parseInt(s.substring(0, head), radix);
       s = s.substring(head);
       length -= head;
       firstTime = false;
@@ -340,8 +340,6 @@ public abstract class Number implements Serializable {
     }
     return floatRegex.test(str);
   }
-
-  // CHECKSTYLE_ON
 
   public byte byteValue() {
     return (byte) intValue();

--- a/user/super/com/google/gwt/emul/java/lang/Object.java
+++ b/user/super/com/google/gwt/emul/java/lang/Object.java
@@ -29,9 +29,8 @@ public class Object {
   /**
    * Holds class literal for subtypes of Object.
    */
-  // CHECKSTYLE_OFF
+  @SuppressWarnings("checkstyle:MemberName")
   private transient Class<?> ___clazz;
-  // CHECKSTYLE_ON
 
   /**
    * Used by {@link com.google.gwt.core.client.impl.WeakMapping} in web mode

--- a/user/super/com/google/gwt/emul/java/lang/Void.java
+++ b/user/super/com/google/gwt/emul/java/lang/Void.java
@@ -28,7 +28,7 @@ public final class Void {
   private Void() {
   }
 
-  // CHECKSTYLE_OFF: Utility Methods for unboxed Void.
+  @SuppressWarnings("checkstyle:MethodName")
   protected static Void $create() {
     throw new AssertionError();
   }

--- a/user/super/com/google/gwt/emul/java/util/Date.java
+++ b/user/super/com/google/gwt/emul/java/util/Date.java
@@ -44,13 +44,11 @@ public class Date implements Cloneable, Comparable<Date>, Serializable {
     return (long) parsed;
   }
 
-  // CHECKSTYLE_OFF: Matching the spec.
+  @SuppressWarnings("checkstyle:MethodName")
   public static long UTC(int year, int month, int date, int hrs, int min,
       int sec) {
     return (long) NativeDate.UTC(year + 1900, month, date, hrs, min, sec, 0);
   }
-
-  // CHECKSTYLE_ON
 
   /**
    * Ensure a number is displayed with two digits.
@@ -299,10 +297,9 @@ public class Date implements Cloneable, Comparable<Date>, Serializable {
 
   @JsType(isNative = true, name = "Date", namespace = JsPackage.GLOBAL)
   private static class NativeDate {
-    // CHECKSTYLE_OFF: Matching the spec.
+    @SuppressWarnings("checkstyle:MethodName")
     public static native double UTC(int year, int month, int dayOfMonth, int hours,
         int minutes, int seconds, int millis);
-    // CHECKSTYLE_ON
     public static native double parse(String dateString);
     public NativeDate() { }
     public NativeDate(double milliseconds) { }

--- a/user/super/com/google/gwt/emul/java/util/List.java
+++ b/user/super/com/google/gwt/emul/java/util/List.java
@@ -90,19 +90,18 @@ public interface List<E> extends Collection<E> {
     return __ofInternal((E[]) new Object[] {e1, e2, e3, e4, e5, e6, e7, e8, e9, e10});
   }
 
-  // CHECKSTYLE_OFF: Internal only method that cannot collide with future JRE changes
   /**
    * Internal-only helper to avoid copying the incoming array, and instead just wrap it with an
    * immutable List after checking there are no nulls.
    */
   @JsIgnore
+  @SuppressWarnings("checkstyle:MethodName")
   static <E> List<E> __ofInternal(E[] elements) {
     for (int i = 0; i < elements.length; i++) {
       checkNotNull(elements[i]);
     }
     return Collections.unmodifiableList(Arrays.asList(elements));
   }
-  // CHECKSTYLE_ON
 
   @JsIgnore
   static <E> List<E> of(E... elements) {

--- a/user/super/com/google/gwt/junit/translatable/com/google/gwt/junit/client/GWTTestCase.java
+++ b/user/super/com/google/gwt/junit/translatable/com/google/gwt/junit/client/GWTTestCase.java
@@ -105,10 +105,10 @@ public abstract class GWTTestCase extends TestCase {
     setName(testName);
   }
 
-  // CHECKSTYLE_OFF
   /**
    * Actually run the user's test. Called from {@link GWTRunner}.
    */
+  @SuppressWarnings("checkstyle:MethodName")
   public void __doRunTest() {
     if (shouldCatchExceptions()) {
       try {
@@ -132,7 +132,6 @@ public abstract class GWTTestCase extends TestCase {
       reportResultsAndRunNextMethod(synchronousException);
     } // else Test is still running; wait for asynchronous completion.
   }
-  // CHECKSTYLE_ON
 
   public boolean catchExceptions() {
     return true;

--- a/user/test/com/google/gwt/dev/jjs/test/CompilerTest.java
+++ b/user/test/com/google/gwt/dev/jjs/test/CompilerTest.java
@@ -866,9 +866,8 @@ public class CompilerTest extends GWTTestCase {
     }
   }-*/;
 
-  // CHECKSTYLE_OFF
-
-  @SuppressWarnings({"empty", "LoopConditionChecker"})
+  @SuppressWarnings({"empty", "LoopConditionChecker",
+      "checkstyle.NeedBraces", "checkstyle.WhitespaceAround", "checkstyle.EmptyStatement"})
   public void testEmptyStatements() {
     boolean b = false;
 
@@ -900,8 +899,6 @@ public class CompilerTest extends GWTTestCase {
     else
       ;
   }
-
-  // CHECKSTYLE_ON
 
   public native void testEmptyStatementsNative() /*-{
     var b = false;

--- a/user/test/com/google/gwt/dev/jjs/test/Java8Test.java
+++ b/user/test/com/google/gwt/dev/jjs/test/Java8Test.java
@@ -40,6 +40,7 @@ import jsinterop.annotations.JsType;
  * Tests Java 8 features.
  */
 @DoNotRunWith(Platform.Devel)
+@SuppressWarnings("checkstyle:LeftCurly") // allow compact methods
 public class Java8Test extends GWTTestCase {
   int local = 42;
 
@@ -90,33 +91,27 @@ public class Java8Test extends GWTTestCase {
 
   interface DefaultInterface {
     void method1();
-    // CHECKSTYLE_OFF
-    default int method2() { return 42; }
+     default int method2() { return 42; }
     default int redeclaredAsAbstract() {
       return 88;
     }
     default Integer addInts(int x, int y) { return x + y; }
     default String print() { return "DefaultInterface"; }
-    // CHECKSTYLE_ON
   }
 
   interface DefaultInterface2 {
     void method3();
-    // CHECKSTYLE_OFF
     default int method4() { return 23; }
     default int redeclaredAsAbstract() {
       return 77;
     }
-    // CHECKSTYLE_ON
   }
 
   interface DefaultInterfaceSubType extends DefaultInterface {
-    // CHECKSTYLE_OFF
     default int method2() { return 43; }
     default String print() {
       return "DefaultInterfaceSubType " + DefaultInterface.super.print();
     }
-    // CHECKSTYLE_ON
   }
 
   static abstract class DualImplementorSuper implements DefaultInterface {
@@ -205,9 +200,9 @@ public class Java8Test extends GWTTestCase {
           implements DefaultInterfaceSubType {
     public void method1() {
     }
-    // CHECKSTYLE_OFF
-    public String print() { return "DefaultInterfaceImplVirtualUpRefTwoInterfaces"; }
-    // CHECKSTYLE_ON
+    public String print() {
+      return "DefaultInterfaceImplVirtualUpRefTwoInterfaces";
+    }
   }
 
   @Override
@@ -543,10 +538,8 @@ public class Java8Test extends GWTTestCase {
   }
 
   interface InterfaceWithTwoDefenderMethods {
-    // CHECKSTYLE_OFF
     default String foo() { return "interface.foo"; }
     default String bar() { return this.foo() + " " + foo(); }
-    // CHECKSTYLE_ON
   }
 
   class ClassImplementOneDefenderMethod implements InterfaceWithTwoDefenderMethods {
@@ -565,9 +558,7 @@ public class Java8Test extends GWTTestCase {
   }
 
   interface InterfaceImplementOneDefenderMethod extends InterfaceWithTwoDefenderMethods {
-    // CHECKSTYLE_OFF
     default String foo() { return "interface1.foo"; }
-    // CHECKSTYLE_ON
   }
 
   interface InterfaceImplementZeroDefenderMethod extends InterfaceWithTwoDefenderMethods {
@@ -602,14 +593,10 @@ public class Java8Test extends GWTTestCase {
   }
 
   interface InterfaceI {
-    // CHECKSTYLE_OFF
     default String print() { return "interface1"; }
-    // CHECKSTYLE_ON
   }
   interface InterfaceII {
-    // CHECKSTYLE_OFF
     default String print() { return "interface2"; }
-    // CHECKSTYLE_ON
   }
   class ClassI {
     public String print() {
@@ -628,16 +615,12 @@ public class Java8Test extends GWTTestCase {
   }
 
   interface II {
-    // CHECKSTYLE_OFF
     default String fun() { return "fun() in i: " + this.foo(); };
     default String foo() { return "foo() in i.\n"; };
-    // CHECKSTYLE_ON
   }
   interface JJ extends II {
-    // CHECKSTYLE_OFF
     default String fun() { return "fun() in j: " + this.foo() + II.super.fun(); };
     default String foo() { return "foo() in j.\n"; }
-    // CHECKSTYLE_ON
   }
   class AA {
     public String fun() {
@@ -694,14 +677,12 @@ public class Java8Test extends GWTTestCase {
   }
 
   interface OuterInterface {
-    // CHECKSTYLE_OFF
     default String m() {
       return "I.m;" + new InnerClass().n();
     }
     default String n() {
       return "I.n;" + this.m();
     }
-    // CHECKSTYLE_ON
     class InnerClass {
       public String n() {
         return "A.n;" + m();

--- a/user/test/com/google/gwt/dev/jjs/test/unusedimports/package-info.java
+++ b/user/test/com/google/gwt/dev/jjs/test/unusedimports/package-info.java
@@ -14,7 +14,5 @@
  * the License.
  */
 
-// CHECKSTYLE_OFF
-
 package com.google.gwt.dev.jjs.test.unusedimports;
 

--- a/user/test/com/google/gwt/place/impl/PlaceHistoryMapperGeneratorTest.java
+++ b/user/test/com/google/gwt/place/impl/PlaceHistoryMapperGeneratorTest.java
@@ -113,7 +113,7 @@ public class PlaceHistoryMapperGeneratorTest extends GWTTestCase {
    * When asked to GWT.create a concrete implementation of PlaceHistoryMapper,
    * the generator politely instantiates it. This is to make life easier
    * for GIN users. See 
-   * http://code.google.com/p/google-web-toolkit/issues/detail?id=5563
+   * <a href="https://github.com/gwtproject/gwt/issues/5562">GitHub issue</a>.
    */
   public void testNotAnInterface() {
     PlaceHistoryMapper subject = GWT.create(LocalConcreteClass.class);
@@ -122,7 +122,7 @@ public class PlaceHistoryMapperGeneratorTest extends GWTTestCase {
   }
 
   /**
-   * See https://code.google.com/p/google-web-toolkit/issues/detail?id=8036
+   * See <a href="https://github.com/gwtproject/gwt/issues/8033">GitHub issue</a>.
    */
   public void testSortOrder() {
     PlaceHistoryMapper subject = GWT.create(SortOrder.class);
@@ -131,7 +131,6 @@ public class PlaceHistoryMapperGeneratorTest extends GWTTestCase {
     assertEquals("Place3:" + place3.content, subject.getToken(place3));
   }
 
-  // CHECKSTYLE_OFF
   private void doTest(AbstractPlaceHistoryMapper<?> subject,
       TokenizerFactory factory) {
     String history1 = subject.getPrefixAndToken(place1).toString();
@@ -179,5 +178,4 @@ public class PlaceHistoryMapperGeneratorTest extends GWTTestCase {
     assertNull(subject.getPrefixAndToken(place));
     assertNull(subject.getTokenizer("snot"));
   }
-  // CHECKSTYLE_ON
 }

--- a/user/test/com/google/gwt/uibinder/elementparsers/ElementParserTester.java
+++ b/user/test/com/google/gwt/uibinder/elementparsers/ElementParserTester.java
@@ -135,9 +135,7 @@ class ElementParserTester {
 
     StringBuffer b = wrapXML(xml);
 
-    // CHECKSTYLE_OFF
     String tag = "g:" + parsedType.getName();
-    // CHECKSTYLE_ON
     parser.parse(getElem(b.toString(), tag), FIELD_NAME, parsedType, writer);
     return fieldManager.lookup(FIELD_NAME);
   }

--- a/user/test/com/google/gwt/xml/client/XMLTest.java
+++ b/user/test/com/google/gwt/xml/client/XMLTest.java
@@ -378,19 +378,15 @@ public class XMLTest extends GWTTestCase {
     for (Iterator<Node> iter = textLikeNodes.iterator(); iter.hasNext();) {
       CharacterData textLike = (CharacterData) iter.next();
       textLike.setData(b.toString());
-      // CHECKSTYLE_OFF
-      assertEquals("initialLength type:" + textLike.getNodeType(), 30000 - 32,
+      assertEquals("initialLength type: " + textLike.getNodeType(), 30000 - 32,
           textLike.getLength());
       assertEquals("initialEquals", textLike.getData(), b.toString());
-      // CHECKSTYLE_ON
     }
     for (int i = 32; i < 29900; i += 100) {
       for (Iterator<Node> iter = textLikeNodes.iterator(); iter.hasNext();) {
         CharacterData textLike = (CharacterData) iter.next();
-        // CHECKSTYLE_OFF
-        assertEquals("substring type:" + textLike.getNodeType() + " count: "
+        assertEquals("substring type: " + textLike.getNodeType() + " count: "
             + i, b.substring(i, i + 100), textLike.substringData(i, 100));
-        // CHECKSTYLE_ON
       }
     }
     for (Iterator<Node> iter = textLikeNodes.iterator(); iter.hasNext();) {
@@ -398,12 +394,10 @@ public class XMLTest extends GWTTestCase {
       CharacterData textLike = (CharacterData) iter.next();
       textLike.deleteData(100, 100);
       bTemp.delete(100, 200);
-      // CHECKSTYLE_OFF
-      assertEquals("deleteLength type:" + textLike.getNodeType(),
+      assertEquals("deleteLength type: " + textLike.getNodeType(),
           bTemp.length(), textLike.getData().length());
-      assertEquals("deleteEquals type:" + textLike.getNodeType(),
+      assertEquals("deleteEquals type: " + textLike.getNodeType(),
           bTemp.toString(), textLike.getData());
-      // CHECKSTYLE_ON
       bTemp.setLength(0);
     }
     for (Iterator<Node> iter = textLikeNodes.iterator(); iter.hasNext();) {
@@ -412,12 +406,10 @@ public class XMLTest extends GWTTestCase {
       textLike.setData(bTemp.toString());
       textLike.replaceData(50, 100, " ");
       bTemp.replace(50, 150, " ");
-      // CHECKSTYLE_OFF
-      assertEquals("replaceLength type:" + textLike.getNodeType(),
+      assertEquals("replaceLength type: " + textLike.getNodeType(),
           bTemp.length(), textLike.getData().length());
-      assertEquals("replaceEquals type:" + textLike.getNodeType(),
+      assertEquals("replaceEquals type: " + textLike.getNodeType(),
           bTemp.toString(), textLike.getData());
-      // CHECKSTYLE_ON
       bTemp.setLength(0);
     }
     for (Iterator<Node> iter = textLikeNodes.iterator(); iter.hasNext();) {


### PR DESCRIPTION
SuppressWarnings makes it easier to see which warnings are actually suppressed and removes the need for on/off toggles that might get mismatched.

Moved out of #10176 