### PR TITLE
Add support for Bazel 9 to the j2cl parts

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -1,0 +1,3 @@
+module(name = "org_gwtproject_gwt")
+
+bazel_dep(name = "rules_java", version = "9.6.1")

--- a/user/BUILD.bazel
+++ b/user/BUILD.bazel
@@ -1,5 +1,8 @@
 # Description:
 #   subset of bazel rules used by j2cl.
+
+load("@rules_java//java:defs.bzl", "java_library")
+
 package(default_visibility = ["//visibility:public"])
 
 licenses(["notice"]) # Apache2
@@ -9,7 +12,7 @@ filegroup(
     srcs = glob([
         "super/com/google/gwt/emul/java/**/*.java",
         "super/com/google/gwt/emul/javax/**/*.java",
-        ]),
+    ], allow_empty=True),
 )
 
 filegroup(


### PR DESCRIPTION
Adds a MODULE.bazel and a @rules_java dep to pull in `java_library`. Bazel complains that the javax glob is empty but I thought it was best to not mess with the list for consistency