### PR TITLE
Fix empty ID assertion, simplify equality check

### DIFF
--- a/user/src/com/google/gwt/aria/client/Id.java
+++ b/user/src/com/google/gwt/aria/client/Id.java
@@ -66,7 +66,7 @@ public class Id implements AriaAttributeType {
   }
 
   private void init(String elementId) {
-    assert elementId != null || elementId.equals("") :
+    assert elementId != null && !elementId.isEmpty() :
       "Invalid elementId: cannot be null or empty.";
     this.id = elementId;
   }

--- a/user/src/com/google/gwt/cell/client/EditTextCell.java
+++ b/user/src/com/google/gwt/cell/client/EditTextCell.java
@@ -84,7 +84,7 @@ public class EditTextCell extends
 
     @Override
     public boolean equals(Object o) {
-      if (!(o instanceof  ViewData)) {
+      if (!(o instanceof ViewData)) {
         return false;
       }
       ViewData vd = (ViewData) o;

--- a/user/src/com/google/gwt/cell/client/EditTextCell.java
+++ b/user/src/com/google/gwt/cell/client/EditTextCell.java
@@ -33,6 +33,7 @@ import com.google.gwt.text.shared.SafeHtmlRenderer;
 import com.google.gwt.text.shared.SimpleSafeHtmlRenderer;
 
 import java.util.Locale;
+import java.util.Objects;
 
 /**
  * An editable text cell. Click to edit, escape to cancel, return to commit.
@@ -83,12 +84,12 @@ public class EditTextCell extends
 
     @Override
     public boolean equals(Object o) {
-      if (o == null) {
+      if (!(o instanceof  ViewData)) {
         return false;
       }
       ViewData vd = (ViewData) o;
-      return equalsOrBothNull(original, vd.original)
-          && equalsOrBothNull(text, vd.text) && isEditing == vd.isEditing
+      return Objects.equals(original, vd.original)
+          && Objects.equals(text, vd.text) && isEditing == vd.isEditing
           && isEditingAgain == vd.isEditingAgain;
     }
 
@@ -128,10 +129,6 @@ public class EditTextCell extends
 
     public void setText(String text) {
       this.text = text;
-    }
-
-    private boolean equalsOrBothNull(Object o1, Object o2) {
-      return (o1 == null) ? o2 == null : o1.equals(o2);
     }
   }
 

--- a/user/src/com/google/gwt/user/cellview/client/ColumnSortList.java
+++ b/user/src/com/google/gwt/user/cellview/client/ColumnSortList.java
@@ -17,6 +17,7 @@ package com.google.gwt.user.cellview.client;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 
 /**
  * An ordered list containing the sort history of {@link Column}s in a table.
@@ -67,7 +68,7 @@ public class ColumnSortList {
       }
 
       ColumnSortInfo other = (ColumnSortInfo) obj;
-      return equalsOrBothNull(getColumn(), other.getColumn())
+      return Objects.equals(getColumn(), other.getColumn())
           && isAscending() == other.isAscending();
     }
 
@@ -92,10 +93,6 @@ public class ColumnSortList {
      */
     public boolean isAscending() {
       return ascending;
-    }
-
-    private boolean equalsOrBothNull(Object a, Object b) {
-      return a == null ? b == null : a.equals(b);
     }
   }
 

--- a/user/src/com/google/gwt/view/client/SingleSelectionModel.java
+++ b/user/src/com/google/gwt/view/client/SingleSelectionModel.java
@@ -18,6 +18,7 @@ package com.google.gwt.view.client;
 import com.google.gwt.view.client.SelectionModel.AbstractSelectionModel;
 
 import java.util.HashSet;
+import java.util.Objects;
 import java.util.Set;
 
 /**
@@ -93,7 +94,7 @@ public class SingleSelectionModel<T> extends AbstractSelectionModel<T>
     if (!selected) {
       Object oldKey = newSelectedPending ? getKey(newSelectedItem) : curKey;
       Object newKey = getKey(item);
-      if (!equalsOrBothNull(oldKey, newKey)) {
+      if (!Objects.equals(oldKey, newKey)) {
         return;
       }
     }
@@ -111,17 +112,13 @@ public class SingleSelectionModel<T> extends AbstractSelectionModel<T>
     resolveChanges();
   }
 
-  private boolean equalsOrBothNull(Object a, Object b) {
-    return (a == null) ? (b == null) : a.equals(b);
-  }
-
   private void resolveChanges() {
     if (!newSelectedPending) {
       return;
     }
 
     Object key = getKey(newSelectedItem);
-    boolean sameKey = equalsOrBothNull(curKey, key);
+    boolean sameKey = Objects.equals(curKey, key);
     boolean changed = false;
     if (newSelected) {
       changed = !sameKey;

--- a/user/src/com/google/web/bindery/event/shared/testing/CountingEventBus.java
+++ b/user/src/com/google/web/bindery/event/shared/testing/CountingEventBus.java
@@ -23,6 +23,7 @@ import com.google.web.bindery.event.shared.SimpleEventBus;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Objects;
 
 /**
  * Wraps an {@link EventBus} to keep a count of registered handlers and how many times events have
@@ -130,8 +131,8 @@ public class CountingEventBus extends EventBus {
         return false;
       }
 
-      TypeSourcePair pair = (TypeSourcePair) o;      
-      return doNullEquals(type, pair.type) && doNullEquals(source, pair.source);
+      TypeSourcePair pair = (TypeSourcePair) o;
+      return Objects.equals(type, pair.type) && Objects.equals(source, pair.source);
     }
 
     @Override
@@ -140,13 +141,6 @@ public class CountingEventBus extends EventBus {
       hash = (hash * 31) + (type == null ? 0 : type.hashCode());
       hash = (hash * 31) + (source == null ? 0 : source.hashCode());
       return hash;
-    }
-
-    private boolean doNullEquals(Object a, Object b) {
-      if ((a == null) ^ (b == null)) {
-        return false;
-      }
-      return ((a == null) && (b == null)) || a.equals(b);
     }
   }
   


### PR DESCRIPTION
This fixes two issues found by nullness analysis:
* the assertion of non-empty IDs for ARIA purposes was logically wrong. When `Id` is created from an element, the `id` attribute is never null and the empty string check was skipped. When `Id` is created from a string (never happens in GWT itself) and the string happens to be `null`, the assertion would result in NPE rather than assertion error.
* the other issue is with slightly inefficient re-implementation of `Objects.equals` which had an unused `null` check (I assume the API didn't exist in JDK back when this wasimplemented, but can be used now).