### PR TITLE
Fix AbstractLocalizableInterfaceCreator.genMethodDecl; Fixes #10205

### DIFF
--- a/.github/workflows/full-check.yml
+++ b/.github/workflows/full-check.yml
@@ -20,6 +20,10 @@ permissions:
   checks: write 
 jobs:
   build:
+    permissions:
+      contents: write
+      checks: write
+      actions: read
     if: ${{ !github.event.pull_request || contains(github.event.pull_request.labels.*.name, 'ready') }}
     runs-on: ubuntu-latest
     strategy:

--- a/.github/workflows/quick-check.yml
+++ b/.github/workflows/quick-check.yml
@@ -5,6 +5,10 @@ name: Quick smoke test
 on: [push, pull_request]
 jobs:
   build:
+    permissions:
+      contents: write
+      checks: write
+      actions: read
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false

--- a/user/src/com/google/gwt/i18n/rebind/AbstractLocalizableInterfaceCreator.java
+++ b/user/src/com/google/gwt/i18n/rebind/AbstractLocalizableInterfaceCreator.java
@@ -266,7 +266,7 @@ public abstract class AbstractLocalizableInterfaceCreator {
     return key;
   }
 
-  private void genMethodDecl(String defaultValue, String key) {
+  private void genMethodDecl(String key, String defaultValue) {
     composer.beginJavaDocComment();
     String escaped = makeJavaString(defaultValue);
     composer.println("Translated " + escaped + ".\n");


### PR DESCRIPTION
Fixes the order of AbstractLocalizableInterfaceCreator.genMethodDecl arguments; 
this reverses the arguments of genMethodDecl to their original order so that the single call matches the declaration again.

Fixes #10205