### PR TITLE
normalize module base path before resolving rpc policy resource

### DIFF
--- a/user/src/com/google/gwt/user/server/rpc/RemoteServiceServlet.java
+++ b/user/src/com/google/gwt/user/server/rpc/RemoteServiceServlet.java
@@ -25,9 +25,8 @@ import com.google.gwt.user.client.rpc.SerializationException;
 
 import java.io.IOException;
 import java.io.InputStream;
-import java.net.MalformedURLException;
 import java.net.URI;
-import java.net.URL;
+import java.net.URISyntaxException;
 import java.text.ParseException;
 import java.util.HashMap;
 import java.util.Map;
@@ -60,8 +59,8 @@ public class RemoteServiceServlet extends AbstractRemoteServiceServlet
     String modulePath = null;
     if (moduleBaseURL != null) {
       try {
-        modulePath = normalizeModulePath(new URL(moduleBaseURL).getPath());
-      } catch (MalformedURLException ex) {
+        modulePath = normalizeModulePath(moduleBaseURL);
+      } catch (URISyntaxException ex) {
         // log the information, we will default
         servlet.log("Malformed moduleBaseURL: " + moduleBaseURL, ex);
       }
@@ -139,23 +138,17 @@ public class RemoteServiceServlet extends AbstractRemoteServiceServlet
   }
 
   /**
-   * Collapses "." and ".." segments in a module base path. The path is derived
-   * from the client-supplied module base URL, which is later concatenated with
-   * the strong name and file suffix to locate a resource; normalizing here
-   * ensures a crafted URL such as {@code http://host/ctx/../../WEB-INF/foo}
-   * cannot walk outside the module directory before the "same web application"
-   * containment check is applied. Returns {@code null} if the path cannot be
-   * parsed.
+   * Returns the path of a client-supplied module base URL with "." and ".."
+   * segments collapsed. The path is later concatenated with the strong name and
+   * file suffix to locate a resource; normalizing here ensures a crafted URL
+   * such as {@code http://host/ctx/../../WEB-INF/foo} cannot walk outside the
+   * module directory before the "same web application" containment check is
+   * applied. The returned path may be {@code null} for a URL without a path
+   * component.
    */
-  private static String normalizeModulePath(String path) {
-    if (path == null) {
-      return null;
-    }
-    try {
-      return URI.create(path).normalize().getRawPath();
-    } catch (IllegalArgumentException ex) {
-      return null;
-    }
+  private static String normalizeModulePath(String moduleBaseURL)
+      throws URISyntaxException {
+    return new URI(moduleBaseURL).normalize().getRawPath();
   }
 
   private static final SerializationPolicyClient CODE_SERVER_CLIENT =
@@ -247,7 +240,7 @@ public class RemoteServiceServlet extends AbstractRemoteServiceServlet
       if (header == null) {
         return null;
       }
-      String path = normalizeModulePath(new URL(header).getPath());
+      String path = normalizeModulePath(header);
       if (path == null) {
         return null;
       }
@@ -256,7 +249,7 @@ public class RemoteServiceServlet extends AbstractRemoteServiceServlet
         return null;
       }
       return path.substring(contextPath.length());
-    } catch (MalformedURLException e) {
+    } catch (URISyntaxException e) {
       return null;
     }
   }

--- a/user/src/com/google/gwt/user/server/rpc/RemoteServiceServlet.java
+++ b/user/src/com/google/gwt/user/server/rpc/RemoteServiceServlet.java
@@ -26,6 +26,7 @@ import com.google.gwt.user.client.rpc.SerializationException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.MalformedURLException;
+import java.net.URI;
 import java.net.URL;
 import java.text.ParseException;
 import java.util.HashMap;
@@ -59,7 +60,7 @@ public class RemoteServiceServlet extends AbstractRemoteServiceServlet
     String modulePath = null;
     if (moduleBaseURL != null) {
       try {
-        modulePath = new URL(moduleBaseURL).getPath();
+        modulePath = normalizeModulePath(new URL(moduleBaseURL).getPath());
       } catch (MalformedURLException ex) {
         // log the information, we will default
         servlet.log("Malformed moduleBaseURL: " + moduleBaseURL, ex);
@@ -135,6 +136,26 @@ public class RemoteServiceServlet extends AbstractRemoteServiceServlet
     }
 
     return serializationPolicy;
+  }
+
+  /**
+   * Collapses "." and ".." segments in a module base path. The path is derived
+   * from the client-supplied module base URL, which is later concatenated with
+   * the strong name and file suffix to locate a resource; normalizing here
+   * ensures a crafted URL such as {@code http://host/ctx/../../WEB-INF/foo}
+   * cannot walk outside the module directory before the "same web application"
+   * containment check is applied. Returns {@code null} if the path cannot be
+   * parsed.
+   */
+  private static String normalizeModulePath(String path) {
+    if (path == null) {
+      return null;
+    }
+    try {
+      return URI.create(path).normalize().getRawPath();
+    } catch (IllegalArgumentException ex) {
+      return null;
+    }
   }
 
   private static final SerializationPolicyClient CODE_SERVER_CLIENT =
@@ -226,7 +247,10 @@ public class RemoteServiceServlet extends AbstractRemoteServiceServlet
       if (header == null) {
         return null;
       }
-      String path = new URL(header).getPath();
+      String path = normalizeModulePath(new URL(header).getPath());
+      if (path == null) {
+        return null;
+      }
       String contextPath = getThreadLocalRequest().getContextPath();
       if (!path.startsWith(contextPath)) {
         return null;

--- a/user/test/com/google/gwt/user/server/rpc/RemoteServiceServletTest.java
+++ b/user/test/com/google/gwt/user/server/rpc/RemoteServiceServletTest.java
@@ -366,6 +366,41 @@ public class RemoteServiceServletTest extends TestCase {
     }
   }
 
+  /**
+   * A crafted moduleBaseURL containing ".." segments must not be able to walk
+   * out of the module directory when the strong name and file suffix are
+   * appended to build the serialization policy resource path.
+   */
+  public void testDoGetSerializationPolicy_ModuleBaseUrlTraversal()
+      throws ServletException {
+    final StringBuilder requestedResource = new StringBuilder();
+    MockServletContext mockContext = new MockServletContext() {
+      @Override
+      public InputStream getResourceAsStream(String resource) {
+        requestedResource.append(resource);
+        return null;
+      }
+    };
+    MockServletConfig mockConfig = new MockServletConfig(mockContext);
+
+    RemoteServiceServlet rss = new RemoteServiceServlet();
+
+    MockHttpServletRequestContextPath mockRequest = new MockHttpServletRequestContextPath();
+    rss.init(mockConfig);
+
+    mockRequest.contextPath = "/MyModule";
+
+    SerializationPolicy serializationPolicy = rss.doGetSerializationPolicy(
+        mockRequest, "http://www.google.com/MyModule/../../../secret", "12345");
+
+    // The traversal walks above the context path, so no policy is loaded and
+    // the resource path handed to the container never escapes the module dir.
+    assertNull(serializationPolicy);
+    assertNotNull(mockContext.messageLogged);
+    assertFalse("resource path must not contain a traversal segment: "
+        + requestedResource, requestedResource.toString().contains(".."));
+  }
+
   public void testDoGetSerializationPolicy_FailToOpenMD5Resource()
       throws ServletException {
     MockServletContext mockContext = new MockServletContext() {


### PR DESCRIPTION
ServerSerializationStreamReader validates the strong name before policy lookup, but the module base URL from the same request reaches loadSerializationPolicy untouched, where new URL(moduleBaseURL).getPath() is joined with the strong name and the .gwt.rpc suffix and opened through getResourceAsStream. A value such as http://host/ctx/../../WEB-INF/foo still satisfies the startsWith(contextPath) guard, so the ../ segments survive into the resource path and can point the policy load outside the module directory; getRequestModuleBasePath resolves the symbol-map path the same way. Normalize the path with URI.normalize() before the containment check at both call sites so traversal segments collapse and the existing check rejects anything that leaves the module directory.