### PR TITLE
compare XSRF token in constant time

### DIFF
--- a/user/src/com/google/gwt/user/server/rpc/XsrfProtectedServiceServlet.java
+++ b/user/src/com/google/gwt/user/server/rpc/XsrfProtectedServiceServlet.java
@@ -23,6 +23,7 @@ import com.google.gwt.util.tools.shared.Md5Utils;
 import com.google.gwt.util.tools.shared.StringUtils;
 
 import java.lang.reflect.Method;
+import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 
 import javax.servlet.ServletException;
@@ -119,7 +120,8 @@ public class XsrfProtectedServiceServlet
     String providedToken = xsrfToken.getToken();
 
     if (providedToken == null || !MessageDigest.isEqual(
-        expectedToken.getBytes(), providedToken.getBytes())) {
+        expectedToken.getBytes(StandardCharsets.UTF_8),
+        providedToken.getBytes(StandardCharsets.UTF_8))) {
       throw new RpcTokenException("Invalid XSRF token");
     }
   }

--- a/user/src/com/google/gwt/user/server/rpc/XsrfProtectedServiceServlet.java
+++ b/user/src/com/google/gwt/user/server/rpc/XsrfProtectedServiceServlet.java
@@ -23,6 +23,7 @@ import com.google.gwt.util.tools.shared.Md5Utils;
 import com.google.gwt.util.tools.shared.StringUtils;
 
 import java.lang.reflect.Method;
+import java.security.MessageDigest;
 
 import javax.servlet.ServletException;
 import javax.servlet.http.Cookie;
@@ -115,8 +116,10 @@ public class XsrfProtectedServiceServlet
     String expectedToken = StringUtils.toHexString(
         Md5Utils.getMd5Digest(sessionCookie.getValue().getBytes()));
     XsrfToken xsrfToken = (XsrfToken) token;
+    String providedToken = xsrfToken.getToken();
 
-    if (!expectedToken.equals(xsrfToken.getToken())) {
+    if (providedToken == null || !MessageDigest.isEqual(
+        expectedToken.getBytes(), providedToken.getBytes())) {
       throw new RpcTokenException("Invalid XSRF token");
     }
   }


### PR DESCRIPTION
validateXsrfToken in XsrfProtectedServiceServlet checks the client-supplied token against the expected value (MD5 hex of the session cookie) with String.equals, which returns on the first mismatching character. The expected value is secret-derived and the check runs on every protected RPC call, so the per-character timing difference is an oracle a remote caller can use to recover the token and defeat the CSRF protection. Switch to MessageDigest.isEqual on the byte arrays so the comparison time no longer depends on how many leading characters match.