### PR TITLE
Restore Arrays.ArrayList server-side type check

### DIFF
--- a/user/src/com/google/gwt/user/server/rpc/core/java/util/Arrays.java
+++ b/user/src/com/google/gwt/user/server/rpc/core/java/util/Arrays.java
@@ -45,8 +45,13 @@ public final class Arrays {
     public static List<?> instantiate(ServerSerializationStreamReader streamReader,
         Type[] expectedParameterTypes, DequeMap<TypeVariable<?>, Type> resolvedTypes)
         throws SerializationException {
-      return com.google.gwt.user.client.rpc.core.java.util.Arrays.ArrayList_CustomFieldSerializer
-            .instantiate(streamReader);
+      int size = streamReader.readInt();
+      Object[] array = new Object[size];
+      for (int i = 0; i < size; ++i) {
+        Object obj = streamReader.readObject(expectedParameterTypes[0], resolvedTypes);
+        array[i] = obj;
+      }
+      return java.util.Arrays.asList(array);
     }
 
     @Override

--- a/user/test/com/google/gwt/user/RpcJreSuite.java
+++ b/user/test/com/google/gwt/user/RpcJreSuite.java
@@ -29,6 +29,7 @@ import com.google.gwt.user.server.rpc.RPCRequestTest;
 import com.google.gwt.user.server.rpc.RPCServletUtilsTest;
 import com.google.gwt.user.server.rpc.RPCTest;
 import com.google.gwt.user.server.rpc.RPCTypeCheckArraysTest;
+import com.google.gwt.user.server.rpc.RPCTypeCheckCollectionsTest;
 import com.google.gwt.user.server.rpc.RPCTypeCheckTest;
 import com.google.gwt.user.server.rpc.RemoteServiceServletTest;
 import com.google.gwt.user.server.rpc.SerializationPolicyLoaderTest;
@@ -69,6 +70,7 @@ public class RpcJreSuite {
     suite.addTestSuite(RPCServletUtilsTest.class);
     suite.addTestSuite(RPCRequestTest.class);
     suite.addTestSuite(RPCTypeCheckArraysTest.class);
+    suite.addTestSuite(RPCTypeCheckCollectionsTest.class);
     suite.addTestSuite(Base64Test.class);
     suite.addTestSuite(UtilTest.class);
     suite.addTestSuite(AbstractXsrfProtectedServiceServletTest.class);

--- a/user/test/com/google/gwt/user/server/rpc/RPCTypeCheckCollectionsTest.java
+++ b/user/test/com/google/gwt/user/server/rpc/RPCTypeCheckCollectionsTest.java
@@ -19,7 +19,6 @@ package com.google.gwt.user.server.rpc;
 import com.google.gwt.user.client.rpc.IncompatibleRemoteServiceException;
 import com.google.gwt.user.client.rpc.IsSerializable;
 import com.google.gwt.user.client.rpc.RemoteService;
-import com.google.gwt.user.client.rpc.SerializationException;
 import com.google.gwt.user.client.rpc.SerializedTypeViolationException;
 import com.google.gwt.user.client.rpc.TestSetFactory.ReverseSorter;
 

--- a/user/test/com/google/gwt/user/server/rpc/RPCTypeCheckCollectionsTest.java
+++ b/user/test/com/google/gwt/user/server/rpc/RPCTypeCheckCollectionsTest.java
@@ -19,6 +19,7 @@ package com.google.gwt.user.server.rpc;
 import com.google.gwt.user.client.rpc.IncompatibleRemoteServiceException;
 import com.google.gwt.user.client.rpc.IsSerializable;
 import com.google.gwt.user.client.rpc.RemoteService;
+import com.google.gwt.user.client.rpc.SerializationException;
 import com.google.gwt.user.client.rpc.SerializedTypeViolationException;
 import com.google.gwt.user.client.rpc.TestSetFactory.ReverseSorter;
 
@@ -27,6 +28,7 @@ import junit.framework.TestCase;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.IdentityHashMap;
@@ -206,7 +208,9 @@ public class RPCTypeCheckCollectionsTest extends TestCase {
       linkedList.add(12345);
       linkedList.add(67890);
       strFactory.write(linkedList);
-      
+      strFactory.write(linkedList);
+      strFactory.write(linkedList);
+
       return strFactory.toString();
       
     } catch (Exception e) {
@@ -851,7 +855,7 @@ public class RPCTypeCheckCollectionsTest extends TestCase {
       linkedHashMap.put("bar", new Integer(12));
       strFactory.write(linkedHashMap);
 
-      TreeMap<HashSet, Integer> treeMap = new TreeMap<HashSet, Integer>();
+      TreeMap<HashSet, Integer> treeMap = new TreeMap<HashSet, Integer>(new IdentitySorter());
       treeMap.put(RPCTypeCheckFactory.generateTestHashSet(), 12345);
       strFactory.write(treeMap);
 
@@ -896,6 +900,12 @@ public class RPCTypeCheckCollectionsTest extends TestCase {
       return null;
     }
   }
+  public static class IdentitySorter implements Comparator<Object>, IsSerializable {
+    @Override
+    public int compare(Object o1, Object o2) {
+      return System.identityHashCode(o1) - System.identityHashCode(o2);
+    }
+  }
 
   @SuppressWarnings("unchecked")
   private static String generateTreeSetHashSetSpoofingSetInteger() {
@@ -908,7 +918,7 @@ public class RPCTypeCheckCollectionsTest extends TestCase {
       hashSet.add(67890);
       strFactory.write(hashSet);
 
-      ReverseSorter sorter = new ReverseSorter();
+      IdentitySorter sorter = new IdentitySorter();
       TreeSet treeSet = new TreeSet(sorter);
       treeSet.add(RPCTypeCheckFactory.generateTestHashSet());
       strFactory.write(treeSet);
@@ -1034,7 +1044,7 @@ public class RPCTypeCheckCollectionsTest extends TestCase {
 
   /**
    * This checks that List correctly handles correct types, and reports when it
-   * gets and incorrectly parameterized generic type.
+   * gets an incorrectly parameterized generic type.
    */
   public void testListSpoofingListRaw() {
     try {

--- a/user/test/com/google/gwt/user/server/rpc/RPCTypeCheckFactory.java
+++ b/user/test/com/google/gwt/user/server/rpc/RPCTypeCheckFactory.java
@@ -494,10 +494,6 @@ public class RPCTypeCheckFactory {
   }
 
   private void writeListBody(List<?> list) throws SerializationException {
-    if (list.getClass().toString().matches(".*Arrays\\$ArrayList.*")) {
-      write(list.toArray());
-      return;
-    }
     if (!list.getClass().toString().matches(".*Collections\\$SingletonList.*")) {
       bodyString += Integer.toString(list.size()) + RPC_SEPARATOR_CHAR;
     }


### PR DESCRIPTION
Fixes bugs introduced by 55dc5bdda52991688d5864b074694c94f947f364, making the check ineffective and making the tests fail. 

Also fixed TreeMap test data, and ensure the tests are all run by their suite.

Fixes #10302