### PR TITLE
Add BigInteger.TWO emulation

### DIFF
--- a/user/super/com/google/gwt/emul/java/math/BigInteger.java
+++ b/user/super/com/google/gwt/emul/java/math/BigInteger.java
@@ -72,6 +72,11 @@ public class BigInteger extends Number implements Comparable<BigInteger>,
   public static final BigInteger TEN = new BigInteger(1, 10);
 
   /**
+   * The {@code BigInteger} constant 2.
+   */
+  public static final BigInteger TWO = new BigInteger(1, 2);
+
+  /**
    * The {@code BigInteger} constant 0.
    */
   public static final BigInteger ZERO = new BigInteger(0, 0);

--- a/user/test/com/google/gwt/emultest/java/math/BigIntegerConstructorsTest.java
+++ b/user/test/com/google/gwt/emultest/java/math/BigIntegerConstructorsTest.java
@@ -1365,4 +1365,11 @@ public class BigIntegerConstructorsTest extends EmulTestBase {
     }
     assertEquals("incorrect sign", 1, aNumber.signum());
   }
+
+  public void testConstants() {
+    assertEquals(0, BigInteger.ZERO.intValue());
+    assertEquals(1, BigInteger.ONE.intValue());
+    assertEquals(2, BigInteger.TWO.intValue());
+    assertEquals(10, BigInteger.TEN.intValue());
+  }
 }


### PR DESCRIPTION
Somewhat related to #10129 which does the same for BigDecimal, but this one is for Java 9 compatibility.