### PR TITLE
Include GWT version, commit in JFR output

### DIFF
--- a/dev/codeserver/java/com/google/gwt/dev/codeserver/CodeServer.java
+++ b/dev/codeserver/java/com/google/gwt/dev/codeserver/CodeServer.java
@@ -24,6 +24,7 @@ import com.google.gwt.dev.javac.UnitCache;
 import com.google.gwt.dev.javac.UnitCacheSingleton;
 import com.google.gwt.dev.util.DiskCachingUtil;
 import com.google.gwt.dev.util.log.PrintWriterTreeLogger;
+import com.google.gwt.dev.util.log.perf.GwtStartupEvent;
 import com.google.gwt.thirdparty.guava.common.collect.ImmutableMap;
 
 import java.io.File;
@@ -51,6 +52,7 @@ public class CodeServer {
     if (!options.parseArgs(args)) {
       System.exit(1);
     }
+    new GwtStartupEvent(CodeServer.class);
 
     main(options);
   }

--- a/dev/core/src/com/google/gwt/dev/About.java
+++ b/dev/core/src/com/google/gwt/dev/About.java
@@ -24,7 +24,7 @@ import java.util.Properties;
  */
 public class About {
   /**
-   * Tag used for text replacement of the SVN version (split up to avoid
+   * Tag used for text replacement of the Git version (split up to avoid
    * replacing it here).
    */
   private static final String GWT_GITREV_TAG = "@GWT_" + "GITREV@";
@@ -35,7 +35,7 @@ public class About {
    */
   private static final String GWT_VERSION_TAG = "@GWT_" + "VERSION@";
 
-  private static final String gwtName = "Google Web Toolkit";
+  private static final String gwtName = "GWT Web Toolkit";
   private static final String gwtGitRev;
   private static final GwtVersion gwtVersion;
 

--- a/dev/core/src/com/google/gwt/dev/CompilePermsServer.java
+++ b/dev/core/src/com/google/gwt/dev/CompilePermsServer.java
@@ -26,6 +26,7 @@ import com.google.gwt.dev.util.StringInterningObjectInputStream;
 import com.google.gwt.dev.util.arg.ArgHandlerLogLevel;
 import com.google.gwt.dev.util.arg.OptionLogLevel;
 import com.google.gwt.dev.util.log.PrintWriterTreeLogger;
+import com.google.gwt.dev.util.log.perf.GwtStartupEvent;
 import com.google.gwt.util.tools.ArgHandlerString;
 
 import java.io.File;
@@ -234,6 +235,7 @@ public class CompilePermsServer {
     int exitCode = -1;
     final CompileServerOptions options = new CompileServerOptionsImpl();
     if (new ArgProcessor(options).processArgs(args)) {
+      new GwtStartupEvent(CompilePermsServer.class);
       PrintWriterTreeLogger logger = new PrintWriterTreeLogger();
       logger.setMaxDetail(options.getLogLevel());
       if (run(options, logger)) {

--- a/dev/core/src/com/google/gwt/dev/Compiler.java
+++ b/dev/core/src/com/google/gwt/dev/Compiler.java
@@ -35,6 +35,7 @@ import com.google.gwt.dev.util.arg.ArgHandlerSaveSourceOutput;
 import com.google.gwt.dev.util.arg.ArgHandlerWarDir;
 import com.google.gwt.dev.util.arg.ArgHandlerWorkDirOptional;
 import com.google.gwt.dev.util.arg.OptionOptimize;
+import com.google.gwt.dev.util.log.perf.GwtStartupEvent;
 import com.google.gwt.dev.util.log.perf.SimpleEvent;
 import com.google.gwt.thirdparty.guava.common.collect.Sets;
 import com.google.gwt.thirdparty.guava.common.io.MoreFiles;
@@ -101,6 +102,7 @@ public class Compiler {
      */
     final CompilerOptions options = new CompilerOptionsImpl();
     if (new ArgProcessor(options).processArgs(args)) {
+      new GwtStartupEvent(Compiler.class);
       CompileTask task = new CompileTask() {
         @Override
         public boolean run(TreeLogger logger) throws UnableToCompleteException {

--- a/dev/core/src/com/google/gwt/dev/DevMode.java
+++ b/dev/core/src/com/google/gwt/dev/DevMode.java
@@ -46,6 +46,7 @@ import com.google.gwt.dev.util.arg.ArgHandlerStrict;
 import com.google.gwt.dev.util.arg.ArgHandlerWarDir;
 import com.google.gwt.dev.util.arg.ArgHandlerWorkDirOptional;
 import com.google.gwt.dev.util.arg.OptionModulePathPrefix;
+import com.google.gwt.dev.util.log.perf.GwtStartupEvent;
 import com.google.gwt.dev.util.log.perf.SimpleEvent;
 import com.google.gwt.thirdparty.guava.common.io.MoreFiles;
 import com.google.gwt.thirdparty.guava.common.io.RecursiveDeleteOption;
@@ -473,6 +474,7 @@ public class DevMode extends DevModeBase implements RestartServerCallback {
      */
     DevMode hostedMode = new DevMode();
     if (new ArgProcessor(hostedMode.options).processArgs(args)) {
+      new GwtStartupEvent(DevMode.class);
       hostedMode.run();
       // Exit w/ success code.
       System.exit(0);

--- a/dev/core/src/com/google/gwt/dev/util/log/perf/GwtStartupEvent.java
+++ b/dev/core/src/com/google/gwt/dev/util/log/perf/GwtStartupEvent.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2026 GWT Project Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.gwt.dev.util.log.perf;
+
+import com.google.gwt.dev.About;
+
+import jdk.jfr.Category;
+import jdk.jfr.Description;
+import jdk.jfr.Event;
+import jdk.jfr.Name;
+import jdk.jfr.StackTrace;
+
+/**
+ * Logs the class that was used to run GWT and the GWT build in use.
+ */
+@Name("gwt.Startup")
+@Description("Basic startup info about the current GWT process")
+@Category("GWT")
+@StackTrace(false)
+public class GwtStartupEvent extends Event {
+  @Description("GWT compiler version")
+  final String gwtVersion = About.getGwtVersion();
+
+  @Description("Git revision of the GWT compiler build")
+  final String gwtCommit = About.getGwtGitRev();
+
+  @Description("Class being invoked to start the compiler")
+  final Class<?> main;
+
+  public GwtStartupEvent(Class<?> main) {
+    this.main = main;
+    commit();
+  }
+}

--- a/dev/core/test/com/google/gwt/dev/AboutTest.java
+++ b/dev/core/test/com/google/gwt/dev/AboutTest.java
@@ -24,11 +24,16 @@ public class AboutTest extends TestCase {
 
   public void testGwtName() {
     String result = About.getGwtName();
-    assertTrue("Google Web Toolkit".equals(result));
+    assertTrue("GWT Web Toolkit".equals(result));
   }
 
   public void testGwtSvnRev() {
     String result = About.getGwtSvnRev();
+    assertFalse(result.length() == 0);
+  }
+
+  public void testGwtGitRev() {
+    String result = About.getGwtGitRev();
     assertFalse(result.length() == 0);
   }
 

--- a/user/src/com/google/gwt/junit/JUnitShell.java
+++ b/user/src/com/google/gwt/junit/JUnitShell.java
@@ -63,6 +63,7 @@ import com.google.gwt.dev.util.arg.ArgHandlerSourceLevel;
 import com.google.gwt.dev.util.arg.ArgHandlerStrict;
 import com.google.gwt.dev.util.arg.ArgHandlerWarDir;
 import com.google.gwt.dev.util.arg.ArgHandlerWorkDirOptional;
+import com.google.gwt.dev.util.log.perf.GwtStartupEvent;
 import com.google.gwt.junit.JUnitMessageQueue.ClientStatus;
 import com.google.gwt.junit.client.GWTTestCase;
 import com.google.gwt.junit.client.TimeoutException;
@@ -694,6 +695,8 @@ public class JUnitShell extends DevMode {
       if (!argProcessor.processArgs(args)) {
         throw new JUnitFatalLaunchException("Error processing shell arguments");
       }
+      new GwtStartupEvent(JUnitShell.class);
+
       // Always bind to the wildcard address and substitute the host address in
       // URLs. Note that connectAddress isn't actually used here, as we
       // override it from the runsStyle in getModuleUrl, but we set it to match


### PR DESCRIPTION
Enhances the "manual, opt-in analytics" by allowing users to upload JFR dumps of a build and detect which particular version or build resulted in the dump.

Deliberately omits command line args at this time - users can leave the default JVM events in place so these are detected or specify them manually. An automatic approach would need more code, able to remove details like paths and module names from the output.

Fixes #10269
Backport #10312