### PR TITLE
Make jaxb optional for validation tests, remove from classpath

### DIFF
--- a/common.ant.xml
+++ b/common.ant.xml
@@ -237,6 +237,7 @@
         <jvmarg value="-Demma.coverage.out.file=@{test.emma.coverage}/coverage.emma"/>
         <jvmarg value="-Demma.coverage.out.merge=true"/>
         <jvmarg value="-Dcom.google.gwt.junit.reportPath=reports"/>
+        <jvmarg value="-Dgwt.validation.ignoreXml=true"/>
         <jvmarg line="@{test.jvmargs}"/>
         <jvmarg line="--add-opens=java.base/java.lang=ALL-UNNAMED" />
         <sysproperty key="gwt.args" value="@{test.args}"/>
@@ -261,7 +262,6 @@
           <pathelement location="${gwt.tools.lib}/selenium/selenium-java-client-driver.jar"/>
           <pathelement location="${gwt.tools.lib}/w3c/sac/sac-1.3.jar"/>
           <pathelement location="${gwt.tools.lib}/w3c/flute/flute-1.3-gg2.jar"/>
-          <pathelement location="${gwt.tools.lib}/jaxb/jaxb-api-2.3.3.jar"/>
           <extraclasspaths/>
         </classpath>
 

--- a/requestfactory/build.xml
+++ b/requestfactory/build.xml
@@ -158,6 +158,7 @@
     <java failonerror="true" fork="true"
       classname="com.google.web.bindery.requestfactory.vm.RequestFactoryJreSuite">
       <jvmarg value="-Xss8m" />
+      <jvmarg value="-Dgwt.validation.ignoreXml=true"/>
       <classpath>
         <fileset dir="${gwt.tools.lib}" includes="tomcat/tomcat-servlet-api-8.0.28.jar" />
         <fileset dir="${gwt.tools.lib}" includes="apache/log4j/log4j-1.2.17.jar" />

--- a/requestfactory/build.xml
+++ b/requestfactory/build.xml
@@ -165,7 +165,6 @@
         <fileset dir="${gwt.tools.lib}" includes="slf4j/slf4j-log4j12/slf4j-log4j12-1.7.12.jar" />
         <fileset dir="${gwt.tools.lib}" includes="hibernate/validator/hibernate-validator-4.1.0.Final.jar" />
         <fileset dir="${gwt.tools.lib}" includes="javax/validation/validation-api-1.0.0.GA.jar" />
-        <fileset dir="${gwt.tools.lib}" includes="javax/xml/bind/jaxb-api-2.1.jar" />
         <fileset dir="${gwt.build.lib}" includes="requestfactory-test.jar" />
         <fileset dir="${gwt.build.lib}" includes="requestfactory-test-src.jar" />
         <fileset dir="${gwt.build.lib}" includes="requestfactory-test-validated.jar" />

--- a/samples/validation/src/main/java/com/google/gwt/sample/validation/server/GreetingServiceImpl.java
+++ b/samples/validation/src/main/java/com/google/gwt/sample/validation/server/GreetingServiceImpl.java
@@ -27,6 +27,7 @@ import org.hibernate.validator.engine.ValidationSupport;
 import java.util.HashSet;
 import java.util.Set;
 
+import javax.validation.Configuration;
 import javax.validation.ConstraintViolation;
 import javax.validation.ConstraintViolationException;
 import javax.validation.Validation;
@@ -40,7 +41,15 @@ import javax.validation.groups.Default;
 public class GreetingServiceImpl extends RemoteServiceServlet implements
     GreetingService {
 
-  private final Validator validator = Validation.buildDefaultValidatorFactory().getValidator();
+  private final Validator validator;
+
+  public GreetingServiceImpl() {
+    Configuration<?> config = Validation.byDefaultProvider().configure();
+    if ("true".equals(System.getProperty("gwt.validation.ignoreXml"))) {
+      config = config.ignoreXmlConfiguration();
+    }
+    validator = config.buildValidatorFactory().getValidator();
+  }
 
   public SafeHtml greetServer(Person person) throws IllegalArgumentException,
       ConstraintViolationException {

--- a/samples/validation/src/main/java/com/google/gwt/sample/validation/server/GreetingServiceImpl.java
+++ b/samples/validation/src/main/java/com/google/gwt/sample/validation/server/GreetingServiceImpl.java
@@ -27,7 +27,6 @@ import org.hibernate.validator.engine.ValidationSupport;
 import java.util.HashSet;
 import java.util.Set;
 
-import javax.validation.Configuration;
 import javax.validation.ConstraintViolation;
 import javax.validation.ConstraintViolationException;
 import javax.validation.Validation;
@@ -44,11 +43,11 @@ public class GreetingServiceImpl extends RemoteServiceServlet implements
   private final Validator validator;
 
   public GreetingServiceImpl() {
-    Configuration<?> config = Validation.byDefaultProvider().configure();
-    if ("true".equals(System.getProperty("gwt.validation.ignoreXml"))) {
-      config = config.ignoreXmlConfiguration();
-    }
-    validator = config.buildValidatorFactory().getValidator();
+    validator = Validation.byDefaultProvider()
+        .configure()
+        .ignoreXmlConfiguration()
+        .buildValidatorFactory()
+        .getValidator();
   }
 
   public SafeHtml greetServer(Person person) throws IllegalArgumentException,

--- a/user/src/com/google/gwt/validation/rebind/BeanHelperCache.java
+++ b/user/src/com/google/gwt/validation/rebind/BeanHelperCache.java
@@ -29,6 +29,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import javax.validation.Configuration;
 import javax.validation.Validation;
 import javax.validation.ValidationException;
 import javax.validation.Validator;
@@ -52,7 +53,11 @@ public class BeanHelperCache { // public for testing
    */
   public BeanHelperCache() {
     cache = new HashMap<JClassType, BeanHelper>();
-    serverSideValidator = Validation.buildDefaultValidatorFactory().getValidator();
+    Configuration<?> config = Validation.byDefaultProvider().configure();
+    if ("true".equals(System.getProperty("gwt.validation.ignoreXml"))) {
+      config = config.ignoreXmlConfiguration();
+    }
+    serverSideValidator = config.buildValidatorFactory().getValidator();
   }
 
   /**

--- a/user/src/com/google/web/bindery/requestfactory/server/ReflectiveServiceLayer.java
+++ b/user/src/com/google/web/bindery/requestfactory/server/ReflectiveServiceLayer.java
@@ -35,11 +35,11 @@ import java.util.Set;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
+import javax.validation.Configuration;
 import javax.validation.ConstraintViolation;
 import javax.validation.Validation;
 import javax.validation.ValidationException;
 import javax.validation.Validator;
-import javax.validation.ValidatorFactory;
 
 /**
  * Implements all methods that interact with domain objects.
@@ -57,8 +57,11 @@ final class ReflectiveServiceLayer extends ServiceLayerDecorator {
   static {
     Validator found;
     try {
-      ValidatorFactory validatorFactory = Validation.buildDefaultValidatorFactory();
-      found = validatorFactory.getValidator();
+      Configuration<?> config = Validation.byDefaultProvider().configure();
+      if ("true".equals(System.getProperty("gwt.validation.ignoreXml"))) {
+        config = config.ignoreXmlConfiguration();
+      }
+      found = config.buildValidatorFactory().getValidator();
     } catch (ValidationException e) {
       log.log(Level.INFO, "Unable to initialize a JSR 303 Bean Validator", e);
       found = null;


### PR DESCRIPTION
Modifies Validation and RequestFactory internals to optionally skip loading validation configuration from XML, defaulting to old behavior. Tests are updated to activate this new behavior, confirmed by removing the jaxb jar from the classpath.

Also modified the validation sample.