### PR TITLE
Enhance logging for non-instantiable field types

### DIFF
--- a/user/src/com/google/gwt/user/rebind/rpc/SerializableTypeOracleBuilder.java
+++ b/user/src/com/google/gwt/user/rebind/rpc/SerializableTypeOracleBuilder.java
@@ -1147,9 +1147,14 @@ public class SerializableTypeOracleBuilder {
           checkAllSubtypesOfObject(fieldLogger.branch(TreeLogger.WARN,
               "Object was reached from a manually serializable type", null), path, problems);
         } else {
-          allSucceeded &=
-              computeTypeInstantiability(fieldLogger, fieldType, path, problems)
-                  .hasInstantiableSubtypes();
+          boolean fieldTypeHasInstantiableSubtypes = computeTypeInstantiability(fieldLogger, fieldType, path, problems)
+              .hasInstantiableSubtypes();
+          allSucceeded &= fieldTypeHasInstantiableSubtypes;
+          if (!fieldTypeHasInstantiableSubtypes) {
+            fieldLogger.log(TreeLogger.DEBUG, "Field's type "
+                + fieldType.getQualifiedSourceName()
+                + " has no instantiable subtypes");
+          }
         }
       }
     }


### PR DESCRIPTION
In relation to https://github.com/gwtproject/gwt/issues/10181 I think that logging fields that cause a negative decision about a type's instantiability should be logged as a warning. Here is a suggestion.