### PR TITLE
Keep JsInterop primitive coercions nullable in JUnsafeTypeCoercion

### DIFF
--- a/dev/core/src/com/google/gwt/dev/jjs/ast/JUnsafeTypeCoercion.java
+++ b/dev/core/src/com/google/gwt/dev/jjs/ast/JUnsafeTypeCoercion.java
@@ -41,6 +41,10 @@ public class JUnsafeTypeCoercion extends JExpression {
 
   @Override
   public JType getType() {
+    if (expression.getType().isPrimitiveType()) {
+      // A primitive-typed value may be JS undefined (native JsInterop/JSNI), so keep it nullable.
+      return coercionType;
+    }
     if (!expression.getType().canBeNull() && !coercionType.isNullType()) {
       // Strengthen type to non null unless it has been determined that the type is not instantiable
       // (and that is reflected by replacing the coercion type by the null type).

--- a/dev/core/test/com/google/gwt/dev/jjs/impl/MethodInlinerTest.java
+++ b/dev/core/test/com/google/gwt/dev/jjs/impl/MethodInlinerTest.java
@@ -15,7 +15,9 @@ package com.google.gwt.dev.jjs.impl;
 
 import com.google.gwt.core.ext.TreeLogger;
 import com.google.gwt.dev.jjs.ast.JMethod;
+import com.google.gwt.dev.jjs.ast.JMethodBody;
 import com.google.gwt.dev.jjs.ast.JProgram;
+import com.google.gwt.dev.jjs.ast.JReturnStatement;
 
 /**
  * Test for {@link MethodInliner}.
@@ -184,6 +186,21 @@ public class MethodInlinerTest extends OptimizerTestBase {
     assertEquals(
         "static int fun2(int a){ return a <= 0 ? a : EntryPoint.fun1(a - 1) + a; }",
         getCanonicalSource(result.findMethod("fun2")));
+  }
+
+  public void testInlinedUncheckedCastOfPrimitiveKeepsNullability() throws Exception {
+    addSnippetImport("javaemul.internal.annotations.UncheckedCast");
+    addSnippetImport("javaemul.internal.annotations.DoNotAutobox");
+    addSnippetClassDecl(
+        "@UncheckedCast static <T> T uncheckedCast(@DoNotAutobox Object o) { return (T) o; }");
+    addSnippetClassDecl("static Double box(double d) { return uncheckedCast(d); }");
+    Result result = optimize("void", "box(1);");
+    JMethod box = result.findMethod("box");
+    JReturnStatement returnStatement =
+        (JReturnStatement) ((JMethodBody) box.getBody()).getStatements().get(0);
+    // After inlining uncheckedCast, the boxed result must not become provably non-null: the
+    // primitive input may be JS undefined when it originates in native JsInterop/JSNI code.
+    assertTrue(returnStatement.getExpr().getType().canBeNull());
   }
 
   @Override

--- a/dev/core/test/com/google/gwt/dev/jjs/impl/MethodInlinerTest.java
+++ b/dev/core/test/com/google/gwt/dev/jjs/impl/MethodInlinerTest.java
@@ -14,10 +14,12 @@
 package com.google.gwt.dev.jjs.impl;
 
 import com.google.gwt.core.ext.TreeLogger;
+import com.google.gwt.dev.jjs.ast.JExpression;
 import com.google.gwt.dev.jjs.ast.JMethod;
 import com.google.gwt.dev.jjs.ast.JMethodBody;
 import com.google.gwt.dev.jjs.ast.JProgram;
 import com.google.gwt.dev.jjs.ast.JReturnStatement;
+import com.google.gwt.dev.jjs.ast.JUnsafeTypeCoercion;
 
 /**
  * Test for {@link MethodInliner}.
@@ -198,9 +200,17 @@ public class MethodInlinerTest extends OptimizerTestBase {
     JMethod box = result.findMethod("box");
     JReturnStatement returnStatement =
         (JReturnStatement) ((JMethodBody) box.getBody()).getStatements().get(0);
-    // After inlining uncheckedCast, the boxed result must not become provably non-null: the
-    // primitive input may be JS undefined when it originates in native JsInterop/JSNI code.
-    assertTrue(returnStatement.getExpr().getType().canBeNull());
+    // The inlined body is the unsafe coercion that autoboxes the primitive to Double. Pin that it
+    // is that coercion (so the test can't pass for an unrelated reason), but assert on its type
+    // rather than the sub-tree shape, which the optimizer may rearrange.
+    JExpression returned = returnStatement.getExpr();
+    assertTrue("inlined box() should return the unsafe coercion to Double",
+        returned instanceof JUnsafeTypeCoercion);
+    assertEquals("java.lang.Double", returned.getType().getName());
+    // The boxed result must not become provably non-null: the coerced primitive may be JS undefined
+    // when it originates in native JsInterop/JSNI code, so a later 'boxed == null' must not fold to
+    // false. This is false on the un-fixed 2.13 compiler and true once the strengthening is skipped.
+    assertTrue(returned.getType().canBeNull());
   }
 
   @Override

--- a/user/test/com/google/gwt/dev/jjs/test/UncheckedCastTest.java
+++ b/user/test/com/google/gwt/dev/jjs/test/UncheckedCastTest.java
@@ -45,4 +45,16 @@ public class UncheckedCastTest extends GWTTestCase {
     boolean unboxedBoolean = uncheckedCast(new Double(12));
     assertTrue(unboxedBoolean);
   }
+
+  private static native double undefinedDouble() /*-{
+    return undefined;
+  }-*/;
+
+  public void testBoxedUndefinedDoubleIsNull() {
+    // Autoboxing a JS undefined value typed as double must yield a Double that compares equal
+    // to null; the compiler must not statically conclude the boxed value is non-null.
+    Double d = undefinedDouble();
+    assertTrue(d == null);
+    assertFalse(d != null);
+  }
 }


### PR DESCRIPTION
Optimized-compile regression from 2.12.x: a native `@JsType(isNative=true)` primitive field holding JS `undefined`, autoboxed and null-checked, reads as non-null since 2.13.0 (`getValue() == null` returns `false` where it returned `true`).

`JUnsafeTypeCoercion.getType()` strengthens its result to non-null whenever the coerced expression can't be null — always true for a primitive. That predates 2.13; #10165 made `uncheckedCast` inlinable, so the non-null type now propagates into the caller, where `DeadCodeElimination` folds `boxed == null` to `false` and `EqualityNormalizer` skips `Cast.maskUndefined`. Either way the `undefined` leaks past the check.

Fix: skip the non-null strengthening when the coerced expression is a primitive — such a value may be JS `undefined` when it comes from native JsInterop/JSNI. Only the result nullability changes, not inlinability, so #10165's win is preserved (`$clinit_Boolean` still pruned).

Tested against the compiler's own harness: the added `MethodInlinerTest` case fails on released gwt-dev 2.13.1 and passes with this change; `TypeTightenerTest` and the rest of `MethodInlinerTest` still pass.

Live repro (2.12.1 / 2.13.1 / 2.13.1 + this fix): https://jornc.github.io/gwt-2.13-undefined-null-repro/

Fixes #10372.

---
We hit this as a regression in our e2e tests while upgrading to the latest GWT release; we traced the cause down to the compiler change above, and prepared the issue, the fix, and the repro proof using [Claude Code](https://claude.com/claude-code).
