### PR TITLE
Inliner should not remove assigments or var decls

### DIFF
--- a/dev/core/src/com/google/gwt/dev/js/JsInliner.java
+++ b/dev/core/src/com/google/gwt/dev/js/JsInliner.java
@@ -201,40 +201,6 @@ public class JsInliner {
           numMods++;
         }
 
-        /*
-         * Eliminate the pattern (localVar = expr, localVar). This tends to
-         * occur when a method interacted with pruned fields or had statements
-         * removed.
-         */
-        JsName assignmentRef = null;
-        JsExpression expr = null;
-        JsName returnRef = null;
-
-        if (x.getArg1() instanceof JsBinaryOperation) {
-          JsBinaryOperation op = (JsBinaryOperation) x.getArg1();
-          if (op.getOperator() == JsBinaryOperator.ASG
-              && op.getArg1() instanceof JsNameRef) {
-            JsNameRef nameRef = (JsNameRef) op.getArg1();
-            if (nameRef.getQualifier() == null) {
-              assignmentRef = nameRef.getName();
-              expr = op.getArg2();
-            }
-          }
-        }
-
-        if (x.getArg2() instanceof JsNameRef) {
-          JsNameRef nameRef = (JsNameRef) x.getArg2();
-          if (nameRef.getQualifier() == null) {
-            returnRef = nameRef.getName();
-          }
-        }
-
-        if (assignmentRef != null && assignmentRef.equals(returnRef)
-            && localVariableNames.contains(assignmentRef)) {
-          assert expr != null;
-          localVariableNames.remove(assignmentRef);
-          ctx.replaceMe(expr);
-        }
         return;
       }
 

--- a/dev/core/test/com/google/gwt/dev/js/JsInlinerTest.java
+++ b/dev/core/test/com/google/gwt/dev/js/JsInlinerTest.java
@@ -363,6 +363,83 @@ public class JsInlinerTest extends OptimizerTestBase {
   }
 
   /**
+   * Regression test for <a href="https://github.com/gwtproject/gwt/issues/10389">issue 10389</a>.
+   * CommaNormalizer used to remove apparently unnecessary var decls, producing incorrect code.
+   */
+  public void testInlinePreservesVarDeclWithMultipleAssignments() throws Exception {
+    String code = Joiner.on('\n').join(
+        "function callee(arg) {",
+        "  var result;",
+        "  result = arg;",
+        "  result = result + 1;",
+        "  return result;",
+        "}",
+        "function caller_doNotInline(x) {",
+        "  return callee(x);",
+        "}",
+        "caller_doNotInline(5);");
+
+    String expected = Joiner.on('\n').join(
+        "function caller_doNotInline(x){var result;return result=x,result=result+1,result}",
+        "caller_doNotInline(5);");
+
+    verifyOptimized(expected, code);
+  }
+
+  /**
+   * Regression test for <a href="https://github.com/gwtproject/gwt/issues/10389">issue 10389</a>.
+   * CommaNormalizer visited all comma expressions in the inlined body, including pre-existing ones,
+   * which could result in incorrectly optimized inlined output.
+   */
+  public void testInlinePreservesVarDeclWithCommaInSubexpression() throws Exception {
+    String code = Joiner.on('\n').join(
+        "function callee() {",
+        "  var a;",
+        "  return bar((a = baz(), a), a);",
+        "}",
+        "function caller_doNotInline() {",
+        "  return callee();",
+        "}",
+        "caller_doNotInline();");
+
+    String expected = Joiner.on('\n').join(
+        "function caller_doNotInline(){var a;return bar((a=baz(),a),a)}",
+        "caller_doNotInline();");
+
+    verifyOptimized(expected, code);
+  }
+
+  /**
+   * This is inspired by <a href="https://github.com/gwtproject/gwt/issues/10389">issue 10389</a>.
+   */
+  public void testDeclareLocalStillReferencedAfterCommaNormalization() throws Exception {
+    String code = Joiner.on('\n').join(
+        "function readUnsignedShort(t){",
+        "  var b1 = t.read();",
+        "  var b2 = t.read();",
+        "  var result = b2;",
+        "  result = (result << 8) | (b1 & 255);",
+        "  return result;",
+        "}",
+
+        "function readChar_doNotInline(t){",
+        "  return readUnsignedShort(t) & 65535;",
+        "}",
+
+        "readChar_doNotInline(o);");
+
+    String expected = Joiner.on('\n').join(
+        "function readChar_doNotInline(t){",
+        "  var b1,b2,result;",
+        "  return (b1=t.read(),b2=t.read(),result=b2,result=result<<8|b1&255,result)&65535;",
+        "}",
+
+        "readChar_doNotInline(o);");
+
+    verifyOptimized(expected, code);
+  }
+
+  /**
    * This is inspired by <a href="https://github.com/gwtproject/gwt/issues/5935">issue 5935</a>.
    */
   public void testPreserveNameScopeWithDoubleInliningAndObfuscation() throws Exception {
@@ -388,8 +465,8 @@ public class JsInlinerTest extends OptimizerTestBase {
         "var x = 10; start(x);");
 
     String expected = Joiner.on('\n').join(
-        "function c(a){var b;b='t';if(a!=10){$wnd.alert('y != 10')}}",
-        "var d=10;c(d);");
+        "function d(a){var b,c;b=(c='t',c=c+'',c);if(a!=10){$wnd.alert('y != 10')}}",
+        "var e=10;d(e);");
 
     verifyOptimizedObfuscated(expected, code);
   }


### PR DESCRIPTION
Add a test for the bug and a test discovered trying to fix it, and removed the bad behavior, and adjusted an existing regression test to pass with valid, if large, code. This code was flawed and could produce broken output in some circumstances, covered in the new test.

May result in a size regression in some cases, tracked in #10399 and #10400.

Fixes #10389
Co-authored-by: Volker Gronau <volker.gronau@global.ntt>