### PR TITLE
Pin GitHub actions to SHA hashes

### DIFF
--- a/.github/workflows/full-check.yml
+++ b/.github/workflows/full-check.yml
@@ -27,17 +27,17 @@ jobs:
         java-version: [ '11', '17', '21', '22' ]
     steps:
       - name: Checkout GWT itself into one directory
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 #v6.0.3
         with:
           path: 'gwt'
       - name: Checkout GWT tools into a sibling directory
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 #v6.0.3
         with:
           repository: 'gwtproject/tools'
           path: 'tools'
       - name: Set up JDK ${{ matrix.java-version }}
         # GWT requires Java 11+ to build
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@ad2b38190b15e4d6bdf0c97fb4fca8412226d287 #v5.3.0
         with:
           java-version: ${{ matrix.java-version }}
           distribution: 'temurin'
@@ -61,32 +61,32 @@ jobs:
             -Dtest.emma.htmlunit.disable=true
 
       - name: Report test results
-        uses: mikepenz/action-junit-report@v6.3.1
+        uses: mikepenz/action-junit-report@3a81627bfac62268172037048872e8ebd4207e6d #v6.4.1
         if: always()
         with:
           report_paths: 'gwt/build/out/**/test/**/reports/TEST-*.xml'
       - name: Upload checkstyle xml for manual review in its own artifact
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a #v7.0.1
         if: always()
         with:
           name: checkstyle-reports-java${{ matrix.java-version }}
           path: 'gwt/build/out/**/checkstyle*.xml'
       - name: Upload test xml files for manual review in its own artifact
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a #v7.0.1
         if: always()
         with:
           name: junit-reports-java${{ matrix.java-version }}
           path: 'gwt/build/out/**/test/**/reports/TEST-*.xml'
 
       - name: On success, upload the release zip
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a #v7.0.1
         with:
           name: gwt-java${{ matrix.java-version }}
           path: 'gwt/build/dist/gwt-*.zip'
 
-      - name: Set up sonatype credentials
+      - name: Set up Sonatype credentials
         # Using the same java version as above, set up a settings.xml file
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@ad2b38190b15e4d6bdf0c97fb4fca8412226d287 #v5.3.0
         if: ${{ github.event_name == 'push' && github.ref_name == 'main' && github.repository_owner == 'gwtproject' && matrix.java-version == '21' }}
         with:
           java-version: ${{ matrix.java-version }}

--- a/.github/workflows/quick-check.yml
+++ b/.github/workflows/quick-check.yml
@@ -12,24 +12,24 @@ jobs:
         java-version: ['11', '17', '21', '22']
     steps:
       - name: Checkout GWT itself into one directory
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 #v6.0.3
         with:
           path: 'gwt'
           # we need depth=2 to see which style violations overlap with the current changes
           fetch-depth: 2
       - name: Checkout GWT tools into a sibling directory
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 #v6.0.3
         with:
           repository: 'gwtproject/tools'
           path: 'tools'
       - name: Set up JDK ${{ matrix.java-version }}
         # GWT presently requires Java 11+ to build
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@ad2b38190b15e4d6bdf0c97fb4fca8412226d287 #v5.3.0
         with:
           java-version: ${{ matrix.java-version }}
           distribution: 'temurin'
       - name: Set up reviewdog for easier checks on the PR's checkstyle output
-        uses: reviewdog/action-setup@v1
+        uses: reviewdog/action-setup@d8a7baabd7f3e8544ee4dbde3ee41d0011c3a93f #v1.5.0
         with:
           reviewdog_version: latest
 
@@ -59,7 +59,7 @@ jobs:
             reviewdog -f=checkstyle -filter-mode=diff_context -reporter=github-pr-annotations -level=info < $f
           done
       - name: Upload checkstyle xml for manual review
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a #v7.0.1
         if: ${{ matrix.java-version == '21' }}
         with:
           name: checkstyle-reports-java${{ matrix.java-version }}


### PR DESCRIPTION
Pointing to mutable tags is bad, because they can be force-pushed by repository owners or bad actors. All the tags GWT is currently referencing are mutable (e.g. list of [reviewdog](https://github.com/reviewdog/action-setup/tags) tags shows the distinction; for [setup-java](https://github.com/actions/setup-java/tags) all tags are mutable). The risk is [well known](https://docs.github.com/en/actions/reference/security/secure-use#using-third-party-actions
), but [until recently](https://github.com/aquasecurity/trivy/security/advisories/GHSA-69fq-xp46-6x23) it wasn't exploited for widely used actions. Now might be a good time to fix this.

This PR replaces all tags with hashes (even if immutable tag would be available, for consistency). The hash + comment format is well [supported by Dependabot](https://docs.github.com/en/actions/reference/security/secure-use#keeping-the-actions-in-your-workflows-secure-and-up-to-date).

