### PR TITLE
Update poms to pass validation for Maven Central sync

### DIFF
--- a/maven/poms/gwt/gwt-codeserver/pom-template.xml
+++ b/maven/poms/gwt/gwt-codeserver/pom-template.xml
@@ -8,15 +8,17 @@
         <artifactId>gwt</artifactId>
         <version>${gwtVersion}</version>
     </parent>
-    <groupId>org.gwtproject</groupId>
     <artifactId>gwt-codeserver</artifactId>
     <packaging>jar</packaging>
-    <version>${gwtVersion}</version>
+    <name>GWT Development CodeServer</name>
+    <description>
+        The GWT Super Dev Mode code server
+    </description>
 
     <dependencies>
-      <dependency>
-        <groupId>org.gwtproject</groupId>
-        <artifactId>gwt-dev</artifactId>
-      </dependency>
+        <dependency>
+            <groupId>org.gwtproject</groupId>
+            <artifactId>gwt-dev</artifactId>
+        </dependency>
     </dependencies>
 </project>

--- a/maven/poms/gwt/gwt-codeserver/pom-template.xml
+++ b/maven/poms/gwt/gwt-codeserver/pom-template.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.gwtproject</groupId>

--- a/maven/poms/gwt/gwt-dev/pom-template.xml
+++ b/maven/poms/gwt/gwt-dev/pom-template.xml
@@ -8,11 +8,12 @@
         <artifactId>gwt</artifactId>
         <version>${gwtVersion}</version>
     </parent>
-    <groupId>org.gwtproject</groupId>
     <artifactId>gwt-dev</artifactId>
     <packaging>jar</packaging>
-    <version>${gwtVersion}</version>
-
+    <name>GWT Developer Tools</name>
+    <description>
+        Compiler, Test runner, Development mode, and other tools for developing GWT applications
+    </description>
     <dependencies>
         <dependency>
             <groupId>com.google.code.findbugs</groupId>

--- a/maven/poms/gwt/gwt-dev/pom-template.xml
+++ b/maven/poms/gwt/gwt-dev/pom-template.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.gwtproject</groupId>

--- a/maven/poms/gwt/gwt-servlet-jakarta/pom-template.xml
+++ b/maven/poms/gwt/gwt-servlet-jakarta/pom-template.xml
@@ -8,10 +8,12 @@
         <artifactId>gwt</artifactId>
         <version>${gwtVersion}</version>
     </parent>
-    <groupId>org.gwtproject</groupId>
     <artifactId>gwt-servlet-jakarta</artifactId>
     <packaging>jar</packaging>
-    <version>${gwtVersion}</version>
+    <name>GWT RPC/RF jakarta.servlet implementation</name>
+    <description>
+        GWT-RPC and RequestFactory implementations for use in jakarta.servlet environments
+    </description>
     <dependencies>
         <dependency>
             <groupId>javax.validation</groupId>

--- a/maven/poms/gwt/gwt-servlet-jakarta/pom-template.xml
+++ b/maven/poms/gwt/gwt-servlet-jakarta/pom-template.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.gwtproject</groupId>

--- a/maven/poms/gwt/gwt-servlet/pom-template.xml
+++ b/maven/poms/gwt/gwt-servlet/pom-template.xml
@@ -8,10 +8,12 @@
         <artifactId>gwt</artifactId>
         <version>${gwtVersion}</version>
     </parent>
-    <groupId>org.gwtproject</groupId>
     <artifactId>gwt-servlet</artifactId>
     <packaging>jar</packaging>
-    <version>${gwtVersion}</version>
+    <name>GWT RPC/RF javax.servlet implementation</name>
+    <description>
+        GWT-RPC and RequestFactory implementations for use in javax.servlet environments
+    </description>
     <dependencies>
         <dependency>
             <groupId>javax.validation</groupId>

--- a/maven/poms/gwt/gwt-servlet/pom-template.xml
+++ b/maven/poms/gwt/gwt-servlet/pom-template.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.gwtproject</groupId>

--- a/maven/poms/gwt/gwt-user/pom-template.xml
+++ b/maven/poms/gwt/gwt-user/pom-template.xml
@@ -8,10 +8,12 @@
         <artifactId>gwt</artifactId>
         <version>${gwtVersion}</version>
     </parent>
-    <groupId>org.gwtproject</groupId>
     <artifactId>gwt-user</artifactId>
     <packaging>jar</packaging>
-    <version>${gwtVersion}</version>
+    <name>GWT User packages</name>
+    <description>
+        GWT-compatible widgets, browser abstractions, and JRE implementations for use in client applications.
+    </description>
     <dependencies>
         <dependency>
             <groupId>com.google.jsinterop</groupId>

--- a/maven/poms/gwt/gwt-user/pom-template.xml
+++ b/maven/poms/gwt/gwt-user/pom-template.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.gwtproject</groupId>

--- a/maven/poms/gwt/pom-template.xml
+++ b/maven/poms/gwt/pom-template.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.gwtproject</groupId>
     <artifactId>gwt</artifactId>

--- a/maven/poms/gwt/pom-template.xml
+++ b/maven/poms/gwt/pom-template.xml
@@ -2,44 +2,43 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
-    <parent>
-        <groupId>org.sonatype.oss</groupId>
-        <artifactId>oss-parent</artifactId>
-        <version>4</version>
-    </parent>
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.gwtproject</groupId>
     <artifactId>gwt</artifactId>
     <packaging>pom</packaging>
-    <name>GWT</name>
-    <url>http://www.gwtproject.org/</url>
+    <name>GWT Web Toolkit</name>
+    <description>BOM for GWT</description>
+    <url>https://www.gwtproject.org/</url>
     <version>${gwtVersion}</version>
     <licenses>
         <license>
             <name>GWT Terms</name>
-            <url>http://www.gwtproject.org/terms.html</url>
+            <comments>GWT itself is Apache 2.0 licensed, but contains some elements with different licenses</comments>
+            <url>https://www.gwtproject.org/terms.html</url>
         </license>
     </licenses>
     <properties>
-      <jetty.version>9.4.58.v20250814</jetty.version>
-      <asm.version>9.6</asm.version>
+        <jetty.version>9.4.58.v20250814</jetty.version>
+        <asm.version>9.6</asm.version>
     </properties>
+    <developers>
+        <developer>
+            <name>GWT Project Contributors</name>
+            <organizationUrl>https://gwtproject.org</organizationUrl>
+            <email>google-web-toolkit-contributors@googlegroups.com</email>
+        </developer>
+    </developers>
+    <scm>
+        <connection>scm:git:https://github.com/gwtproject/gwt.git</connection>
+        <developerConnection>scm:git:git@github.com/gwtproject/gwt.git</developerConnection>
+        <url>https://github.com/gwtproject/gwt</url>
+    </scm>
     <dependencyManagement>
         <dependencies>
             <dependency>
-                <groupId>com.google.gwt</groupId>
-                <artifactId>gwt-user</artifactId>
-                <version>2.10.0</version>
-            </dependency>
-            <dependency>
                 <groupId>org.gwtproject</groupId>
                 <artifactId>gwt-user</artifactId>
                 <version>${project.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>com.google.gwt</groupId>
-                <artifactId>gwt-dev</artifactId>
-                <version>2.10.0</version>
             </dependency>
             <dependency>
                 <groupId>org.gwtproject</groupId>
@@ -47,19 +46,9 @@
                 <version>${project.version}</version>
             </dependency>
             <dependency>
-                <groupId>com.google.gwt</groupId>
-                <artifactId>gwt-codeserver</artifactId>
-                <version>2.10.0</version>
-            </dependency>
-            <dependency>
                 <groupId>org.gwtproject</groupId>
                 <artifactId>gwt-codeserver</artifactId>
                 <version>${project.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>com.google.gwt</groupId>
-                <artifactId>gwt-servlet</artifactId>
-                <version>2.10.0</version>
             </dependency>
             <dependency>
                 <groupId>org.gwtproject</groupId>
@@ -78,6 +67,29 @@
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
+
+            <!-- List the final release of the old com.google.gwt groupId to help build tools correctly relocate -->
+            <dependency>
+                <groupId>com.google.gwt</groupId>
+                <artifactId>gwt-user</artifactId>
+                <version>2.10.0</version>
+            </dependency>
+            <dependency>
+                <groupId>com.google.gwt</groupId>
+                <artifactId>gwt-dev</artifactId>
+                <version>2.10.0</version>
+            </dependency>
+            <dependency>
+                <groupId>com.google.gwt</groupId>
+                <artifactId>gwt-codeserver</artifactId>
+                <version>2.10.0</version>
+            </dependency>
+            <dependency>
+                <groupId>com.google.gwt</groupId>
+                <artifactId>gwt-servlet</artifactId>
+                <version>2.10.0</version>
+            </dependency>
+
             <dependency>
                 <groupId>com.google.jsinterop</groupId>
                 <artifactId>jsinterop-annotations</artifactId>

--- a/maven/poms/requestfactory/apt/pom-template.xml
+++ b/maven/poms/requestfactory/apt/pom-template.xml
@@ -8,8 +8,11 @@
         <artifactId>requestfactory</artifactId>
         <version>${gwtVersion}</version>
     </parent>
-    <groupId>org.gwtproject.web.bindery</groupId>
     <artifactId>requestfactory-apt</artifactId>
     <packaging>jar</packaging>
-    <version>${gwtVersion}</version>
+    <name>GWT RequestFactory annotation processor</name>
+    <description>
+        Compile-time codegeneration tool to validate RF contexts and proxies, and generate
+        metadata used at runtime by RequestFactory implementations.
+    </description>
 </project>

--- a/maven/poms/requestfactory/apt/pom-template.xml
+++ b/maven/poms/requestfactory/apt/pom-template.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.gwtproject.web.bindery</groupId>

--- a/maven/poms/requestfactory/client/pom-template.xml
+++ b/maven/poms/requestfactory/client/pom-template.xml
@@ -8,10 +8,12 @@
         <artifactId>requestfactory</artifactId>
         <version>${gwtVersion}</version>
     </parent>
-    <groupId>org.gwtproject.web.bindery</groupId>
     <artifactId>requestfactory-client</artifactId>
     <packaging>jar</packaging>
-    <version>${gwtVersion}</version>
+    <name>GWT RequestFactory client implementation</name>
+    <description>
+        GWT client implementation of RequestFactory, including generator for use at compile time.
+    </description>
     <dependencies>
         <dependency>
             <groupId>javax.validation</groupId>

--- a/maven/poms/requestfactory/client/pom-template.xml
+++ b/maven/poms/requestfactory/client/pom-template.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.gwtproject.web.bindery</groupId>

--- a/maven/poms/requestfactory/pom-template.xml
+++ b/maven/poms/requestfactory/pom-template.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.gwtproject.web.bindery</groupId>
     <artifactId>requestfactory</artifactId>

--- a/maven/poms/requestfactory/pom-template.xml
+++ b/maven/poms/requestfactory/pom-template.xml
@@ -2,50 +2,44 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
-    <parent>
-        <groupId>org.sonatype.oss</groupId>
-        <artifactId>oss-parent</artifactId>
-        <version>4</version>
-    </parent>
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.gwtproject.web.bindery</groupId>
     <artifactId>requestfactory</artifactId>
     <packaging>pom</packaging>
-    <name>RequestFactory</name>
-    <url>http://www.gwtproject.org/doc/latest/DevGuideRequestFactory.html</url>
+    <name>GWT RequestFactory</name>
+    <url>https://www.gwtproject.org/doc/latest/DevGuideRequestFactory.html</url>
+    <description>BOM for GWT's RequestFactory</description>
     <version>${gwtVersion}</version>
     <licenses>
         <license>
             <name>GWT Terms</name>
-            <url>http://www.gwtproject.org/terms.html</url>
+            <comments>GWT itself is Apache 2.0 licensed, but contains some elements with different licenses</comments>
+            <url>https://www.gwtproject.org/terms.html</url>
         </license>
     </licenses>
+    <developers>
+        <developer>
+            <name>GWT Project Contributors</name>
+            <organizationUrl>https://gwtproject.org</organizationUrl>
+            <email>google-web-toolkit-contributors@googlegroups.com</email>
+        </developer>
+    </developers>
+    <scm>
+        <connection>scm:git:https://github.com/gwtproject/gwt.git</connection>
+        <developerConnection>scm:git:git@github.com/gwtproject/gwt.git</developerConnection>
+        <url>https://github.com/gwtproject/gwt</url>
+    </scm>
     <dependencyManagement>
         <dependencies>
             <dependency>
-                <groupId>com.google.web.bindery</groupId>
-                <artifactId>requestfactory-apt</artifactId>
-                <version>2.10.0</version>
-            </dependency>
-            <dependency>
                 <groupId>org.gwtproject.web.bindery</groupId>
                 <artifactId>requestfactory-apt</artifactId>
                 <version>${project.version}</version>
             </dependency>
             <dependency>
-                <groupId>com.google.web.bindery</groupId>
-                <artifactId>requestfactory-client</artifactId>
-                <version>2.10.0</version>
-            </dependency>
-            <dependency>
                 <groupId>org.gwtproject.web.bindery</groupId>
                 <artifactId>requestfactory-client</artifactId>
                 <version>${project.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>com.google.web.bindery</groupId>
-                <artifactId>requestfactory-server</artifactId>
-                <version>2.10.0</version>
             </dependency>
             <dependency>
                 <groupId>org.gwtproject.web.bindery</groupId>
@@ -57,6 +51,24 @@
                 <artifactId>requestfactory-server-jakarta</artifactId>
                 <version>${project.version}</version>
             </dependency>
+
+            <!-- List the final release of the old com.google.gwt groupId to help build tools correctly relocate -->
+            <dependency>
+                <groupId>com.google.web.bindery</groupId>
+                <artifactId>requestfactory-apt</artifactId>
+                <version>2.10.0</version>
+            </dependency>
+            <dependency>
+                <groupId>com.google.web.bindery</groupId>
+                <artifactId>requestfactory-client</artifactId>
+                <version>2.10.0</version>
+            </dependency>
+            <dependency>
+                <groupId>com.google.web.bindery</groupId>
+                <artifactId>requestfactory-server</artifactId>
+                <version>2.10.0</version>
+            </dependency>
+
             <dependency>
                 <groupId>javax.validation</groupId>
                 <artifactId>validation-api</artifactId>

--- a/maven/poms/requestfactory/server-jakarta/pom-template.xml
+++ b/maven/poms/requestfactory/server-jakarta/pom-template.xml
@@ -8,10 +8,12 @@
         <artifactId>requestfactory</artifactId>
         <version>${gwtVersion}</version>
     </parent>
-    <groupId>org.gwtproject.web.bindery</groupId>
     <artifactId>requestfactory-server-jakarta</artifactId>
     <packaging>jar</packaging>
-    <version>${gwtVersion}</version>
+    <name>GWT RequestFactory jakarta.servlet implementation</name>
+    <description>
+        Server implementation of RequestFactory for use in jakarta.servlet environments.
+    </description>
     <dependencies>
         <dependency>
             <groupId>javax.validation</groupId>

--- a/maven/poms/requestfactory/server-jakarta/pom-template.xml
+++ b/maven/poms/requestfactory/server-jakarta/pom-template.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.gwtproject.web.bindery</groupId>

--- a/maven/poms/requestfactory/server/pom-template.xml
+++ b/maven/poms/requestfactory/server/pom-template.xml
@@ -8,10 +8,12 @@
         <artifactId>requestfactory</artifactId>
         <version>${gwtVersion}</version>
     </parent>
-    <groupId>org.gwtproject.web.bindery</groupId>
     <artifactId>requestfactory-server</artifactId>
     <packaging>jar</packaging>
-    <version>${gwtVersion}</version>
+    <name>GWT RequestFactory javax.servlet implementation</name>
+    <description>
+        Server implementation of RequestFactory for use in javax.servlet environments.
+    </description>
     <dependencies>
         <dependency>
             <groupId>javax.validation</groupId>

--- a/maven/poms/requestfactory/server/pom-template.xml
+++ b/maven/poms/requestfactory/server/pom-template.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.gwtproject.web.bindery</groupId>


### PR DESCRIPTION
The new Sonatype publishing mechanism requires a different process to deploy, and seems to have stricter requirements. Removed unnecessary parent poms, added developers, scm, description, and re-grouped bom dependencies to avoid confusion from `com.google.gwt` dependencies.

Fixes #10264 