### PR TITLE
fix off-by-one out-of-bounds write in EmulatedCharset.getBytes

### DIFF
--- a/user/super/com/google/gwt/emul/javaemul/internal/EmulatedCharset.java
+++ b/user/super/com/google/gwt/emul/javaemul/internal/EmulatedCharset.java
@@ -38,7 +38,7 @@ public abstract class EmulatedCharset extends Charset {
       int n = offset + count;
       byte[] bytes = new byte[count];
       for (int i = offset; i < n; ++i) {
-        bytes[i] = (byte) (buffer[i] & 255);
+        bytes[i - offset] = (byte) (buffer[i] & 255);
       }
       return bytes;
     }

--- a/user/test/com/google/gwt/emultest/java/io/OutputStreamWriterTest.java
+++ b/user/test/com/google/gwt/emultest/java/io/OutputStreamWriterTest.java
@@ -88,6 +88,14 @@ public class OutputStreamWriterTest extends GWTTestCase {
             new String(ASCII_CHAR_ARRAY).getBytes(StandardCharsets.UTF_8), baos.toByteArray()));
   }
 
+  public void testWriteArrayWithOffset() throws IOException {
+    OutputStreamWriter latin1Writer = new OutputStreamWriter(baos, StandardCharsets.ISO_8859_1);
+    char[] chars = {'a', 'b', 'c', 'd'};
+    latin1Writer.write(chars, 1, 2);
+    latin1Writer.close();
+    assertTrue(Arrays.equals(new byte[] {'b', 'c'}, baos.toByteArray()));
+  }
+
   public void testWriteArrayUsingNullArray() throws IOException {
     final char[] b = null;
     try {


### PR DESCRIPTION
Noticed LatinCharset.getBytes writes bytes[i] while i runs from offset, but bytes is only count long. So OutputStreamWriter.write(buf, offset, count) with a non-zero offset on ISO-8859-1/Latin-1 writes past the output array and leaves bytes[0..offset) unwritten; the precondition check only validates offset/count against the input buffer. Index the destination with i - offset.