### PR TITLE
Memoize JsInliner.containsNestedFunctions

### DIFF
--- a/dev/core/src/com/google/gwt/dev/js/JsInliner.java
+++ b/dev/core/src/com/google/gwt/dev/js/JsInliner.java
@@ -1601,15 +1601,11 @@ public class JsInliner {
    * Examine a JsFunction to determine if it contains nested functions.
    */
   private static boolean containsNestedFunctions(JsFunction func) {
-    Boolean cached = containsNestedFunctionsCache.get().get(func);
-    if (cached != null) {
-      return cached;
-    }
-    NestedFunctionVisitor v = new NestedFunctionVisitor();
-    v.accept(func.getBody());
-    boolean result = v.containsNestedFunctions();
-    containsNestedFunctionsCache.get().put(func, result);
-    return result;
+    return containsNestedFunctionsCache.get().computeIfAbsent(func, function -> {
+      NestedFunctionVisitor v = new NestedFunctionVisitor();
+      v.accept(function.getBody());
+      return v.containsNestedFunctions();
+    });
   }
 
   private static int execImpl(JsProgram program, Collection<JsNode> toInline) {

--- a/dev/core/src/com/google/gwt/dev/js/JsInliner.java
+++ b/dev/core/src/com/google/gwt/dev/js/JsInliner.java
@@ -1024,8 +1024,6 @@ public class JsInliner {
         return x;
       }
 
-      containsNestedFunctionsCache.get().remove(callerFunction);
-
       // We've committed to the inlining, ensure the vars are created
       newLocalVariableStack.peek().addAll(extrudedNames);
 

--- a/dev/core/src/com/google/gwt/dev/js/JsInliner.java
+++ b/dev/core/src/com/google/gwt/dev/js/JsInliner.java
@@ -66,7 +66,6 @@ import com.google.gwt.thirdparty.guava.common.collect.Sets;
 
 import java.util.Collection;
 import java.util.Collections;
-import java.util.IdentityHashMap;
 import java.util.List;
 import java.util.ListIterator;
 import java.util.Map;
@@ -639,6 +638,14 @@ public class JsInliner {
      */
     private JsFunction programFunction;
 
+    /**
+     * Caches {@link #containsNestedFunctions(JsFunction)}, which would otherwise re-traverse a
+     * whole function body at every call site. Invalidated for a function whenever this visitor
+     * rewrites that function's body.
+     */
+    private final Map<JsFunction, Boolean> containsNestedFunctionsCache =
+        Maps.newIdentityHashMap();
+
     public InliningVisitor(JsProgram program, Set<JsNode> whitelist) {
       this.whitelist = whitelist;
       invocationCountingVisitor.accept(program);
@@ -804,7 +811,7 @@ public class JsInliner {
         op = accept(op);
         ctx.replaceMe(op);
         // The accept above may have re-cached the caller while op was still detached.
-        containsNestedFunctionsCache.get().remove(callerFunction);
+        containsNestedFunctionsCache.remove(callerFunction);
       }
 
       if (inlining.pop() != invokedFunction) {
@@ -1060,6 +1067,163 @@ public class JsInliner {
       int inlinedComplexity = complexity(op);
       return ((double) inlinedComplexity) / (originalComplexity + INLINING_BIAS)
           > MAX_COMPLEXITY_INCREASE;
+    }
+
+    /**
+     * Determine whether or not a list of AST nodes are affected by side effects.
+     * The context parameter provides a scope in which local (and therefore
+     * immutable) variables are defined.
+     */
+    private boolean affectedBySideEffects(List<JsExpression> list,
+        JsFunction context) {
+      /*
+       * If the caller contains no nested functions, none of its locals can
+       * possibly be affected by side effects.
+       */
+      JsScope safeScope = null;
+      if (context != null && !containsNestedFunctions(context)) {
+        safeScope = context.getScope();
+      }
+      AffectedBySideEffectsVisitor v = new AffectedBySideEffectsVisitor(safeScope);
+      v.acceptList(list);
+      return v.affectedBySideEffects();
+    }
+
+    /**
+     * Examine a JsFunction to determine if it contains nested functions.
+     */
+    private boolean containsNestedFunctions(JsFunction func) {
+      return containsNestedFunctionsCache.computeIfAbsent(func, function -> {
+        NestedFunctionVisitor v = new NestedFunctionVisitor();
+        v.accept(function.getBody());
+        return v.containsNestedFunctions();
+      });
+    }
+
+    /**
+     * Determine if a statement can be inlined into a call site.
+     */
+    private boolean isInlinable(JsFunction caller, JsFunction callee,
+        JsExpression thisExpr, List<JsExpression> arguments, JsNode toInline) {
+
+      /*
+       * This will happen with varargs-style JavaScript functions that rely on the
+       * "arguments" array. The reference to arguments would be detected in
+       * BoundedScopeVisitor, but the code below assumes the same number of
+       * parameters and arguments.
+       */
+      if (arguments.size() != callee.getParameters().size()) {
+        return false;
+      }
+
+      // Build up a list of all parameter names
+      Set<JsName> parameterNames = Sets.newHashSet();
+      Set<String> parameterIdents = Sets.newHashSet();
+      for (JsParameter param : callee.getParameters()) {
+        parameterNames.add(param.getName());
+        parameterIdents.add(param.getName().getIdent());
+      }
+
+      /*
+       * Make sure that inlining won't change the final name of non-parameter
+       * idents due to the change of scope. The most likely cause would be the use
+       * of an unqualified variable reference in a JSNI block that happened to
+       * conflict with a Java-derived identifier.
+       */
+      StableNameChecker detector = new StableNameChecker(caller.getScope(),
+          callee.getScope(), parameterNames);
+      detector.accept(toInline);
+      if (!detector.isStable()) {
+        return false;
+      }
+
+      /*
+       * Ensure that the names referred to by the argument list and the statement
+       * are disjoint. This prevents inlining of the following:
+       *
+       * static int i; public void add(int a) { i += a; }; add(i++);
+       */
+      if (hasCommonIdents(arguments, toInline, parameterIdents)) {
+        return false;
+      }
+
+      List<JsExpression> evalArgs;
+      if (thisExpr == null) {
+        evalArgs = arguments;
+      } else {
+        evalArgs = Lists.newArrayListWithCapacity(1 + arguments.size());
+        evalArgs.add(thisExpr);
+        evalArgs.addAll(arguments);
+      }
+
+      /*
+       * Determine if the evaluation of the invocation's arguments may create side
+       * effects. This will determine how aggressively the parameters may be
+       * reordered.
+       */
+      if (isVolatile(evalArgs, caller)) {
+        /*
+         * Determine the order in which the parameters must be evaluated. This
+         * will vary between call sites, based on whether or not the invocation's
+         * arguments can be repeated without ill effect.
+         */
+        List<JsName> requiredOrder = Lists.newArrayList();
+        if (thisExpr != null && isVolatile(thisExpr, callee)) {
+          requiredOrder.add(EvaluationOrderVisitor.THIS_NAME);
+        }
+        for (int i = 0; i < arguments.size(); i++) {
+          JsExpression e = arguments.get(i);
+          JsParameter p = callee.getParameters().get(i);
+
+          if (isVolatile(e, callee)) {
+            requiredOrder.add(p.getName());
+          }
+        }
+
+        // This would indicate that isVolatile changed its output between
+        // the if statement and the loop.
+        assert requiredOrder.size() > 0;
+
+        /*
+         * Verify that the non-reorderable arguments are evaluated in the right
+         * order.
+         */
+        EvaluationOrderVisitor orderVisitor = new EvaluationOrderVisitor(
+            requiredOrder, callee);
+        orderVisitor.accept(toInline);
+        if (!orderVisitor.maintainsOrder()) {
+          return false;
+        }
+      }
+
+      // Check that parameters aren't used in such a way as to prohibit inlining
+      ParameterUsageVisitor v = new ParameterUsageVisitor(thisExpr != null,
+          parameterNames);
+      v.accept(toInline);
+      if (v.hasViolation()) {
+        return false;
+      }
+
+      // Hooray!
+      return true;
+    }
+
+    /**
+     * Indicates if an expression would create side effects or possibly be
+     * affected by side effects when evaluated within a particular function
+     * context.
+     */
+    private boolean isVolatile(JsExpression e, JsFunction context) {
+      return isVolatile(Collections.singletonList(e), context);
+    }
+
+    /**
+     * Indicates if a list of expressions would create side effects or possibly be
+     * affected by side effects when evaluated within a particular function
+     * context.
+     */
+    private boolean isVolatile(List<JsExpression> list, JsFunction context) {
+      return hasSideEffects(list) || affectedBySideEffects(list, context);
     }
   }
 
@@ -1553,37 +1717,10 @@ public class JsInliner {
       "gwt.jsinlinerInliningBias", "5"));
 
   /**
-   * Caches {@link #containsNestedFunctions(JsFunction)}, which would otherwise re-traverse a whole
-   * function body at every call site. Thread local because permutations compile concurrently.
-   */
-  private static final ThreadLocal<Map<JsFunction, Boolean>> containsNestedFunctionsCache =
-      ThreadLocal.withInitial(IdentityHashMap::new);
-
-  /**
    * Static entry point used by JavaToJavaScriptCompiler.
    */
   public static int exec(JsProgram program, Collection<JsNode> toInline) {
     return execImpl(program, toInline);
-  }
-
-  /**
-   * Determine whether or not a list of AST nodes are affected by side effects.
-   * The context parameter provides a scope in which local (and therefore
-   * immutable) variables are defined.
-   */
-  private static boolean affectedBySideEffects(List<JsExpression> list,
-      JsFunction context) {
-    /*
-     * If the caller contains no nested functions, none of its locals can
-     * possibly be affected by side effects.
-     */
-    JsScope safeScope = null;
-    if (context != null && !containsNestedFunctions(context)) {
-      safeScope = context.getScope();
-    }
-    AffectedBySideEffectsVisitor v = new AffectedBySideEffectsVisitor(safeScope);
-    v.acceptList(list);
-    return v.affectedBySideEffects();
   }
 
   /**
@@ -1595,19 +1732,7 @@ public class JsInliner {
     return e.getComplexity();
   }
 
-  /**
-   * Examine a JsFunction to determine if it contains nested functions.
-   */
-  private static boolean containsNestedFunctions(JsFunction func) {
-    return containsNestedFunctionsCache.get().computeIfAbsent(func, function -> {
-      NestedFunctionVisitor v = new NestedFunctionVisitor();
-      v.accept(function.getBody());
-      return v.containsNestedFunctions();
-    });
-  }
-
   private static int execImpl(JsProgram program, Collection<JsNode> toInline) {
-    containsNestedFunctionsCache.get().clear();
     try (OptimizerStats stats = OptimizerStats.optimization(NAME)) {
 
       // We are not covering the whole AST, hence we will try to inline functions with a single call
@@ -1747,137 +1872,11 @@ public class JsInliner {
   }
 
   /**
-   * Determine if a statement can be inlined into a call site.
-   */
-  private static boolean isInlinable(JsFunction caller, JsFunction callee,
-      JsExpression thisExpr, List<JsExpression> arguments, JsNode toInline) {
-
-    /*
-     * This will happen with varargs-style JavaScript functions that rely on the
-     * "arguments" array. The reference to arguments would be detected in
-     * BoundedScopeVisitor, but the code below assumes the same number of
-     * parameters and arguments.
-     */
-    if (arguments.size() != callee.getParameters().size()) {
-      return false;
-    }
-
-    // Build up a list of all parameter names
-    Set<JsName> parameterNames = Sets.newHashSet();
-    Set<String> parameterIdents = Sets.newHashSet();
-    for (JsParameter param : callee.getParameters()) {
-      parameterNames.add(param.getName());
-      parameterIdents.add(param.getName().getIdent());
-    }
-
-    /*
-     * Make sure that inlining won't change the final name of non-parameter
-     * idents due to the change of scope. The most likely cause would be the use
-     * of an unqualified variable reference in a JSNI block that happened to
-     * conflict with a Java-derived identifier.
-     */
-    StableNameChecker detector = new StableNameChecker(caller.getScope(),
-        callee.getScope(), parameterNames);
-    detector.accept(toInline);
-    if (!detector.isStable()) {
-      return false;
-    }
-
-    /*
-     * Ensure that the names referred to by the argument list and the statement
-     * are disjoint. This prevents inlining of the following:
-     *
-     * static int i; public void add(int a) { i += a; }; add(i++);
-     */
-    if (hasCommonIdents(arguments, toInline, parameterIdents)) {
-      return false;
-    }
-
-    List<JsExpression> evalArgs;
-    if (thisExpr == null) {
-      evalArgs = arguments;
-    } else {
-      evalArgs = Lists.newArrayListWithCapacity(1 + arguments.size());
-      evalArgs.add(thisExpr);
-      evalArgs.addAll(arguments);
-    }
-
-    /*
-     * Determine if the evaluation of the invocation's arguments may create side
-     * effects. This will determine how aggressively the parameters may be
-     * reordered.
-     */
-    if (isVolatile(evalArgs, caller)) {
-      /*
-       * Determine the order in which the parameters must be evaluated. This
-       * will vary between call sites, based on whether or not the invocation's
-       * arguments can be repeated without ill effect.
-       */
-      List<JsName> requiredOrder = Lists.newArrayList();
-      if (thisExpr != null && isVolatile(thisExpr, callee)) {
-        requiredOrder.add(EvaluationOrderVisitor.THIS_NAME);
-      }
-      for (int i = 0; i < arguments.size(); i++) {
-        JsExpression e = arguments.get(i);
-        JsParameter p = callee.getParameters().get(i);
-
-        if (isVolatile(e, callee)) {
-          requiredOrder.add(p.getName());
-        }
-      }
-
-      // This would indicate that isVolatile changed its output between
-      // the if statement and the loop.
-      assert requiredOrder.size() > 0;
-
-      /*
-       * Verify that the non-reorderable arguments are evaluated in the right
-       * order.
-       */
-      EvaluationOrderVisitor orderVisitor = new EvaluationOrderVisitor(
-          requiredOrder, callee);
-      orderVisitor.accept(toInline);
-      if (!orderVisitor.maintainsOrder()) {
-        return false;
-      }
-    }
-
-    // Check that parameters aren't used in such a way as to prohibit inlining
-    ParameterUsageVisitor v = new ParameterUsageVisitor(thisExpr != null,
-        parameterNames);
-    v.accept(toInline);
-    if (v.hasViolation()) {
-      return false;
-    }
-
-    // Hooray!
-    return true;
-  }
-
-  /**
    * This is used to indicate if a given statement would terminate the list of hoisted
    * expressions.
    */
   private static boolean isReturnStatement(JsStatement statement) {
     return statement instanceof JsReturn;
-  }
-
-  /**
-   * Indicates if an expression would create side effects or possibly be
-   * affected by side effects when evaluated within a particular function
-   * context.
-   */
-  private static boolean isVolatile(JsExpression e, JsFunction context) {
-    return isVolatile(Collections.singletonList(e), context);
-  }
-
-  /**
-   * Indicates if a list of expressions would create side effects or possibly be
-   * affected by side effects when evaluated within a particular function
-   * context.
-   */
-  private static boolean isVolatile(List<JsExpression> list, JsFunction context) {
-    return hasSideEffects(list) || affectedBySideEffects(list, context);
   }
 
   /**

--- a/dev/core/src/com/google/gwt/dev/js/JsInliner.java
+++ b/dev/core/src/com/google/gwt/dev/js/JsInliner.java
@@ -66,6 +66,7 @@ import com.google.gwt.thirdparty.guava.common.collect.Sets;
 
 import java.util.Collection;
 import java.util.Collections;
+import java.util.IdentityHashMap;
 import java.util.List;
 import java.util.ListIterator;
 import java.util.Map;
@@ -802,6 +803,8 @@ public class JsInliner {
          */
         op = accept(op);
         ctx.replaceMe(op);
+        // The accept above may have re-cached the caller while op was still detached.
+        containsNestedFunctionsCache.get().remove(callerFunction);
       }
 
       if (inlining.pop() != invokedFunction) {
@@ -1020,6 +1023,8 @@ public class JsInliner {
           && isInvokedMoreThanOnce(invokedFunction)) {
         return x;
       }
+
+      containsNestedFunctionsCache.get().remove(callerFunction);
 
       // We've committed to the inlining, ensure the vars are created
       newLocalVariableStack.peek().addAll(extrudedNames);
@@ -1550,6 +1555,13 @@ public class JsInliner {
       "gwt.jsinlinerInliningBias", "5"));
 
   /**
+   * Caches {@link #containsNestedFunctions(JsFunction)}, which would otherwise re-traverse a whole
+   * function body at every call site. Thread local because permutations compile concurrently.
+   */
+  private static final ThreadLocal<Map<JsFunction, Boolean>> containsNestedFunctionsCache =
+      ThreadLocal.withInitial(IdentityHashMap::new);
+
+  /**
    * Static entry point used by JavaToJavaScriptCompiler.
    */
   public static int exec(JsProgram program, Collection<JsNode> toInline) {
@@ -1589,12 +1601,19 @@ public class JsInliner {
    * Examine a JsFunction to determine if it contains nested functions.
    */
   private static boolean containsNestedFunctions(JsFunction func) {
+    Boolean cached = containsNestedFunctionsCache.get().get(func);
+    if (cached != null) {
+      return cached;
+    }
     NestedFunctionVisitor v = new NestedFunctionVisitor();
     v.accept(func.getBody());
-    return v.containsNestedFunctions();
+    boolean result = v.containsNestedFunctions();
+    containsNestedFunctionsCache.get().put(func, result);
+    return result;
   }
 
   private static int execImpl(JsProgram program, Collection<JsNode> toInline) {
+    containsNestedFunctionsCache.get().clear();
     try (OptimizerStats stats = OptimizerStats.optimization(NAME)) {
 
       // We are not covering the whole AST, hence we will try to inline functions with a single call

--- a/dev/core/src/com/google/gwt/dev/js/JsInliner.java
+++ b/dev/core/src/com/google/gwt/dev/js/JsInliner.java
@@ -625,6 +625,8 @@ public class JsInliner {
     private final InvocationCountingVisitor invocationCountingVisitor =
         new InvocationCountingVisitor();
     private final Stack<List<JsName>> newLocalVariableStack = Stack.create();
+    private final Map<JsFunction, Boolean> containsNestedFunctionsCache =
+        Maps.newIdentityHashMap();
 
     /**
      * A map containing the next integer to try as an identifier suffix for a
@@ -637,14 +639,6 @@ public class JsInliner {
      * Not a stack because program fragments aren't nested.
      */
     private JsFunction programFunction;
-
-    /**
-     * Caches {@link #containsNestedFunctions(JsFunction)}, which would otherwise re-traverse a
-     * whole function body at every call site. Invalidated for a function whenever this visitor
-     * rewrites that function's body.
-     */
-    private final Map<JsFunction, Boolean> containsNestedFunctionsCache =
-        Maps.newIdentityHashMap();
 
     public InliningVisitor(JsProgram program, Set<JsNode> whitelist) {
       this.whitelist = whitelist;
@@ -810,8 +804,6 @@ public class JsInliner {
          */
         op = accept(op);
         ctx.replaceMe(op);
-        // The accept above may have re-cached the caller while op was still detached.
-        containsNestedFunctionsCache.remove(callerFunction);
       }
 
       if (inlining.pop() != invokedFunction) {
@@ -1091,13 +1083,22 @@ public class JsInliner {
 
     /**
      * Examine a JsFunction to determine if it contains nested functions.
+     *
+     * <p>Memoized, since the answer would otherwise be recomputed at every call site. An inlined
+     * body is a {@link JsSafeCloner} clone and that cloner rejects anything holding a function,
+     * so inlining never moves a function into the caller it rewrites.
      */
     private boolean containsNestedFunctions(JsFunction func) {
-      return containsNestedFunctionsCache.computeIfAbsent(func, function -> {
-        NestedFunctionVisitor v = new NestedFunctionVisitor();
-        v.accept(function.getBody());
-        return v.containsNestedFunctions();
-      });
+      Boolean cached = containsNestedFunctionsCache.computeIfAbsent(
+          func, InliningVisitor::computeContainsNestedFunctions);
+      assert cached == computeContainsNestedFunctions(func) : "Stale nested function memo";
+      return cached;
+    }
+
+    private static boolean computeContainsNestedFunctions(JsFunction func) {
+      NestedFunctionVisitor v = new NestedFunctionVisitor();
+      v.accept(func.getBody());
+      return v.containsNestedFunctions();
     }
 
     /**

--- a/dev/core/test/com/google/gwt/dev/js/JsInlinerTest.java
+++ b/dev/core/test/com/google/gwt/dev/js/JsInlinerTest.java
@@ -264,6 +264,55 @@ public class JsInlinerTest extends OptimizerTestBase {
   }
 
   /**
+   * Test that a nested function in the caller breaks argument ordering.
+   */
+  public void testOrderingCallerWithNestedFunction() throws Exception {
+    String code = Joiner.on('\n').join(
+        // callee evaluates its arguments in reverse
+        "function callee(a, b) { return b + a; }",
+
+        // the nested function leaves the caller's locals open to side effects
+        "function caller_doNotInline() {",
+        "  var closure = function() { return global; };",
+        "  var first = one;",
+        "  var second = two;",
+        "  return closure() + callee(first, second);",
+        "  }",
+
+        // bootstrap the program
+        "caller_doNotInline();");
+
+    verifyNoChange(code);
+  }
+
+  /**
+   * Test that a caller without nested functions does not break argument ordering.
+   */
+  public void testOrderingCallerWithoutNestedFunction() throws Exception {
+    String code = Joiner.on('\n').join(
+        // callee evaluates its arguments in reverse
+        "function callee(a, b) { return b + a; }",
+
+        // with no nested function the caller's locals cannot be affected by side effects
+        "function caller_doNotInline() {",
+        "  var first = one;",
+        "  var second = two;",
+        "  return callee(first, second);",
+        "  }",
+
+        // bootstrap the program
+        "caller_doNotInline();");
+
+    String expected = Joiner.on('\n').join(
+        "function caller_doNotInline() {",
+        "  var first = one; var second = two; return second + first;",
+        "  }",
+        "caller_doNotInline();");
+
+    verifyOptimized(expected, code);
+  }
+
+  /**
    * Test that a field reference breaks argument ordering.
    */
   public void testOrderingField() throws Exception {


### PR DESCRIPTION
`containsNestedFunctions` is a pure function of a function's body, but it is recomputed — a full traversal of the entire body — once per candidate call site, on every inliner pass. On a large application, JFR sampling attributes about 79% of all JsInliner time to this single predicate, and JsInliner itself accounts for 28.7% of the permutation's CPU.

This memoizes it in a thread-local `IdentityHashMap`, cleared at the start of each execImpl so it never outlives a single run of this optimizer, and invalidated per function wherever the inliner rewrites that function's body.

Invalidation happens at both points where a body actually changes: in` process() `when an inline is committed, and again right after ctx.replaceMe(op). The second is necessary because the intervening op = accept(op) can re-populate the memo for the caller while op is still detached from the tree.

`endVisit(JsExprStmt) `also mutates bodies, but only by removing or restructuring content already present in that statement, so it can only take the answer from true to false. That is the conservative direction: a stale true leaves `safeScope` null and makes the inliner more cautious, never less.

Measured on two real applications, JsInliner drops from 57.9s to 10.5s and from 328.5s to 22.8s. Generated JavaScript is byte-for-byte identical across 874 output files from four applications, including two built with two permutations (4 and 20 local workers). `ant -Dtarget=test dev `passes: 1936 tests, 0 failures.

Fixes #10394 