### PR TITLE
Remove check for stack property in Error

### DIFF
--- a/user/super/com/google/gwt/emul/java/lang/Throwable.java
+++ b/user/super/com/google/gwt/emul/java/lang/Throwable.java
@@ -103,7 +103,7 @@ public class Throwable implements Serializable {
   }
 
   private void initializeBackingError() {
-    setBackingJsObject(fixIE(createError(toString(detailMessage))));
+    setBackingJsObject(createError(toString(detailMessage)));
 
     captureStackTrace();
   }
@@ -116,15 +116,6 @@ public class Throwable implements Serializable {
 
   // Called by J2CL transpiler. Do not remove!
   void privateInitError(Object error) { }
-
-  @SuppressWarnings("unusable-by-js")
-  private static native Object fixIE(Object e) /*-{
-    // In IE -unlike every other browser-, the stack property is not defined until you throw it.
-    if (!("stack" in e)) {
-      try { throw e; } catch(ignored) {}
-    }
-    return e;
-  }-*/;
 
   @SuppressWarnings("unusable-by-js")
   private native void captureStackTrace() /*-{


### PR DESCRIPTION
The `stack` property is present in `Error` by default in all important browsers as mentioned in the comment (manually verified with Chrome, FF, Edge, HtmlUnit 2.55), therefore the `fixIE` method doesn't do anything and can be removed.