### PR TITLE
Parallelize CodeSplitter's not-exclusive CFA computation

### DIFF
--- a/dev/core/src/com/google/gwt/dev/jjs/ast/JProgram.java
+++ b/dev/core/src/com/google/gwt/dev/jjs/ast/JProgram.java
@@ -1023,7 +1023,8 @@ public class JProgram extends JNode implements ArrayTypeCreator {
     return staticImpl;
   }
 
-  public JArrayType getTypeArray(JType elementType) {
+  // Synchronized because CodeSplitter reaches this from concurrent CFA traversals.
+  public synchronized JArrayType getTypeArray(JType elementType) {
     JArrayType arrayType = arrayTypes.get(elementType);
     if (arrayType == null) {
       arrayType = new JArrayType(elementType);

--- a/dev/core/src/com/google/gwt/dev/jjs/impl/codesplitter/CodeSplitter.java
+++ b/dev/core/src/com/google/gwt/dev/jjs/impl/codesplitter/CodeSplitter.java
@@ -43,6 +43,11 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
 
 /**
  * <p>
@@ -274,6 +279,12 @@ public class CodeSplitter {
    */
   private Map<Fragment, ControlFlowAnalyzer> computeNotExclusiveCfaForFragments(
       Collection<Fragment> exclusiveFragments) {
+    // Recording a dependency graph is order sensitive, so it keeps the serial loop below.
+    if (dependencyRecorder == MultipleDependencyGraphRecorder.NULL_RECORDER
+        && exclusiveFragments.size() > 1) {
+      return computeNotExclusiveCfaForFragmentsInParallel(exclusiveFragments);
+    }
+
     String dependencyGraphNameAfterInitialSequence = dependencyGraphNameAfterInitialSequence();
 
     Map<Fragment, ControlFlowAnalyzer> notExclusiveCfaByFragment = Maps.newHashMap();
@@ -302,6 +313,59 @@ public class CodeSplitter {
       notExclusiveCfaByFragment.put(fragment, cfa);
     }
     return notExclusiveCfaByFragment;
+  }
+
+  /**
+   * Runs {@link #computeNotExclusiveCfaForFragment} for every fragment in parallel. The iterations
+   * are independent: each builds its own ControlFlowAnalyzer, whose copy constructor duplicates
+   * every mutable set, and otherwise only reads the program.
+   */
+  private Map<Fragment, ControlFlowAnalyzer> computeNotExclusiveCfaForFragmentsInParallel(
+      final Collection<Fragment> exclusiveFragments) {
+    Map<Fragment, ControlFlowAnalyzer> notExclusiveCfaByFragment = Maps.newLinkedHashMap();
+    int threads = Math.min(Runtime.getRuntime().availableProcessors(), exclusiveFragments.size());
+    ExecutorService executor = Executors.newFixedThreadPool(threads);
+    try {
+      Map<Fragment, Future<ControlFlowAnalyzer>> futures = Maps.newLinkedHashMap();
+      for (final Fragment fragment : exclusiveFragments) {
+        assert fragment.isExclusive();
+        futures.put(fragment, executor.submit(new Callable<ControlFlowAnalyzer>() {
+          @Override
+          public ControlFlowAnalyzer call() {
+            return computeNotExclusiveCfaForFragment(fragment, exclusiveFragments);
+          }
+        }));
+      }
+      for (Map.Entry<Fragment, Future<ControlFlowAnalyzer>> entry : futures.entrySet()) {
+        try {
+          notExclusiveCfaByFragment.put(entry.getKey(), entry.getValue().get());
+        } catch (InterruptedException e) {
+          Thread.currentThread().interrupt();
+          throw new RuntimeException(e);
+        } catch (ExecutionException e) {
+          throw new RuntimeException(e.getCause());
+        }
+      }
+    } finally {
+      executor.shutdown();
+    }
+    return notExclusiveCfaByFragment;
+  }
+
+  private ControlFlowAnalyzer computeNotExclusiveCfaForFragment(Fragment fragment,
+      Collection<Fragment> exclusiveFragments) {
+    ControlFlowAnalyzer cfa = new ControlFlowAnalyzer(initialSequenceCfa);
+    for (Fragment otherFragment : exclusiveFragments) {
+      // don't trace the initial fragments as they have already been traced and their atoms are
+      // already in {@code initialSequenceCfa}.
+      if (otherFragment.isInitial() || otherFragment == fragment) {
+        continue;
+      }
+      for (JRunAsync otherRunAsync : otherFragment.getRunAsyncs()) {
+        cfa.traverseFromRunAsync(otherRunAsync);
+      }
+    }
+    return cfa;
   }
 
   /**


### PR DESCRIPTION
`computeNotExclusiveCfaForFragments` is quadratic in the number of exclusive fragments: for each fragment it traverses the run-asyncs of every other fragment. Applications with many split points pay heavily — with 231 split points this loop alone is 25.6% of the permutation's CPU, and CodeSplitter overall is 181s of an 11-minute compile.

The iterations are independent. `ControlFlowAnalyzer`'s copy constructor deep-copies every mutable set, each traversal writes only to its own analyzer, and `ControlFlowAnalyzer` is purely analytical — it contains no setters on AST nodes. This runs them on a fixed thread pool.

Two constraints are respected:

- Dependency-graph recording is stateful and order sensitive, so the parallel path is only taken when no recorder is installed. With `-compileReport` the original serial loop runs unchanged.
- `JProgram.getTypeArray` lazily creates array types in a plain HashMap and is reachable from the traversal, so it is now `synchronized`. It is the only shared mutable state on this path; `getAllArrayTypes`, which already sorts to avoid nondeterminism, is not reachable from `traverseFromRunAsync`.

Happy to derive the pool size from `-localWorkers` instead of `availableProcessors()` if you'd prefer to avoid oversubscription when permutations are already compiled in parallel.

CodeSplitter drops from 38.4s to 17.0s with 122 split points and from 181.4s to 71.5s with 231. Generated JavaScript is byte-for-byte identical across 874 output files from four applications. ant -Dtarget=test dev passes: 1936 tests, 0 failures.

Fixes #10395 