### PR TITLE
Fix Safari timer throttling in CrossSiteIframeLinker bootstrap iframe

### DIFF
--- a/dev/core/src/com/google/gwt/core/ext/linker/impl/installLocationIframe.js
+++ b/dev/core/src/com/google/gwt/core/ext/linker/impl/installLocationIframe.js
@@ -28,25 +28,46 @@ function getInstallLocation() {
 
 function setupInstallLocation() {
   if (frameDoc) { return; }
+
+  // Remove any stale bootstrap iframe left over from a previous page load
+  // (e.g. after a Shift+Reload in Safari) to prevent accumulation and avoid
+  // inheriting a throttled browsing-context state.
+  var stale = $doc.getElementById('__MODULE_NAME__');
+  if (stale && stale.parentNode) {
+    stale.parentNode.removeChild(stale);
+  }
+
   // Create the script frame, making sure it's invisible, but not
   // "display:none", which keeps some browsers from running code in it.
+  //
+  // The iframe must have a non-zero intersection with the viewport.
+  // Safari (WebKit) throttles DOM timers in iframes whose visible rect is
+  // empty, which includes iframes placed off-screen at negative coordinates
+  // as well as those hidden via visibility:hidden or opacity:0.  A 50x50px
+  // fixed element at the top-left corner with opacity:0.01 is imperceptible
+  // to users while reliably preventing the throttle.
   var scriptFrame = $doc.createElement('iframe');
   scriptFrame.id = '__MODULE_NAME__';
-  scriptFrame.style.cssText = 'position:absolute; width:0; height:0; border:none; left: -1000px;'
-    + ' top: -1000px;';
+  scriptFrame.style.cssText = 'position:fixed; left:0; top:0; width:50px; height:50px;'
+    + ' border:none; opacity:0.01;';
   scriptFrame.tabIndex = -1;
   $doc.body.appendChild(scriptFrame);
 
   frameDoc = scriptFrame.contentWindow.document;
 
-  // The following code is needed for proper operation in Firefox, Safari, and
+  // The following code is needed for proper operation in Firefox and
   // Internet Explorer.
   //
   // In Firefox, this prevents the frame from re-loading asynchronously and
   // throwing away the current document.
   //
   // In IE, it ensures that the <body> element is immediately available.
-  if (navigator.userAgent.indexOf("Chrome") == -1) {
+  //
+  // Safari is excluded because document.write() + document.close() triggers
+  // a navigation cycle that puts Safari's browsing context into a throttled
+  // state, causing the same multi-minute delay as the off-screen iframe style.
+  var isSafari = navigator.vendor && navigator.vendor.indexOf("Apple") != -1;
+  if (navigator.userAgent.indexOf("Chrome") == -1 && !isSafari) {
     frameDoc.open();
     var doctype = (document.compatMode == 'CSS1Compat') ? '<!doctype html>' : '';
     frameDoc.write(doctype + '<html><head></head><body></body></html>');


### PR DESCRIPTION
Safari (WebKit) throttles DOM timers in iframes with an empty viewport
intersection, causing `onModuleLoad()` to be delayed by 2–4+ minutes
(vs ~1s on Chrome) when the bootstrap iframe is positioned off-screen.

Three changes to `installLocationIframe.js`:

1. **Iframe style**: replace the off-screen `position:absolute` at `-1000px`
   with `position:fixed` at `(0,0)` with `width:50px; height:50px; opacity:0.01`.
   The element is in the viewport (non-zero intersection), preventing WebKit
   throttling, while remaining imperceptible to users.
   Note: `opacity:0` and `visibility:hidden` also trigger throttling.

2. **Skip `document.write` for Safari**: `document.write()` + `document.close()`
   triggers a navigation cycle that puts Safari's browsing context into a
   throttled state. Extends the existing Chrome bypass (commit `43ca6fb`)
   to cover Safari as well.

3. **Remove stale iframes** before creating a new one: prevents accumulation
   across reloads and avoids inheriting a throttled browsing-context state
   (most visible on Shift+Reload in Safari).

Affected: Safari 18.6 (10–115s delay), Safari 26.2 (~244s delay).
Unaffected browsers see no functional or visual change.

Fixes #10303