### PR TITLE
Compute total size of samples correctly

### DIFF
--- a/samples/build.xml
+++ b/samples/build.xml
@@ -60,7 +60,7 @@
       <param name="mvn.args" value="verify" />
     </antcall>
     <length property="gwt.sample.length">
-      <fileset dir="." includes="*/target/*/*/*.cache.js,*/*-client/target/*/*/*.cache.js"/>
+      <fileset dir="." includes="hello/target/*/*/*.cache.js,*/*-client/target/*/*/*.cache.js,*/*-client/target/*/*/deferredjs/*/*.cache.js"/>
     </length>
     <echo message="compiled size of all samples is ${gwt.sample.length} bytes." level="info"/>
   </target>

--- a/samples/build.xml
+++ b/samples/build.xml
@@ -60,7 +60,7 @@
       <param name="mvn.args" value="verify" />
     </antcall>
     <length property="gwt.sample.length">
-      <fileset dir="." includes="*/target/*/*/*.cache.js"/>
+      <fileset dir="." includes="*/target/*/*/*.cache.js,*/*-client/target/*/*/*.cache.js"/>
     </length>
     <echo message="compiled size of all samples is ${gwt.sample.length} bytes." level="info"/>
   </target>


### PR DESCRIPTION
This fixes the size of compiled samples reported during a build.

Except for `hello` all samples have multiple modules, so `target` is not always in the top level folder. Also included deferredjs/ for split point content.