### PR TITLE
Rewrite Java9+ references to something that should work in Java 8

### DIFF
--- a/user/build.xml
+++ b/user/build.xml
@@ -96,6 +96,7 @@
   <target name="compile" description="Compile all class files"
           unless="compile.complete">
     <gwt.javac
+            release="8"
             excludes="**/EmulatedCharset.java,**/HashCodes.java,**/ConsoleLogger.java,**/NativeRegExp.java,**/SuperDevModeLogger.java">
       <src path="super/com/google/gwt/emul/javaemul/internal" />
       <classpath>
@@ -224,6 +225,7 @@
 
       <!-- Compile a specific gwt-user jar just for jakarta, which will be only used then to produce gwt-servlet-jakarta.jar -->
       <gwt.javac
+              release="8"
               srcdir="${project.build}/jakarta-src"
               destdir="${javac.out}-jakarta"
               excludes="**/EmulatedCharset.java,**/HashCodes.java,**/ConsoleLogger.java,**/NativeRegExp.java,**/SuperDevModeLogger.java,**/junit/**">

--- a/user/src/com/google/gwt/resources/rebind/context/AbstractResourceContext.java
+++ b/user/src/com/google/gwt/resources/rebind/context/AbstractResourceContext.java
@@ -24,8 +24,10 @@ import com.google.gwt.resources.ext.ResourceContext;
 import com.google.gwt.resources.ext.ResourceGenerator;
 import com.google.gwt.resources.ext.ResourceGeneratorUtil;
 import com.google.gwt.thirdparty.guava.common.io.BaseEncoding;
+import com.google.gwt.thirdparty.guava.common.io.ByteStreams;
 
 import java.io.IOException;
+import java.io.InputStream;
 import java.net.URL;
 import java.net.URLConnection;
 
@@ -71,7 +73,10 @@ public abstract class AbstractResourceContext implements ResourceContext {
     String fileName = ResourceGeneratorUtil.baseName(resource);
     try {
       URLConnection urlConnection = resource.openConnection();
-      byte[] bytes = urlConnection.getInputStream().readAllBytes();
+      final byte[] bytes;
+      try (InputStream inputStream = urlConnection.getInputStream()) {
+        bytes = ByteStreams.toByteArray(inputStream);
+      }
       String finalMimeType = (mimeType != null) ? mimeType : urlConnection.getContentType();
       return deploy(fileName, finalMimeType, bytes, forceExternal);
     } catch (IOException e) {

--- a/user/src/com/google/gwt/uibinder/rebind/GwtResourceEntityResolver.java
+++ b/user/src/com/google/gwt/uibinder/rebind/GwtResourceEntityResolver.java
@@ -20,6 +20,7 @@ import com.google.gwt.dev.resource.Resource;
 import com.google.gwt.dev.resource.ResourceOracle;
 import com.google.gwt.dev.util.collect.Sets;
 
+import com.google.gwt.thirdparty.guava.common.io.ByteStreams;
 import org.xml.sax.EntityResolver;
 import org.xml.sax.InputSource;
 
@@ -75,7 +76,7 @@ class GwtResourceEntityResolver implements EntityResolver {
     if (resource != null) {
       String content;
       try (InputStream is = resource.openContents()) {
-        content = new String(is.readAllBytes(), StandardCharsets.UTF_8);
+        content = new String(ByteStreams.toByteArray(is), StandardCharsets.UTF_8);
       } catch (IOException ex) {
         logger.log(TreeLogger.ERROR, "Error reading resource: " + resource.getLocation());
         throw new RuntimeException(ex);

--- a/user/src/com/google/gwt/uibinder/rebind/UiBinderGenerator.java
+++ b/user/src/com/google/gwt/uibinder/rebind/UiBinderGenerator.java
@@ -27,6 +27,7 @@ import com.google.gwt.dev.resource.Resource;
 import com.google.gwt.dev.resource.ResourceOracle;
 import com.google.gwt.resources.rg.GssResourceGenerator;
 import com.google.gwt.resources.rg.GssResourceGenerator.GssOptions;
+import com.google.gwt.thirdparty.guava.common.io.ByteStreams;
 import com.google.gwt.uibinder.client.UiTemplate;
 import com.google.gwt.uibinder.rebind.messages.MessagesWriter;
 import com.google.gwt.uibinder.rebind.model.ImplicitClientBundle;
@@ -205,7 +206,7 @@ public class UiBinderGenerator extends Generator {
       String content = designTime.getTemplateContent(templatePath);
       if (content == null) {
         try (InputStream in = resource.openContents()) {
-          content = new String(in.readAllBytes(), StandardCharsets.UTF_8);
+          content = new String(ByteStreams.toByteArray(in), StandardCharsets.UTF_8);
         }
       }
       doc = new W3cDomHelper(logger.getTreeLogger(), resourceOracle).documentFor(content,

--- a/user/src/com/google/gwt/user/tools/CommandLineCreatorUtils.java
+++ b/user/src/com/google/gwt/user/tools/CommandLineCreatorUtils.java
@@ -15,6 +15,8 @@
  */
 package com.google.gwt.user.tools;
 
+import com.google.gwt.thirdparty.guava.common.io.ByteStreams;
+
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
@@ -129,7 +131,7 @@ public class CommandLineCreatorUtils {
       if (in == null) {
         throw new FileNotFoundException(partialPath);
       }
-      return new String(in.readAllBytes(), StandardCharsets.UTF_8);
+      return new String(ByteStreams.toByteArray(in), StandardCharsets.UTF_8);
     }
   }
 

--- a/user/src/com/google/gwt/user/tools/QuerySourceMap.java
+++ b/user/src/com/google/gwt/user/tools/QuerySourceMap.java
@@ -33,7 +33,7 @@ public class QuerySourceMap {
     int col = Integer.valueOf(args[2]);
 
     SourceMapping consumer = SourceMapConsumerFactory.parse(
-        Files.readString(Paths.get(filename), StandardCharsets.UTF_8));
+        new String(Files.readAllBytes(Paths.get(filename)), StandardCharsets.UTF_8));
     System.out.println(consumer.getMappingForLine(line, col));
   }
 }

--- a/user/src/com/google/gwt/user/tools/WebAppCreator.java
+++ b/user/src/com/google/gwt/user/tools/WebAppCreator.java
@@ -21,6 +21,7 @@ import com.google.gwt.dev.Compiler;
 import com.google.gwt.dev.DevMode;
 import com.google.gwt.dev.GwtVersion;
 import com.google.gwt.dev.util.collect.HashSet;
+import com.google.gwt.thirdparty.guava.common.io.ByteStreams;
 import com.google.gwt.thirdparty.guava.common.io.CharStreams;
 import com.google.gwt.user.tools.util.ArgHandlerIgnore;
 import com.google.gwt.user.tools.util.ArgHandlerOverwrite;
@@ -731,7 +732,7 @@ public final class WebAppCreator {
       }
       if (fileCreator.isBinary) {
         try (FileOutputStream o = new FileOutputStream(file); InputStream i = url.openStream()) {
-          i.transferTo(o);
+          ByteStreams.copy(i, o);
         }
       } else {
         try (InputStream i = url.openStream()) {

--- a/user/src/com/google/web/bindery/requestfactory/server/RequestFactoryJarExtractor.java
+++ b/user/src/com/google/web/bindery/requestfactory/server/RequestFactoryJarExtractor.java
@@ -507,7 +507,7 @@ public class RequestFactoryJarExtractor {
         String destPath = getPackagePath(state.type) + state.source;
         if (sources.add(sourcePath) && loader.exists(sourcePath)) {
           try (InputStream is = loader.getResourceAsStream(sourcePath)) {
-            emitter.emit(destPath, new ByteArrayInputStream(is.readAllBytes()));
+            emitter.emit(destPath, is);
           }
         }
       }


### PR DESCRIPTION
A simple, step that forces Java 8 as the max for all of gwt-user, so that gwt-servlet can continue to function in Java 8 environments for the time being.