### PR TITLE
Fix for String::lastIndexOf with negative position argument

### DIFF
--- a/user/super/com/google/gwt/emul/java/lang/String.java
+++ b/user/super/com/google/gwt/emul/java/lang/String.java
@@ -502,7 +502,7 @@ public final class String implements Comparable<String>, CharSequence,
   }
 
   public int lastIndexOf(String str, int start) {
-    return asNativeString().lastIndexOf(str, start);
+    return start < 0 ? -1 : asNativeString().lastIndexOf(str, start);
   }
 
   @Override

--- a/user/test/com/google/gwt/emultest/java/lang/StringTest.java
+++ b/user/test/com/google/gwt/emultest/java/lang/StringTest.java
@@ -568,10 +568,12 @@ public class StringTest extends GWTTestCase {
   }
 
   public void testLastIndexOf() {
-    String x = "abcdeabcdef";
+    String x = hideFromCompiler("abcdeabcdef");
     assertEquals(9, x.lastIndexOf("e"));
     assertEquals(10, x.lastIndexOf("f"));
     assertEquals(-1, x.lastIndexOf("f", 1));
+    assertEquals(-1, x.lastIndexOf("a", -1));
+    assertEquals(-1, x.lastIndexOf('a', -1));
   }
 
   public void testLength() {


### PR DESCRIPTION
Fixes #6614 by adding a check for the discrepancy.

In JS

> If position is less than 0, the behavior is the same as for 0 
> -- https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/lastIndexOf

whereas in Java negative position always results in -1.