### PR TITLE
Contain public resource output paths

### DIFF
--- a/dev/codeserver/BUILD
+++ b/dev/codeserver/BUILD
@@ -62,17 +62,8 @@ java_library(
 test_suite(
     name = "tests",
     tests = [
-        ":LauncherDirTest",
         ":RecompilerTest",
         ":SourceHandlerTest",
-    ],
-)
-
-java_test(
-    name = "LauncherDirTest",
-    test_class = "com.google.gwt.dev.codeserver.LauncherDirTest",
-    runtime_deps = [
-        ":testlib",
     ],
 )
 

--- a/dev/codeserver/BUILD
+++ b/dev/codeserver/BUILD
@@ -62,8 +62,17 @@ java_library(
 test_suite(
     name = "tests",
     tests = [
+        ":LauncherDirTest",
         ":RecompilerTest",
         ":SourceHandlerTest",
+    ],
+)
+
+java_test(
+    name = "LauncherDirTest",
+    test_class = "com.google.gwt.dev.codeserver.LauncherDirTest",
+    runtime_deps = [
+        ":testlib",
     ],
 )
 

--- a/dev/codeserver/java/com/google/gwt/dev/codeserver/LauncherDir.java
+++ b/dev/codeserver/java/com/google/gwt/dev/codeserver/LauncherDir.java
@@ -21,6 +21,7 @@ import com.google.gwt.core.ext.UnableToCompleteException;
 import com.google.gwt.dev.cfg.ModuleDef;
 import com.google.gwt.dev.codeserver.CompileDir.PolicyFile;
 import com.google.gwt.dev.resource.impl.ResourceOracleImpl;
+import com.google.gwt.dev.util.OutputFileSet;
 import com.google.gwt.thirdparty.guava.common.base.Charsets;
 import com.google.gwt.thirdparty.guava.common.base.Preconditions;
 import com.google.gwt.thirdparty.guava.common.io.Files;
@@ -143,6 +144,9 @@ class LauncherDir {
   }
 
   static File pathToPublicResource(File moduleOutputDir, String pathName) throws IOException {
+    if (OutputFileSet.pathEscapesRoot(pathName)) {
+      throw new IOException("Path escapes module output directory: " + pathName);
+    }
     File outputRoot = moduleOutputDir.getCanonicalFile();
     File file = new File(outputRoot, pathName).getCanonicalFile();
     if (!isDescendantOrSelf(outputRoot, file)) {

--- a/dev/codeserver/java/com/google/gwt/dev/codeserver/LauncherDir.java
+++ b/dev/codeserver/java/com/google/gwt/dev/codeserver/LauncherDir.java
@@ -132,7 +132,7 @@ class LauncherDir {
     // Copy the public resources to the output.
     ResourceOracleImpl publicResources = module.getPublicResourceOracle();
     for (String pathName : publicResources.getPathNames()) {
-      File file = new File(moduleOutputDir, pathName);
+      File file = pathToPublicResource(moduleOutputDir, pathName);
       File parent = file.getParentFile();
       if (!parent.isDirectory() && !parent.mkdirs()) {
         compileLogger.log(Type.ERROR, "cannot create directory: " + parent);
@@ -140,5 +140,23 @@ class LauncherDir {
       }
       Files.asByteSink(file).writeFrom(publicResources.getResourceAsStream(pathName));
     }
+  }
+
+  static File pathToPublicResource(File moduleOutputDir, String pathName) throws IOException {
+    File outputRoot = moduleOutputDir.getCanonicalFile();
+    File file = new File(outputRoot, pathName).getCanonicalFile();
+    if (!isDescendantOrSelf(outputRoot, file)) {
+      throw new IOException("Path escapes module output directory: " + pathName);
+    }
+    return file;
+  }
+
+  private static boolean isDescendantOrSelf(File root, File file) {
+    for (File current = file; current != null; current = current.getParentFile()) {
+      if (current.equals(root)) {
+        return true;
+      }
+    }
+    return false;
   }
 }

--- a/dev/codeserver/javatests/com/google/gwt/dev/codeserver/CodeServerSuite.java
+++ b/dev/codeserver/javatests/com/google/gwt/dev/codeserver/CodeServerSuite.java
@@ -23,6 +23,7 @@ import junit.framework.TestSuite;
 public class CodeServerSuite {
   public static Test suite() {
     TestSuite suite = new TestSuite("Tests of the code server package");
+    suite.addTestSuite(LauncherDirTest.class);
     suite.addTestSuite(CodeServerGwtTest.class);
     return suite;
   }

--- a/dev/codeserver/javatests/com/google/gwt/dev/codeserver/LauncherDirTest.java
+++ b/dev/codeserver/javatests/com/google/gwt/dev/codeserver/LauncherDirTest.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2026 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.gwt.dev.codeserver;
+
+import com.google.gwt.thirdparty.guava.common.io.MoreFiles;
+import com.google.gwt.thirdparty.guava.common.io.RecursiveDeleteOption;
+
+import junit.framework.TestCase;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+
+/**
+ * Tests for {@link LauncherDir}.
+ */
+public class LauncherDirTest extends TestCase {
+
+  public void testPathToPublicResourceAllowsNestedResource() throws IOException {
+    File moduleOutputDir = Files.createTempDirectory("launcherdir").toFile();
+    try {
+      File resolved = LauncherDir.pathToPublicResource(moduleOutputDir, "img/../img/logo.png");
+      assertEquals(new File(moduleOutputDir, "img/logo.png").getCanonicalFile(), resolved);
+    } finally {
+      MoreFiles.deleteRecursively(moduleOutputDir.toPath(), RecursiveDeleteOption.ALLOW_INSECURE);
+    }
+  }
+
+  public void testPathToPublicResourceRejectsEscapingResource() throws IOException {
+    File moduleOutputDir = Files.createTempDirectory("launcherdir").toFile();
+    try {
+      String outsideName = moduleOutputDir.getName() + "-outside";
+
+      try {
+        LauncherDir.pathToPublicResource(moduleOutputDir, "../" + outsideName);
+        fail("Expected public resource path escaping the module output directory to be rejected");
+      } catch (IOException expected) {
+        assertTrue(expected.getMessage().contains("escapes module output directory"));
+      }
+
+      assertFalse(new File(moduleOutputDir.getParentFile(), outsideName).exists());
+    } finally {
+      MoreFiles.deleteRecursively(moduleOutputDir.toPath(), RecursiveDeleteOption.ALLOW_INSECURE);
+    }
+  }
+}

--- a/dev/core/src/com/google/gwt/dev/util/OutputFileSet.java
+++ b/dev/core/src/com/google/gwt/dev/util/OutputFileSet.java
@@ -74,8 +74,44 @@ public abstract class OutputFileSet {
    */
   // TODO: revalidate whether any timestamp based overwrite prevention is needed.
   public OutputStream openForWrite(String path, long timeStampMillis) throws IOException {
+    if (pathEscapesRoot(path)) {
+      throw new IOException("Path escapes output directory: " + path);
+    }
     pathsSeen.add(path);
     return createNewOutputStream(path, timeStampMillis);
+  }
+
+  /**
+   * Returns true if resolving {@code path} against an output root would leave
+   * that root via {@code ..} segments. Harmless in-root normalization such as
+   * {@code a/../b} is allowed. A leading {@code /} is treated as the output-set
+   * root, not the filesystem root.
+   */
+  public static boolean pathEscapesRoot(String path) {
+    String normalized = path;
+    if (normalized.startsWith("/")) {
+      normalized = normalized.substring(1);
+    }
+    int depth = 0;
+    int start = 0;
+    while (start <= normalized.length()) {
+      int slash = normalized.indexOf('/', start);
+      String part = slash < 0 ? normalized.substring(start)
+          : normalized.substring(start, slash);
+      start = slash < 0 ? normalized.length() + 1 : slash + 1;
+      if (part.isEmpty() || ".".equals(part)) {
+        continue;
+      }
+      if ("..".equals(part)) {
+        depth--;
+        if (depth < 0) {
+          return true;
+        }
+      } else {
+        depth++;
+      }
+    }
+    return false;
   }
 
   protected abstract OutputStream createNewOutputStream(String path,

--- a/dev/core/src/com/google/gwt/dev/util/OutputFileSetOnDirectory.java
+++ b/dev/core/src/com/google/gwt/dev/util/OutputFileSetOnDirectory.java
@@ -86,6 +86,24 @@ public class OutputFileSetOnDirectory extends OutputFileSet {
   }
 
   private File pathToFile(String path) throws IOException {
-    return new File(dir, prefix + path).getCanonicalFile();
+    File baseDir = dir.getCanonicalFile();
+    File outputRoot = new File(baseDir, prefix).getCanonicalFile();
+    if (!isDescendantOrSelf(baseDir, outputRoot)) {
+      throw new IOException("Prefix escapes output directory: " + prefix);
+    }
+    File file = new File(outputRoot, path).getCanonicalFile();
+    if (!isDescendantOrSelf(outputRoot, file)) {
+      throw new IOException("Path escapes output directory: " + path);
+    }
+    return file;
+  }
+
+  private static boolean isDescendantOrSelf(File root, File file) {
+    for (File current = file; current != null; current = current.getParentFile()) {
+      if (current.equals(root)) {
+        return true;
+      }
+    }
+    return false;
   }
 }

--- a/dev/core/test/com/google/gwt/dev/util/OutputFileSetOnDirectoryTest.java
+++ b/dev/core/test/com/google/gwt/dev/util/OutputFileSetOnDirectoryTest.java
@@ -29,6 +29,15 @@ import java.nio.file.Files;
  */
 public class OutputFileSetOnDirectoryTest extends TestCase {
 
+  public void testPathEscapesRoot() {
+    assertFalse(OutputFileSet.pathEscapesRoot("a/b"));
+    assertFalse(OutputFileSet.pathEscapesRoot("a/../b"));
+    assertFalse(OutputFileSet.pathEscapesRoot("path/../to/./file"));
+    assertTrue(OutputFileSet.pathEscapesRoot("../b"));
+    assertTrue(OutputFileSet.pathEscapesRoot("a/../../b"));
+    assertTrue(OutputFileSet.pathEscapesRoot("/../path/../to/./file"));
+  }
+
   public void testCreateNewOutputStream() throws IOException {
     File work = Files.createTempDirectory("outputfileset").toFile();
     try {

--- a/dev/core/test/com/google/gwt/dev/util/OutputFileSetOnDirectoryTest.java
+++ b/dev/core/test/com/google/gwt/dev/util/OutputFileSetOnDirectoryTest.java
@@ -42,9 +42,54 @@ public class OutputFileSetOnDirectoryTest extends TestCase {
       output.createNewOutputStream("path/../to/file", tstamp).close();
       assertTrue(new File(work, "test/to/file").exists());
 
-      output.createNewOutputStream("/../path/../to/./file", tstamp).close();
-      assertTrue(new File(work, "to/file").exists());
+      try {
+        output.createNewOutputStream("../to/file", tstamp).close();
+        fail("Expected path escaping the output prefix to be rejected");
+      } catch (IOException expected) {
+        assertTrue(expected.getMessage().contains("escapes output directory"));
+      }
+      assertFalse(new File(work, "to/file").exists());
 
+    } finally {
+      MoreFiles.deleteRecursively(work.toPath(), RecursiveDeleteOption.ALLOW_INSECURE);
+    }
+  }
+
+  public void testEscapingPrefixRejected() throws IOException {
+    File work = Files.createTempDirectory("outputfileset").toFile();
+    try {
+      String outsideName = work.getName() + "-outside";
+      OutputFileSetOnDirectory output = new OutputFileSetOnDirectory(work, "test/");
+
+      try {
+        output.createNewOutputStream("../../" + outsideName,
+            OutputFileSet.TIMESTAMP_UNAVAILABLE).close();
+        fail("Expected path escaping the output directory to be rejected");
+      } catch (IOException expected) {
+        assertTrue(expected.getMessage().contains("escapes output directory"));
+      }
+
+      assertFalse(new File(work.getParentFile(), outsideName).exists());
+    } finally {
+      MoreFiles.deleteRecursively(work.toPath(), RecursiveDeleteOption.ALLOW_INSECURE);
+    }
+  }
+
+  public void testEscapingConstructorPrefixRejected() throws IOException {
+    File work = Files.createTempDirectory("outputfileset").toFile();
+    try {
+      String outsideName = work.getName() + "-outside";
+      OutputFileSetOnDirectory output =
+          new OutputFileSetOnDirectory(work, "../" + outsideName + "/");
+
+      try {
+        output.createNewOutputStream("file", OutputFileSet.TIMESTAMP_UNAVAILABLE).close();
+        fail("Expected output prefix escaping the output directory to be rejected");
+      } catch (IOException expected) {
+        assertTrue(expected.getMessage().contains("escapes output directory"));
+      }
+
+      assertFalse(new File(work.getParentFile(), outsideName + "/file").exists());
     } finally {
       MoreFiles.deleteRecursively(work.toPath(), RecursiveDeleteOption.ALLOW_INSECURE);
     }


### PR DESCRIPTION
Contain public resource output paths

Public resource paths can be supplied by classpath resources and are later written into compiler and CodeServer output directories. This change resolves output paths against the intended output root and rejects any path that canonicalizes outside that root before creating parent directories or writing bytes.

Changes:
- Contain `OutputFileSetOnDirectory` writes inside `dir + prefix`.
- Contain CodeServer public-resource writes inside the module output directory.
- Add regression coverage for harmless in-root normalization and escaping traversal attempts.
- Add the new CodeServer test to the Bazel and JUnit suite metadata.

Validation:
- `git diff --check`
- `ant dev -Dtarget=test -Dgwt.junit.testcase.dev.core.includes="**/OutputFileSetOnDirectoryTest.class"`
- `ant codeserver -Dtarget=test -Dtest.dev.disable=true`

No linked issue.