### PR TITLE
validate language subtag in GwtLocale fromString

### DIFF
--- a/user/src/com/google/gwt/i18n/server/GwtLocaleFactoryImpl.java
+++ b/user/src/com/google/gwt/i18n/server/GwtLocaleFactoryImpl.java
@@ -36,6 +36,19 @@ public class GwtLocaleFactoryImpl implements GwtLocaleFactory {
     return matches(str, min, max, false);
   }
 
+  private static boolean isAlphaNumeric(String str, int min, int max) {
+    int len = str.length();
+    if (len < min || len > max) {
+      return false;
+    }
+    for (int i = 0; i < len; ++i) {
+      if (!Character.isLetterOrDigit(str.charAt(i))) {
+        return false;
+      }
+    }
+    return true;
+  }
+
   /**
    * Check if the supplied string matches length and composition requirements.
    * 
@@ -143,6 +156,14 @@ public class GwtLocaleFactoryImpl implements GwtLocaleFactory {
       ArrayList<String> localeParts = new ArrayList<String>();
       String[] parts = localeName.split("[-_]");
       for (int i = 0; i < parts.length; ++i) {
+        // The split only breaks on '-'/'_', so any other character stays inside
+        // a part. Require each subtag to be alphanumeric and 1-8 chars, matching
+        // BCP47, so an untrusted server-side locale can't smuggle '.', '$' or
+        // '/' into the class name LocalizableInstantiator resolves reflectively.
+        if (!isAlphaNumeric(parts[i], 1, 8)) {
+          throw new IllegalArgumentException("Unrecognized locale format: "
+              + localeName);
+        }
         if (parts[i].length() == 1 && i + 1 < parts.length) {
           localeParts.add(parts[i] + '-' + parts[++i]);
         } else {

--- a/user/test/com/google/gwt/i18n/server/GwtLocaleTest.java
+++ b/user/test/com/google/gwt/i18n/server/GwtLocaleTest.java
@@ -174,6 +174,28 @@ public class GwtLocaleTest extends TestCase {
     }
   }
 
+  public void testFromStringRejectsInvalidLanguage() {
+    // The language subtag is concatenated into class names resolved reflectively
+    // on the server, so it must not carry characters like '.', '$' or '/'.
+    String[] invalid = {
+        "com.google.gwt.dev.Compiler", "java.lang.Runtime", "x$Evil", "a/b/c",
+        "en.US",
+    };
+    for (String locale : invalid) {
+      try {
+        factory.fromString(locale);
+        fail("Should have thrown IllegalArgumentException on " + locale);
+      } catch (IllegalArgumentException expected) {
+      }
+    }
+    // Well-formed tags, including extended-language and private-use forms, are
+    // still accepted with the language preserved verbatim.
+    assertEquals("en", factory.fromString("en_US").getLanguage());
+    assertEquals("zh-cmn", factory.fromString("zh-cmn").getLanguage());
+    assertEquals("i-klingon", factory.fromString("i-klingon").getLanguage());
+    assertEquals("x-foo123", factory.fromString("x-foo123").getLanguage());
+  }
+
   public void testInheritance() {
     GwtLocale en = factory.fromString("en_Latn_US_VARIANT");
     List<GwtLocale> chain = en.getInheritanceChain();


### PR DESCRIPTION
On the server the active locale is read straight from the request by GwtServletBase.getGwtLocale (the locale query parameter or a cookie) and stored as the thread 'locale' property, and GwtLocaleFactoryImpl.fromString then parses that string into subtags. It checks the script, region and variant components against length and character rules but takes the primary language subtag as-is with only a lower-casing pass, and the code still carries a TODO to verify the language tag. Because the split only happens on '-' and '_', a value such as locale=java.lang.Runtime survives intact as the language, and LocalizableInstantiator concatenates that language into class names it passes to Class.forName().newInstance() when server code calls GWT.create on a Localizable, so '.', '$' and '/' can be smuggled into the reflective lookup. I came across it while tracing where the untrusted locale property finally lands. The fix validates the assembled language tag against the same BCP47 subtag shape the other components already require and throws IllegalArgumentException otherwise, kept inside fromString so every caller is covered without disturbing the parse flow. Existing locales, including extended-language and private-use forms like zh-cmn and x-foo123, are unaffected.