### PR TITLE
Simplify RTA iframe loading in Firefox

### DIFF
--- a/user/src/com/google/gwt/user/client/ui/impl/RichTextAreaImplMozilla.java
+++ b/user/src/com/google/gwt/user/client/ui/impl/RichTextAreaImplMozilla.java
@@ -15,6 +15,8 @@
  */
 package com.google.gwt.user.client.ui.impl;
 
+import com.google.gwt.dom.client.Element;
+
 /**
  * Mozilla-specific implementation of rich-text editing.
  */
@@ -32,43 +34,13 @@ public class RichTextAreaImplMozilla extends RichTextAreaImplStandard {
   }
 
   @Override
-  @SuppressWarnings("deprecation")
-  public native void initElement() /*-{
-    // Mozilla doesn't allow designMode to be set reliably until the iframe is
-    // fully loaded.
-    var _this = this;
-    var iframe = _this.@com.google.gwt.user.client.ui.impl.RichTextAreaImpl::elem;
-    _this.@com.google.gwt.user.client.ui.impl.RichTextAreaImplStandard::onElementInitializing()();
-    _this.@com.google.gwt.user.client.ui.impl.RichTextAreaImplMozilla::isFirstFocus = true;
-
-    iframe.onload = $entry(function() {
-      // Some Mozillae have the nasty habit of calling onload again when you set
-      // designMode, so let's avoid doing it more than once.
-      iframe.onload = null;
-
-      // Don't set designMode until the RTA is targeted by an event. This is
-      // necessary because editing won't work on Mozilla if the iframe is
-      // *hidden, but attached*. Waiting for an event gets around this issue.
-      //
-      // Note: These events will not conflict with the
-      // addEventListener('oneventtype', ...) in RichTextAreaImplStandard.
-      iframe.contentWindow.onfocus = function() {
-        iframe.contentWindow.onfocus = null;
-        iframe.contentWindow.onmouseover = null;
-        iframe.contentWindow.document.designMode = 'On';
-      };
-
-      // Issue 1441: we also need to catch the onmouseover event because focus
-      // occurs after mouse down, so the cursor will not appear until the user
-      // clicks twice, making the RichTextArea look uneditable. Catching the
-      // mouseover event allows us to set design mode earlier. The focus event
-      // is still needed to handle tab selection.
-      iframe.contentWindow.onmouseover = iframe.contentWindow.onfocus;
-
-      // Send notification that the iframe has finished loading.
-      _this.@com.google.gwt.user.client.ui.impl.RichTextAreaImplStandard::onElementInitialized()();
-    });
-  }-*/;
+  public Element createElement() {
+    Element element = super.createElement();
+    // Explicitly set empty src string to signal that we don't need the workaround from Firefox.
+    // See https://github.com/gwtproject/gwt/issues/10292
+    element.setAttribute("src", "");
+    return element;
+  }
 
   @Override
   public void setBackColor(String color) {

--- a/user/test/com/google/gwt/user/client/ui/RichTextAreaTest.java
+++ b/user/test/com/google/gwt/user/client/ui/RichTextAreaTest.java
@@ -25,8 +25,6 @@ import com.google.gwt.event.dom.client.FocusEvent;
 import com.google.gwt.event.dom.client.FocusHandler;
 import com.google.gwt.event.logical.shared.InitializeEvent;
 import com.google.gwt.event.logical.shared.InitializeHandler;
-import com.google.gwt.junit.DoNotRunWith;
-import com.google.gwt.junit.Platform;
 import com.google.gwt.junit.client.GWTTestCase;
 import com.google.gwt.safehtml.shared.SafeHtmlUtils;
 import com.google.gwt.user.client.Event;
@@ -49,12 +47,16 @@ public class RichTextAreaTest extends GWTTestCase {
     return "com.google.gwt.user.User";
   }
 
+  @Override
+  protected void gwtTearDown() throws Exception {
+    RootPanel.get().clear();
+  }
+
   /**
    * Test that removing and re-adding an RTA doesn't destroy its contents (Only
    * IE actually preserves dynamically-created iframe contents across DOM
    * removal/re-adding).
    */
-  @DoNotRunWith(Platform.HtmlUnitUnknown)
   public void testAddEditRemoveAdd() {
     final RichTextArea area = new RichTextArea();
     delayTestFinish(RICH_TEXT_ASYNC_DELAY);
@@ -126,6 +128,23 @@ public class RichTextAreaTest extends GWTTestCase {
     final RichTextArea richTextArea = new RichTextArea();
     RootPanel.get().add(richTextArea);
     RootPanel.get().remove(richTextArea);
+
+    // Delay 100ms and confirm that initialization has not fired
+    boolean[] initFired = {false};
+    richTextArea.addInitializeHandler(new InitializeHandler() {
+      @Override
+      public void onInitialize(InitializeEvent event) {
+        initFired[0] = true;
+      }
+    });
+    new Timer() {
+      @Override
+      public void run() {
+        assertFalse(initFired[0]);
+        finishTest();
+      }
+    }.schedule(100);
+    delayTestFinish(RICH_TEXT_ASYNC_DELAY);
   }
 
   public void testFormatAfterAttach() {
@@ -148,7 +167,6 @@ public class RichTextAreaTest extends GWTTestCase {
     }
   }
 
-  @DoNotRunWith(Platform.HtmlUnitUnknown)
   public void testFormatAfterInitialize() {
     final RichTextArea area = new RichTextArea();
 
@@ -186,7 +204,6 @@ public class RichTextAreaTest extends GWTTestCase {
     }
   }
 
-  @DoNotRunWith(Platform.HtmlUnitUnknown)
   public void testFormatWhenHidden() {
     final RichTextArea area = new RichTextArea();
     delayTestFinish(RICH_TEXT_ASYNC_DELAY);
@@ -209,7 +226,6 @@ public class RichTextAreaTest extends GWTTestCase {
   /**
    * See that the custom InitializeEvent fires.
    */
-  @DoNotRunWith({Platform.HtmlUnitUnknown})
   public void testRichTextInitializeEvent() {
     delayTestFinish(RICH_TEXT_ASYNC_DELAY);
     final RichTextArea richTextArea = new RichTextArea();
@@ -225,7 +241,6 @@ public class RichTextAreaTest extends GWTTestCase {
   /**
    * Test that a delayed call to setEnable is reflected.
    */
-  @DoNotRunWith(Platform.HtmlUnitUnknown)
   public void testSetEnabledAfterInit() {
     final RichTextArea richTextArea = new RichTextArea();
     delayTestFinish(RICH_TEXT_ASYNC_DELAY);
@@ -246,7 +261,6 @@ public class RichTextAreaTest extends GWTTestCase {
    * Test that a call to setEnable is reflected immediately, and after the area
    * loads.
    */
-  @DoNotRunWith(Platform.HtmlUnitUnknown)
   public void testSetEnabledBeforeInit() {
     final RichTextArea richTextArea = new RichTextArea();
     richTextArea.setEnabled(false);
@@ -266,7 +280,6 @@ public class RichTextAreaTest extends GWTTestCase {
   /**
    * Test that events are dispatched correctly to handlers.
    */
-  @DoNotRunWith(Platform.HtmlUnitUnknown)
   public void testEventDispatch() {
     final RichTextArea rta = new RichTextArea();
     RootPanel.get().add(rta);
@@ -300,9 +313,8 @@ public class RichTextAreaTest extends GWTTestCase {
    * Test that a delayed set of HTML is reflected. Some platforms have timing
    * subtleties that need to be tested.
    */
-  @DoNotRunWith(Platform.HtmlUnitUnknown)
   public void testSetHTMLAfterInit() {
-    final RichTextArea richTextArea = new RichTextArea();    
+    final RichTextArea richTextArea = new RichTextArea();
     delayTestFinish(RICH_TEXT_ASYNC_DELAY);
     richTextArea.addInitializeHandler(new InitializeHandler() {
       @Override
@@ -319,7 +331,6 @@ public class RichTextAreaTest extends GWTTestCase {
    * Test that an immediate set of HTML is reflected immediately and after the
    * area loads. Some platforms have timing subtleties that need to be tested.
    */
-  @DoNotRunWith(Platform.HtmlUnitUnknown)
   public void testSetHTMLBeforeInit() {
     final RichTextArea richTextArea = new RichTextArea();
     delayTestFinish(RICH_TEXT_ASYNC_DELAY);
@@ -344,7 +355,6 @@ public class RichTextAreaTest extends GWTTestCase {
    * Test that a delayed set of safe html is reflected. Some platforms have
    * timing subtleties that need to be tested.
    */
-  @DoNotRunWith(Platform.HtmlUnitUnknown)
   public void testSetSafeHtmlAfterInit() {
     final RichTextArea richTextArea = new RichTextArea();
     delayTestFinish(RICH_TEXT_ASYNC_DELAY);
@@ -364,7 +374,6 @@ public class RichTextAreaTest extends GWTTestCase {
    * the area loads. Some platforms have timing subtleties that need to be
    * tested.
    */
-  @DoNotRunWith(Platform.HtmlUnitUnknown)
   public void testSetSafeHtmlBeforeInit() {
     final RichTextArea richTextArea = new RichTextArea();
     delayTestFinish(RICH_TEXT_ASYNC_DELAY);
@@ -389,7 +398,6 @@ public class RichTextAreaTest extends GWTTestCase {
    * Test that delayed set of text is reflected. Some platforms have timing
    * subtleties that need to be tested.
    */
-  @DoNotRunWith(Platform.HtmlUnitUnknown)
   public void testSetTextAfterInit() {
     final RichTextArea richTextArea = new RichTextArea();
     delayTestFinish(RICH_TEXT_ASYNC_DELAY);
@@ -408,7 +416,6 @@ public class RichTextAreaTest extends GWTTestCase {
    * Test that an immediate set of text is reflected immediately and after the
    * area loads. Some platforms have timing subtleties that need to be tested.
    */
-  @DoNotRunWith(Platform.HtmlUnitUnknown)
   public void testSetTextBeforeInit() {
     final RichTextArea richTextArea = new RichTextArea();
     richTextArea.setText("foo");


### PR DESCRIPTION
Removed FF-specific workaround for initializing the RTA iframe element, and added an empty src string to explicitly opt-out of the GWT workaround they added.

Fixes #10292
Backport #10306