### PR TITLE
fix fragment id capture in StackTraceDeobfuscator file name regex

### DIFF
--- a/user/src/com/google/gwt/core/server/StackTraceDeobfuscator.java
+++ b/user/src/com/google/gwt/core/server/StackTraceDeobfuscator.java
@@ -147,7 +147,7 @@ public abstract class StackTraceDeobfuscator {
   }
 
   private static final Pattern JsniRefPattern = Pattern.compile("@?([^:]+)::([^(]+)(\\((.*)\\))?");
-  private static final Pattern fragmentIdPattern = Pattern.compile("(?:.*[^\\d])?(\\d+)\\.js");
+  private static final Pattern fragmentIdPattern = Pattern.compile("(?:.*\\D)?(\\d+)\\.js");
   // Matches ServerSerializationStreamReader: the strong name reaches us straight from the
   // client (X-GWT-Permutation header) and is concatenated into symbol/source map file names.
   private static final Pattern strongNamePattern = Pattern.compile("[a-zA-Z0-9_]+");

--- a/user/src/com/google/gwt/core/server/StackTraceDeobfuscator.java
+++ b/user/src/com/google/gwt/core/server/StackTraceDeobfuscator.java
@@ -147,7 +147,7 @@ public abstract class StackTraceDeobfuscator {
   }
 
   private static final Pattern JsniRefPattern = Pattern.compile("@?([^:]+)::([^(]+)(\\((.*)\\))?");
-  private static final Pattern fragmentIdPattern = Pattern.compile(".*(\\d+)\\.js");
+  private static final Pattern fragmentIdPattern = Pattern.compile("(?:.*[^\\d])?(\\d+)\\.js");
   // Matches ServerSerializationStreamReader: the strong name reaches us straight from the
   // client (X-GWT-Permutation header) and is concatenated into symbol/source map file names.
   private static final Pattern strongNamePattern = Pattern.compile("[a-zA-Z0-9_]+");

--- a/user/test/com/google/gwt/core/server/StackTraceDeobfuscatorTest.java
+++ b/user/test/com/google/gwt/core/server/StackTraceDeobfuscatorTest.java
@@ -41,6 +41,18 @@ public class StackTraceDeobfuscatorTest extends TestCase {
     return new StackTraceElement[] {new StackTraceElement("C", "m", "C.java", 1)};
   }
 
+  /**
+   * Builds a frame as the browser reports it for a fragment, whose file name comes from the
+   * "//# sourceURL=&lt;module&gt;-&lt;fragment&gt;.js" comment written by CrossSiteIframeLinker.
+   * The column marker makes the frame source map capable, and an unknown method symbol leaves
+   * the fragment id to be recovered from the file name.
+   */
+  private static StackTraceElement[] traceInFragmentFile(String fileName) {
+    return new StackTraceElement[] {new StackTraceElement("C", "unknown", fileName + "@1", 1)};
+  }
+
+  private static final String STRONG_NAME = "0F2C4A6E8B1D3F5709ABCDEF12345678";
+
   public void testTraversalStrongNameIsNotUsedToBuildPath() {
     RecordingDeobfuscator d = new RecordingDeobfuscator();
     d.resymbolize(trace(), "../../../../../../etc/passwd");
@@ -52,5 +64,26 @@ public class StackTraceDeobfuscatorTest extends TestCase {
     RecordingDeobfuscator d = new RecordingDeobfuscator();
     d.resymbolize(trace(), "0F2C4A6E8B1D3F5709ABCDEF12345678");
     assertEquals("0F2C4A6E8B1D3F5709ABCDEF12345678.symbolMap", d.opened.get(0));
+  }
+
+  public void testSingleDigitFragmentIdIsReadFromFileName() {
+    RecordingDeobfuscator d = new RecordingDeobfuscator();
+    d.resymbolize(traceInFragmentFile("app-5.js"), STRONG_NAME);
+    assertTrue("expected fragment 5 to be requested: " + d.opened,
+        d.opened.contains(STRONG_NAME + "_sourceMap5.json"));
+  }
+
+  public void testMultiDigitFragmentIdIsReadFromFileName() {
+    RecordingDeobfuscator d = new RecordingDeobfuscator();
+    d.resymbolize(traceInFragmentFile("app-12.js"), STRONG_NAME);
+    assertTrue("expected fragment 12, not its last digit: " + d.opened,
+        d.opened.contains(STRONG_NAME + "_sourceMap12.json"));
+  }
+
+  public void testMultiDigitFragmentIdIsReadFromModuleNameEndingInDigit() {
+    RecordingDeobfuscator d = new RecordingDeobfuscator();
+    d.resymbolize(traceInFragmentFile("app2-104.js"), STRONG_NAME);
+    assertTrue("expected fragment 104, not its last digit: " + d.opened,
+        d.opened.contains(STRONG_NAME + "_sourceMap104.json"));
   }
 }

--- a/user/test/com/google/gwt/core/server/StackTraceDeobfuscatorTest.java
+++ b/user/test/com/google/gwt/core/server/StackTraceDeobfuscatorTest.java
@@ -76,14 +76,14 @@ public class StackTraceDeobfuscatorTest extends TestCase {
   public void testMultiDigitFragmentIdIsReadFromFileName() {
     RecordingDeobfuscator d = new RecordingDeobfuscator();
     d.resymbolize(traceInFragmentFile("app-12.js"), STRONG_NAME);
-    assertTrue("expected fragment 12, not its last digit: " + d.opened,
+    assertTrue("expected fragment 12 to be requested: " + d.opened,
         d.opened.contains(STRONG_NAME + "_sourceMap12.json"));
   }
 
   public void testMultiDigitFragmentIdIsReadFromModuleNameEndingInDigit() {
     RecordingDeobfuscator d = new RecordingDeobfuscator();
     d.resymbolize(traceInFragmentFile("app2-104.js"), STRONG_NAME);
-    assertTrue("expected fragment 104, not its last digit: " + d.opened,
+    assertTrue("expected fragment 104 to be requested: " + d.opened,
         d.opened.contains(STRONG_NAME + "_sourceMap104.json"));
   }
 }


### PR DESCRIPTION
When a frame has no symbol map entry, which is the normal case for anonymous functions, the deobfuscator falls back to reading the code split fragment number out of the frame's file name. That name comes from the `//# sourceURL=<moduleName>-<fragmentId>.js` comment CrossSiteIframeLinker writes at the end of every fragment, so it is the only place the fragment number is still available on the server. The pattern used to read it back is `.*(\d+)\.js`, and because `.*` is greedy it backs off only far enough to leave a single digit for the capture group, so `app-12.js` reports fragment 2 and `app2-104.js` reports fragment 4. Under ten fragments that happens to be correct, which is presumably why it has gone unnoticed, but past that the wrong `_sourceMap<N>.json` is loaded and the frame gets resolved against unrelated source. Requiring a non-digit ahead of the captured run fixes the capture, and it also drops the quadratic backtracking the old pattern has on a file name that arrives from the client (a 32k name took ~700ms to reject, ~1ms after). The set of file names that match is unchanged, only the digits handed back differ, and I kept the change to the pattern so the surrounding fallback stays as it is.