### PR TITLE
DeadCodeEliminationTest cleanup, optimize String.hashCode

### DIFF
--- a/dev/core/src/com/google/gwt/dev/jjs/impl/DeadCodeElimination.java
+++ b/dev/core/src/com/google/gwt/dev/jjs/impl/DeadCodeElimination.java
@@ -1847,13 +1847,6 @@ public class DeadCodeElimination {
         return;
       }
 
-      if (method.getName().endsWith("hashCode")) {
-        // This cannot be computed at compile time because our implementation
-        // differs from the JRE.
-        // TODO: actually, I think it DOES match now, so we can remove this?
-        return;
-      }
-
       boolean isStaticImplMethod = program.isStaticImpl(method);
       JExpression instance = isStaticImplMethod ? x.getArgs().get(0) : x.getInstance();
       // drop the instance argument if the call was devirtualized as the compile time evaluation


### PR DESCRIPTION
This test had a few tests unnecessarily disabled checks as well as some typos or errors in comments.

Added a simple test for optimizing out for loops, as this was missing.

Enabled String.hashCode() constant optimization, our emul has been consistent with JRE semantics since d0940870.

Also fixes #10067 by specifying locale when printing floats.
