### PR TITLE
Set least-privilege GITHUB_TOKEN permissions for quick-check workflow

### DIFF
--- a/.github/workflows/quick-check.yml
+++ b/.github/workflows/quick-check.yml
@@ -3,6 +3,14 @@
 # style guide violations. Presently, tests are not run on pull requests.
 name: Quick smoke test
 on: [push, pull_request]
+
+# Least-privilege token: this workflow only checks out the code and lets
+# reviewdog read the pull request diff to post checkstyle annotations
+# (the github-pr-annotations reporter needs no write access).
+permissions:
+  contents: read
+  pull-requests: read
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## What

`.github/workflows/quick-check.yml` did not declare a `permissions:` block, so it ran with the repository's default `GITHUB_TOKEN` scopes. This adds an explicit least-privilege block:

```yaml
permissions:
  contents: read        # checkout the repository
  pull-requests: read   # reviewdog reads the PR diff to post checkstyle annotations
```

## Why

Scoping the token to exactly what the job needs follows the principle of least privilege and the [OpenSSF Scorecard `Token-Permissions`](https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions) check, limiting the blast radius if a step or third-party action is compromised. This mirrors the hardening already merged for the other workflow in #10169.

## Impact

Permissions-only change — no build, trigger, or action-version changes. The reviewdog `github-pr-annotations` reporter posts annotations via GitHub Actions log commands (no API write), and only reads the PR diff, so `pull-requests: read` preserves the checkstyle annotation behavior.

_Note: this change was prepared with AI assistance; I reviewed and validated it against the workflow myself._