### PR TITLE
Avoid warning when compiling records

### DIFF
--- a/dev/core/src/com/google/gwt/dev/javac/testing/impl/JavaResourceBase.java
+++ b/dev/core/src/com/google/gwt/dev/javac/testing/impl/JavaResourceBase.java
@@ -282,15 +282,18 @@ public class JavaResourceBase {
           "package java.lang.runtime;",
           "public class ObjectMethods {}");
 
-  // We only need Objects.hash() for Records - the real JRE would synthesize these methods on the
-  // fly using ObjectMethods, but we need to generate the code up front. This implementation is
-  // wrong, but the important thing is only that it exists for these tests.
+  // We only need Objects.hash() and .equals() for Records - the real JRE would synthesize these
+  // methods on the fly using ObjectMethods, but we need to generate the code up front.
+  // This implementation is wrong, but the important thing is only that it exists for these tests.
   public static final MockJavaResource OBJECTS =
       createMockJavaResource("java.util.Objects",
-          "package java.util;",
-          "public class Objects {",
-          "  public static int hash(Object... values) { return values.hashCode(); }",
-          "}");
+          """
+          package java.util;
+          public class Objects {
+            public static boolean equals(Object a, Object b) { return a == b; }
+            public static int hash(Object... values) { return values.hashCode(); }
+          }
+          """);
 
   public static final MockJavaResource RECORD =
       createMockJavaResource("java.lang.Record",

--- a/dev/core/src/com/google/gwt/dev/jjs/JavaToJavaScriptCompiler.java
+++ b/dev/core/src/com/google/gwt/dev/jjs/JavaToJavaScriptCompiler.java
@@ -1164,7 +1164,7 @@ public final class JavaToJavaScriptCompiler {
       // (2) Construct and unify the unresolved Java AST
       CompilationState compilationState =
           constructJavaAst(precompilationContext);
-
+      ImplementRecordComponents.exec(jprogram);
       // TODO(stalcup): hide metrics gathering in a callback or subclass
       JsniRestrictionChecker.exec(logger, jprogram);
       JsInteropRestrictionChecker.exec(logger, jprogram, getMinimalRebuildCache());
@@ -1181,8 +1181,6 @@ public final class JavaToJavaScriptCompiler {
       DevirtualizeDefaultMethodForwarding.exec(jprogram);
       // Replace calls to native overrides of object methods.
       ReplaceCallsToNativeJavaLangObjectOverrides.exec(jprogram);
-
-      ImplementRecordComponents.exec(jprogram);
 
       FixAssignmentsToUnboxOrCast.exec(jprogram);
       if (options.isEnableAssertions()) {

--- a/dev/core/test/com/google/gwt/dev/jjs/impl/JsInteropRestrictionCheckerTest.java
+++ b/dev/core/test/com/google/gwt/dev/jjs/impl/JsInteropRestrictionCheckerTest.java
@@ -2522,7 +2522,7 @@ public class JsInteropRestrictionCheckerTest extends OptimizerTestBase {
     assertBuggySucceeds();
   }
 
-  public void testUnusuableByJsWarns() throws Exception {
+  public void testUnusableByJsWarns() throws Exception {
     addSnippetImport("jsinterop.annotations.JsFunction");
     addSnippetImport("jsinterop.annotations.JsType");
     addSnippetImport("jsinterop.annotations.JsMethod");
@@ -2625,6 +2625,18 @@ public class JsInteropRestrictionCheckerTest extends OptimizerTestBase {
     assertBuggySucceeds();
   }
 
+  public void testRecordSucceeds() throws Exception {
+    // override equals and hashCode so that we don't need the source for java.lang.Objects
+    addSnippetClassDecl("""
+        public class Hidden { }
+        public record Buggy(Hidden val) {
+          public boolean equals(Object o) {return o == this;}
+          public int hashCode() {return 1;}
+        }
+        """);
+    assertBuggySucceeds();
+  }
+
   public final void assertBuggySucceeds(String... expectedWarnings)
       throws Exception {
     Result result = assertCompileSucceeds("Buggy buggy = null;", expectedWarnings);
@@ -2639,6 +2651,7 @@ public class JsInteropRestrictionCheckerTest extends OptimizerTestBase {
   @Override
   protected boolean doOptimizeMethod(TreeLogger logger, JProgram program, JMethod method) {
     try {
+      ImplementRecordComponents.exec(program);
       JsInteropRestrictionChecker.exec(logger, program, new MinimalRebuildCache());
     } catch (Exception e) {
       throw new RuntimeException(e);

--- a/dev/core/test/com/google/gwt/dev/jjs/impl/JsInteropRestrictionCheckerTest.java
+++ b/dev/core/test/com/google/gwt/dev/jjs/impl/JsInteropRestrictionCheckerTest.java
@@ -2626,13 +2626,9 @@ public class JsInteropRestrictionCheckerTest extends OptimizerTestBase {
   }
 
   public void testRecordSucceeds() throws Exception {
-    // override equals and hashCode so that we don't need the source for java.lang.Objects
     addSnippetClassDecl("""
         public class Hidden { }
-        public record Buggy(Hidden val) {
-          public boolean equals(Object o) {return o == this;}
-          public int hashCode() {return 1;}
-        }
+        public record Buggy(Hidden val) { }
         """);
     assertBuggySucceeds();
   }


### PR DESCRIPTION
Fixes #10252 by rearranging the compilation steps -- record components have to be implemented earlier.