### PR TITLE
Permit failure to delete files on Windows, and close finished logs

### DIFF
--- a/dev/codeserver/java/com/google/gwt/dev/codeserver/OutboxDir.java
+++ b/dev/codeserver/java/com/google/gwt/dev/codeserver/OutboxDir.java
@@ -88,9 +88,11 @@ class OutboxDir {
     // (This is not guaranteed to delete all directories on Windows if a directory is locked.)
     for (File candidate : children) {
       if (candidate.getName().startsWith(COMPILE_DIR_PREFIX)) {
-        MoreFiles.deleteRecursively(candidate.toPath(), RecursiveDeleteOption.ALLOW_INSECURE);
-        if (candidate.exists()) {
-          logger.log(Type.WARN, "unable to delete '" + candidate + "' (skipped)");
+        try {
+          MoreFiles.deleteRecursively(candidate.toPath(), RecursiveDeleteOption.ALLOW_INSECURE);
+        } catch (IOException e) {
+          // Developers on Windows may add a breakpoint here to see which file was still open
+          logger.log(Type.WARN, "Unable to delete '" + candidate + "' (skipped)");
         }
       }
     }


### PR DESCRIPTION
Audited all other usages of `PrintWriterTreeLogger`, and found this was only one of two usages that writes to a file rather than System.out/err or a StringWriter. The other usage writes to a file in the old devmode flag `-logdir`, which is optional, and expected not to be within another directory that the compiler needs to clean.

Fixes #10272
Backport #10273