### PR TITLE
Use Objects.equals to compare record fields for null support

### DIFF
--- a/dev/core/src/com/google/gwt/dev/jjs/impl/ImplementRecordComponents.java
+++ b/dev/core/src/com/google/gwt/dev/jjs/impl/ImplementRecordComponents.java
@@ -61,6 +61,7 @@ public class ImplementRecordComponents {
   private final JMethod getClassMethod;
   private final JMethod getSimpleNameMethod;
   private final JClassType javaLangString;
+  private final JMethod objectsEquals;
 
   private ImplementRecordComponents(JProgram program) {
     this.program = program;
@@ -69,6 +70,8 @@ public class ImplementRecordComponents {
     getClassMethod = program.getIndexedMethod(RuntimeConstants.OBJECT_GET_CLASS);
     getSimpleNameMethod = program.getIndexedMethod(RuntimeConstants.CLASS_GET_SIMPLE_NAME);
     javaLangString = program.getTypeJavaLangString();
+    objectsEquals = program.getIndexedType("Objects")
+        .findMethod("equals(Ljava/lang/Object;Ljava/lang/Object;)Z", false);
   }
 
   private void execImpl() {
@@ -190,28 +193,18 @@ public class ImplementRecordComponents {
     body.getBlock().addStmt(uncheckedAssign.makeStatement());
 
     JExpression componentCheck = JBooleanLiteral.TRUE;
-    JMethod objectEquals = program.getIndexedMethod(RuntimeConstants.OBJECT_EQUALS);
     for (JField field : type.getFields()) {
       if (!field.isStatic()) {
         JFieldRef myField = new JFieldRef(info, new JThisRef(info, type), field, type);
         JFieldRef otherField = new JFieldRef(info, typedOther.createRef(info), field, type);
-        final JBinaryOperation equals;
+        final JExpression equals;
         if (field.getType().isPrimitiveType()) {
           equals = new JBinaryOperation(info, JPrimitiveType.BOOLEAN,
                   JBinaryOperator.EQ,
                   myField,
                   otherField);
         } else {
-          // We would like to use Objects.equals here to be more concise, but we would need
-          // to look up the right impl based on the field - just as simple to insert a null check
-          // and get it a little closer to all being inlined away
-
-          // Make another field ref to call equals() on
-          JFieldRef myField2 = new JFieldRef(info, new JThisRef(info, type), field, type);
-          equals = new JBinaryOperation(info, JPrimitiveType.BOOLEAN, JBinaryOperator.AND,
-                  new JBinaryOperation(info, JPrimitiveType.BOOLEAN, JBinaryOperator.NEQ,
-                          myField, JNullLiteral.INSTANCE),
-                  new JMethodCall(info, myField2, objectEquals, otherField));
+          equals = new JMethodCall(info, null, objectsEquals, myField, otherField);
         }
         if (componentCheck != JBooleanLiteral.TRUE) {
           componentCheck = new JBinaryOperation(info, JPrimitiveType.BOOLEAN,

--- a/user/test-super/com/google/gwt/dev/jjs/super/com/google/gwt/dev/jjs/test/Java17Test.java
+++ b/user/test-super/com/google/gwt/dev/jjs/super/com/google/gwt/dev/jjs/test/Java17Test.java
@@ -185,6 +185,7 @@ public class Java17Test extends GWTTestCase {
     RecordWithReferenceType sameA = new RecordWithReferenceType(new TopLevelRecord("a", 1));
     RecordWithReferenceType sameB = new RecordWithReferenceType(new TopLevelRecord("a", 1));
     RecordWithReferenceType different = new RecordWithReferenceType(new TopLevelRecord("a", 2));
+    RecordWithReferenceType nullChild = new RecordWithReferenceType(null);
     // check that an instance is equal to itself
     assertEquals(sameA, sameA);
     assertEquals(sameA.hashCode(), sameA.hashCode());
@@ -196,6 +197,14 @@ public class Java17Test extends GWTTestCase {
     assertFalse(sameA.hashCode() == different.hashCode());
 
     assertFalse(sameA.equals(null));
+    assertFalse(nullChild.equals(sameA));
+    assertFalse(sameA.equals(nullChild));
+    assertTrue(new RecordWithReferenceType(null).equals(nullChild));
+    assertTrue(nullChild.equals(nullChild));
+
+    assertTrue(new TopLevelRecord(null, 1).equals(new TopLevelRecord(null, 1)));
+    assertFalse(new TopLevelRecord("asdf", 2).equals(new TopLevelRecord(null, 2)));
+    assertFalse(new TopLevelRecord(null, 3).equals(new TopLevelRecord("abc", 3)));
   }
 
   /**


### PR DESCRIPTION
This likely generates slightly more code than before, but the code it emits is correct.

Fixes #10293
Backport #10313