### PR TITLE
Close response stream on unsupported content encoding

### DIFF
--- a/user/src/com/google/web/bindery/requestfactory/vm/testing/UrlRequestTransport.java
+++ b/user/src/com/google/web/bindery/requestfactory/vm/testing/UrlRequestTransport.java
@@ -122,6 +122,7 @@ public class UrlRequestTransport implements RequestTransport {
       } else if ("deflate".equalsIgnoreCase(encoding)) {
         in = new InflaterInputStream(in);
       } else if (encoding != null) {
+        in.close();
         receiver.onTransportFailure(new ServerFailure("Unknown server encoding " + encoding));
         return;
       }

--- a/user/test/com/google/web/bindery/requestfactory/vm/RequestFactoryJreSuite.java
+++ b/user/test/com/google/web/bindery/requestfactory/vm/RequestFactoryJreSuite.java
@@ -35,6 +35,7 @@ import com.google.web.bindery.requestfactory.server.ServiceInheritanceJreTest;
 import com.google.web.bindery.requestfactory.server.ServiceLocatorTest;
 import com.google.web.bindery.requestfactory.shared.impl.SimpleEntityProxyIdTest;
 import com.google.web.bindery.requestfactory.vm.impl.ClassComparatorTest;
+import com.google.web.bindery.requestfactory.vm.testing.UrlRequestTransportTest;
 
 import junit.framework.Test;
 import junit.framework.TestResult;
@@ -68,6 +69,7 @@ public class RequestFactoryJreSuite {
     suite.addTestSuite(ServiceInheritanceJreTest.class);
     suite.addTestSuite(ServiceLocatorTest.class);
     suite.addTestSuite(SimpleEntityProxyIdTest.class);
+    suite.addTestSuite(UrlRequestTransportTest.class);
 
     return suite;
   }

--- a/user/test/com/google/web/bindery/requestfactory/vm/testing/UrlRequestTransportTest.java
+++ b/user/test/com/google/web/bindery/requestfactory/vm/testing/UrlRequestTransportTest.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright 2026 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.web.bindery.requestfactory.vm.testing;
+
+import com.google.web.bindery.requestfactory.shared.RequestTransport.TransportReceiver;
+import com.google.web.bindery.requestfactory.shared.ServerFailure;
+
+import junit.framework.TestCase;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.net.URLConnection;
+import java.net.URLStreamHandler;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * JRE tests for {@link UrlRequestTransport}.
+ */
+public class UrlRequestTransportTest extends TestCase {
+
+  private static class CloseTrackingInputStream extends ByteArrayInputStream {
+    private boolean closed;
+
+    CloseTrackingInputStream() {
+      super("{}".getBytes());
+    }
+
+    @Override
+    public void close() throws IOException {
+      closed = true;
+      super.close();
+    }
+  }
+
+  private static class FakeHttpURLConnection extends HttpURLConnection {
+    private final CloseTrackingInputStream input = new CloseTrackingInputStream();
+
+    FakeHttpURLConnection(URL url) {
+      super(url);
+    }
+
+    @Override
+    public void connect() {
+    }
+
+    @Override
+    public void disconnect() {
+    }
+
+    @Override
+    public String getContentEncoding() {
+      return "br";
+    }
+
+    @Override
+    public Map<String, List<String>> getHeaderFields() {
+      return Collections.emptyMap();
+    }
+
+    @Override
+    public InputStream getInputStream() {
+      return input;
+    }
+
+    @Override
+    public OutputStream getOutputStream() {
+      return new ByteArrayOutputStream();
+    }
+
+    @Override
+    public int getResponseCode() {
+      return HTTP_OK;
+    }
+
+    @Override
+    public boolean usingProxy() {
+      return false;
+    }
+  }
+
+  public void testUnsupportedEncodingClosesInputStream() throws Exception {
+    final FakeHttpURLConnection[] connection = new FakeHttpURLConnection[1];
+    URL url = new URL(null, "http://example.test/requestfactory", new URLStreamHandler() {
+      @Override
+      protected URLConnection openConnection(URL url) {
+        connection[0] = new FakeHttpURLConnection(url);
+        return connection[0];
+      }
+    });
+
+    new UrlRequestTransport(url).send("{}", new TransportReceiver() {
+      @Override
+      public void onTransportFailure(ServerFailure failure) {
+        assertEquals("Unknown server encoding br", failure.getMessage());
+      }
+
+      @Override
+      public void onTransportSuccess(String payload) {
+        fail("Expected unsupported encoding to fail");
+      }
+    });
+
+    assertTrue(connection[0].input.closed);
+  }
+}


### PR DESCRIPTION

## Summary

This fixes a response stream leak in `UrlRequestTransport` when the server returns an unsupported `Content-Encoding`.

## Problem

* `send()` opens the response `InputStream`.
* When `Content-Encoding` is unsupported, the method reports a transport failure and returns immediately.
* The opened stream is not closed before returning.

## Fix

* Close the response stream before returning from the unsupported encoding branch.
* No changes to existing success or failure behavior.
* No changes to transport callbacks or response handling.