### PR TITLE
validate permutation strong name in StackTraceDeobfuscator

### DIFF
--- a/user/src/com/google/gwt/core/server/StackTraceDeobfuscator.java
+++ b/user/src/com/google/gwt/core/server/StackTraceDeobfuscator.java
@@ -148,6 +148,10 @@ public abstract class StackTraceDeobfuscator {
 
   private static final Pattern JsniRefPattern = Pattern.compile("@?([^:]+)::([^(]+)(\\((.*)\\))?");
   private static final Pattern fragmentIdPattern = Pattern.compile(".*(\\d+)\\.js");
+  // A permutation strong name is a compiler-generated hash; the same character set is enforced on
+  // the RPC path in ServerSerializationStreamReader. It arrives here from the client-supplied
+  // X-GWT-Permutation header, so it must be constrained before it is used to build a file name.
+  private static final Pattern STRONG_NAME_PATTERN = Pattern.compile("[a-zA-Z0-9_]+");
   private static final int LINE_NUMBER_UNKNOWN = -1;
   private static final String SYMBOL_DATA_UNKNOWN = "";
 
@@ -344,6 +348,7 @@ public abstract class StackTraceDeobfuscator {
 
   protected InputStream getSourceMapInputStream(String permutationStrongName, int fragmentNumber)
       throws IOException {
+    checkStrongName(permutationStrongName);
     return openInputStream(permutationStrongName + "_sourceMap" + fragmentNumber + ".json");
   }
 
@@ -356,7 +361,21 @@ public abstract class StackTraceDeobfuscator {
    * @return a new {@link InputStream}
    */
   protected InputStream getSymbolMapInputStream(String permutationStrongName) throws IOException {
+    checkStrongName(permutationStrongName);
     return openInputStream(permutationStrongName + ".symbolMap");
+  }
+
+  /**
+   * Rejects a permutation strong name that is not a bare compiler hash. The strong name reaches
+   * this class straight from the client-controlled X-GWT-Permutation header, and it is concatenated
+   * into the symbol/source map file name, so a value such as {@code ../../secret} would otherwise
+   * escape the configured symbolMaps location.
+   */
+  private static void checkStrongName(String permutationStrongName) throws IOException {
+    if (permutationStrongName == null
+        || !STRONG_NAME_PATTERN.matcher(permutationStrongName).matches()) {
+      throw new IOException("Invalid permutation strong name: " + permutationStrongName);
+    }
   }
 
   /**

--- a/user/test/com/google/gwt/core/server/StackTraceDeobfuscatorTest.java
+++ b/user/test/com/google/gwt/core/server/StackTraceDeobfuscatorTest.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2024 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.gwt.core.server;
+
+import junit.framework.TestCase;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Test for {@link StackTraceDeobfuscator}.
+ */
+public class StackTraceDeobfuscatorTest extends TestCase {
+
+  /**
+   * Records every file name that reaches {@link #openInputStream} and serves data from an in-memory
+   * map, so the test can observe what the strong name resolves to.
+   */
+  private static class RecordingDeobfuscator extends StackTraceDeobfuscator {
+    final Map<String, String> files = new HashMap<String, String>();
+    String lastRequested;
+
+    @Override
+    protected InputStream openInputStream(String fileName) throws IOException {
+      lastRequested = fileName;
+      String data = files.get(fileName);
+      if (data == null) {
+        throw new IOException("Missing resource: " + fileName);
+      }
+      return new ByteArrayInputStream(data.getBytes(StandardCharsets.UTF_8));
+    }
+  }
+
+  private static StackTraceElement element(String method) {
+    return new StackTraceElement("Foo", method, "Foo.java", 1);
+  }
+
+  public void testValidStrongNameStillResolves() {
+    RecordingDeobfuscator d = new RecordingDeobfuscator();
+    d.files.put("ABCDEF0123.symbolMap",
+        "a,@com.example.Foo::bar()V,bar,Foo.java,42,0\n");
+
+    d.resymbolize(new StackTraceElement[] {element("a")}, "ABCDEF0123");
+
+    assertEquals("ABCDEF0123.symbolMap", d.lastRequested);
+  }
+
+  public void testTraversingStrongNameIsRejected() {
+    RecordingDeobfuscator d = new RecordingDeobfuscator();
+    StackTraceElement original = element("a");
+
+    StackTraceElement[] result =
+        d.resymbolize(new StackTraceElement[] {original}, "../../etc/passwd");
+
+    // The malicious name must never be turned into a file request.
+    assertNull(d.lastRequested);
+    // Deobfuscation is a best-effort no-op for an unusable strong name.
+    assertEquals(original, result[0]);
+  }
+}


### PR DESCRIPTION
StackTraceDeobfuscator builds the symbol and source map file names by concatenating the permutation strong name, and that name comes straight from the client X-GWT-Permutation header via the remote logging service, so a value such as ../../ reads files outside the configured symbolMaps directory. The RPC path already constrains the strong name to a bare compiler hash in ServerSerializationStreamReader; this applies the same check in the deobfuscator before the name is turned into a path, keeping valid hashes working while rejecting traversal.