### PR TITLE
reject unquoted angle brackets in SafeStyles style name and value checks

### DIFF
--- a/user/src/com/google/gwt/safecss/shared/SafeStylesHostedModeUtils.java
+++ b/user/src/com/google/gwt/safecss/shared/SafeStylesHostedModeUtils.java
@@ -95,6 +95,8 @@ public class SafeStylesHostedModeUtils {
       return "Style property names cannot contain a semi-colon: " + name;
     } else if (name.indexOf(':') >= 0) {
       return "Style property names cannot contain a colon: " + name;
+    } else if (name.indexOf('<') >= 0 || name.indexOf('>') >= 0) {
+      return "Style property names cannot contain a bracket (< or >): " + name;
     }
 
     return null;
@@ -120,6 +122,14 @@ public class SafeStylesHostedModeUtils {
     // Empty value.
     if (value == null || value.length() == 0) {
       return "Style property values cannot be null or empty";
+    }
+
+    /*
+     * The HTML tokenizer runs before the CSS parser, so a bracket ends the
+     * enclosing style element even inside a quoted string or a url().
+     */
+    if (value.indexOf('<') >= 0 || value.indexOf('>') >= 0) {
+      return "Style property values cannot contain a bracket (< or >): " + value;
     }
 
     /*

--- a/user/src/com/google/gwt/safecss/shared/SafeStylesHostedModeUtils.java
+++ b/user/src/com/google/gwt/safecss/shared/SafeStylesHostedModeUtils.java
@@ -96,7 +96,7 @@ public class SafeStylesHostedModeUtils {
     } else if (name.indexOf(':') >= 0) {
       return "Style property names cannot contain a colon: " + name;
     } else if (name.indexOf('<') >= 0 || name.indexOf('>') >= 0) {
-      return "Style property names cannot contain a bracket (< or >): " + name;
+      return "Style property names cannot contain an angle bracket: " + name;
     }
 
     return null;
@@ -125,17 +125,9 @@ public class SafeStylesHostedModeUtils {
     }
 
     /*
-     * The HTML tokenizer runs before the CSS parser, so a bracket ends the
-     * enclosing style element even inside a quoted string or a url().
-     */
-    if (value.indexOf('<') >= 0 || value.indexOf('>') >= 0) {
-      return "Style property values cannot contain a bracket (< or >): " + value;
-    }
-
-    /*
      * A value can contain any token, but parenthesis, brackets, braces, and
-     * single/double quotes must be paired. Semi-colons are only allowed in
-     * strings, such as in a url.
+     * single/double quotes must be paired. Semi-colons and angle brackets are
+     * only allowed in strings, such as in a url.
      */
 
     // Create a map of pairable 'open' characters to 'close' characters.
@@ -222,6 +214,10 @@ public class SafeStylesHostedModeUtils {
       } else if (ch == ':') {
         // Contains an unescaped colon.
         return "Style property values cannot contain a colon (except within quotes): " + value;
+      } else if (ch == '<' || ch == '>') {
+        // Contains an unescaped angle bracket, which would end an enclosing style element.
+        return "Style property values cannot contain an angle bracket (except within quotes): "
+            + value;
       }
     }
 

--- a/user/src/com/google/gwt/safecss/shared/SafeStylesHostedModeUtils.java
+++ b/user/src/com/google/gwt/safecss/shared/SafeStylesHostedModeUtils.java
@@ -215,7 +215,7 @@ public class SafeStylesHostedModeUtils {
         // Contains an unescaped colon.
         return "Style property values cannot contain a colon (except within quotes): " + value;
       } else if (ch == '<' || ch == '>') {
-        // Contains an unescaped angle bracket, which would end an enclosing style element.
+        // Contains an unescaped angle bracket.
         return "Style property values cannot contain an angle bracket (except within quotes): "
             + value;
       }

--- a/user/test/com/google/gwt/safecss/shared/GwtSafeStylesUtilsTest.java
+++ b/user/test/com/google/gwt/safecss/shared/GwtSafeStylesUtilsTest.java
@@ -47,8 +47,7 @@ public class GwtSafeStylesUtilsTest extends GWTTestCase {
       ";startsWithSemicolon", "endsWithSemicolon;", "contains;semicolon",
       "almost-escaped\\\\;semi-colon", "almost-escaped\\\\:colon", "unmatched'singlequote",
       "unmatched\"doublequote", "url(http://withUnmatched(Paren)", "url(http://unterminated",
-      "end-in-escape-character\\", "contains<open-bracket", "contains>close-bracket",
-      "red</style><script>alert(1)</script>"};
+      "end-in-escape-character\\", "contains<open-bracket", "contains>close-bracket"};
 
   static final String[] VALID_STYLE_NAMES = {
       "simple", "one-hyphen", "has-two-hyphens", "-starts-with-hyphen", "_startsWithUnderscore",

--- a/user/test/com/google/gwt/safecss/shared/GwtSafeStylesUtilsTest.java
+++ b/user/test/com/google/gwt/safecss/shared/GwtSafeStylesUtilsTest.java
@@ -38,7 +38,7 @@ public class GwtSafeStylesUtilsTest extends GWTTestCase {
   static final String[] INVALID_STYLE_NAMES = {
       null, "", ";startsWithSemicolon", "endsWithSemicolon;", "contains;semicolon",
       "--starts-with-double-hyphen", "0starts-with-digit", "-0starts-with-hyphen-digit",
-      "contains:colon"};
+      "contains:colon", "contains<open-bracket", "contains>close-bracket"};
 
   static final String INVALID_STYLE_VALUE = "contains;semicolon";
 
@@ -47,7 +47,9 @@ public class GwtSafeStylesUtilsTest extends GWTTestCase {
       ";startsWithSemicolon", "endsWithSemicolon;", "contains;semicolon",
       "almost-escaped\\\\;semi-colon", "almost-escaped\\\\:colon", "unmatched'singlequote",
       "unmatched\"doublequote", "url(http://withUnmatched(Paren)", "url(http://unterminated",
-      "end-in-escape-character\\"};
+      "end-in-escape-character\\", "contains<open-bracket", "contains>close-bracket",
+      "red</style><script>alert(1)</script>", "url(http://endsStyleElement</style>)",
+      "'quoted</style><script>alert(1)</script>'"};
 
   static final String[] VALID_STYLE_NAMES = {
       "simple", "one-hyphen", "has-two-hyphens", "-starts-with-hyphen", "_startsWithUnderscore",

--- a/user/test/com/google/gwt/safecss/shared/GwtSafeStylesUtilsTest.java
+++ b/user/test/com/google/gwt/safecss/shared/GwtSafeStylesUtilsTest.java
@@ -48,8 +48,7 @@ public class GwtSafeStylesUtilsTest extends GWTTestCase {
       "almost-escaped\\\\;semi-colon", "almost-escaped\\\\:colon", "unmatched'singlequote",
       "unmatched\"doublequote", "url(http://withUnmatched(Paren)", "url(http://unterminated",
       "end-in-escape-character\\", "contains<open-bracket", "contains>close-bracket",
-      "red</style><script>alert(1)</script>", "url(http://endsStyleElement</style>)",
-      "'quoted</style><script>alert(1)</script>'"};
+      "red</style><script>alert(1)</script>"};
 
   static final String[] VALID_STYLE_NAMES = {
       "simple", "one-hyphen", "has-two-hyphens", "-starts-with-hyphen", "_startsWithUnderscore",
@@ -64,7 +63,8 @@ public class GwtSafeStylesUtilsTest extends GWTTestCase {
       "url('http://withSingleQuotes')", "url(\"http://withDoubleQuotes\")",
       "url(http://withSemiColon;)", "url(http://withUnmatchedBracket{[)",
       "url(http://withUnmatchedCloseBracket}])", "end-in-escaped-backslash\\\\", "u-near-end-u",
-      "url-near-end-url", "absolute"};
+      "url-near-end-url", "absolute", "\">\"", "angle-in'single<quote'",
+      "url(http://withAngleBracket>)"};
 
   private static Boolean isAssertionEnabled;
 


### PR DESCRIPTION
SafeStylesHostedModeUtils.isValidStyleName and isValidStyleValue reject a misplaced `;`, `:`, `-` and unpaired quotes, but not `<` or `>`, even though SafeStylesUtils.verifySafeStylesConstraints lists them alongside the same characters. This makes the two consistent.

Names reject `<` and `>` outright. Values reject them only outside quotes and url(), matching the existing `;` handling, so `list-style-type: ">"` and similar stay valid.

Not a security fix: the `*Trusted*` methods put the burden on the caller, and these checks are dev-mode assertions. Purely a consistency tweak to the existing validation.

Test cases added to the INVALID_STYLE_NAMES / INVALID_STYLE_VALUES and VALID_STYLE_VALUES arrays in GwtSafeStylesUtilsTest, which both GwtSafeStylesUtilsTest and GwtSafeStylesHostedModeUtilsTest iterate.