### PR TITLE
Inline JS assignment, reference to just assignment

### DIFF
--- a/dev/core/src/com/google/gwt/dev/js/JsStaticEval.java
+++ b/dev/core/src/com/google/gwt/dev/js/JsStaticEval.java
@@ -716,17 +716,23 @@ public class JsStaticEval {
       return arg1;
     }
 
-    // Likewise, simplify (name++, name) to (name++)
+    // Likewise, simplify (name++, name) or (++name, name) to (++name)
     if (arg1 instanceof JsUnaryOperation unaryOp
         && arg2 instanceof JsNameRef resultRef
-        && unaryOp.getOperator().isModifying()
-        && unaryOp.getArg() instanceof JsNameRef assignRef
+        && (unaryOp.getOperator() == JsUnaryOperator.INC
+            || unaryOp.getOperator() == JsUnaryOperator.DEC)
+        && unaryOp.getArg() instanceof JsNameRef unaryArgRef
         && resultRef.getQualifier() == null
-        && assignRef.getQualifier() == null
-        && assignRef.getName() == resultRef.getName()) {
-      assert assignRef.isResolved() : "assignRef was not resolved: " + assignRef;
+        && unaryArgRef.getQualifier() == null
+        && unaryArgRef.getName() == resultRef.getName()) {
+      assert unaryArgRef.isResolved() : "unaryArgRef was not resolved: " + unaryArgRef;
       assert resultRef.isResolved() : "resultRef was not resolved: " + resultRef;
-      return arg1;
+      if (unaryOp instanceof JsPrefixOperation) {
+        return unaryOp;
+      }
+      // Rewrite the discarded postfix operation into the equivalent prefix operation.
+      return new JsPrefixOperation(unaryOp.getSourceInfo(), unaryOp.getOperator(),
+          unaryOp.getArg());
     }
 
     return expr;

--- a/dev/core/src/com/google/gwt/dev/js/JsStaticEval.java
+++ b/dev/core/src/com/google/gwt/dev/js/JsStaticEval.java
@@ -35,6 +35,7 @@ import com.google.gwt.dev.js.ast.JsFor;
 import com.google.gwt.dev.js.ast.JsFunction;
 import com.google.gwt.dev.js.ast.JsIf;
 import com.google.gwt.dev.js.ast.JsModVisitor;
+import com.google.gwt.dev.js.ast.JsNameRef;
 import com.google.gwt.dev.js.ast.JsNullLiteral;
 import com.google.gwt.dev.js.ast.JsNumberLiteral;
 import com.google.gwt.dev.js.ast.JsPrefixOperation;
@@ -700,6 +701,21 @@ public class JsStaticEval {
     if (!arg1.hasSideEffects()) {
       return arg2;
     }
+
+    // Simplify (name = expr, name) to (name = expr), a pattern produced by both java and js method
+    // inlining passes.
+    if (arg1 instanceof JsBinaryOperation op
+        && arg2 instanceof JsNameRef resultRef
+        && op.getOperator() == JsBinaryOperator.ASG
+        && op.getArg1() instanceof JsNameRef assignRef
+        && resultRef.getQualifier() == null
+        && assignRef.getQualifier() == null
+        && assignRef.getName() == resultRef.getName()) {
+      assert assignRef.isResolved() : "assignRef was not resolved: " + assignRef;
+      assert resultRef.isResolved() : "resultRef was not resolved: " + resultRef;
+      return arg1;
+    }
+
     return expr;
   }
 

--- a/dev/core/src/com/google/gwt/dev/js/JsStaticEval.java
+++ b/dev/core/src/com/google/gwt/dev/js/JsStaticEval.java
@@ -706,8 +706,21 @@ public class JsStaticEval {
     // inlining passes.
     if (arg1 instanceof JsBinaryOperation op
         && arg2 instanceof JsNameRef resultRef
-        && op.getOperator() == JsBinaryOperator.ASG
+        && op.getOperator().isAssignment()
         && op.getArg1() instanceof JsNameRef assignRef
+        && resultRef.getQualifier() == null
+        && assignRef.getQualifier() == null
+        && assignRef.getName() == resultRef.getName()) {
+      assert assignRef.isResolved() : "assignRef was not resolved: " + assignRef;
+      assert resultRef.isResolved() : "resultRef was not resolved: " + resultRef;
+      return arg1;
+    }
+
+    // Likewise, simplify (name++, name) to (name++)
+    if (arg1 instanceof JsUnaryOperation unaryOp
+        && arg2 instanceof JsNameRef resultRef
+        && unaryOp.getOperator().isModifying()
+        && unaryOp.getArg() instanceof JsNameRef assignRef
         && resultRef.getQualifier() == null
         && assignRef.getQualifier() == null
         && assignRef.getName() == resultRef.getName()) {

--- a/dev/core/test/com/google/gwt/dev/js/JsStaticEvalTest.java
+++ b/dev/core/test/com/google/gwt/dev/js/JsStaticEvalTest.java
@@ -250,6 +250,52 @@ public class JsStaticEvalTest extends OptimizerTestBase {
         optimize("function f() { var a, b = 1; alert((a = foo(), b)); }"));
   }
 
+  /**
+   * Simplify (name op= expr, name) to (name op= expr) for any compound assignment, since the
+   * compound assignment already evaluates to the updated value.
+   */
+  public void testSimplifyCommaCompoundAssignmentReturn() throws Exception {
+    assertEquals("function f(){var a;alert(a+=foo())}\n",
+        optimize("function f() { var a; alert((a += foo(), a)); }"));
+    assertEquals("alert(a-=foo());", optimize("alert((a -= foo(), a))"));
+    assertEquals("alert(a|=foo());", optimize("alert((a |= foo(), a))"));
+
+    // Confirm that we only simplify when the read is the same local
+    assertEquals("function f(){var a,b=1;alert((a+=foo(),b))}\n",
+        optimize("function f() { var a, b = 1; alert((a += foo(), b)); }"));
+  }
+
+  public void testSimplifyCommaIncDecReturn() throws Exception {
+    // Prefix is returned as-is
+    assertEquals("function f(){var a;alert(++a)}\n",
+        optimize("function f() { var a; alert((++a, a)); }"));
+    assertEquals("alert(--a);", optimize("alert((--a, a))"));
+
+    // Postfix is rewritten to the equivalent prefix form
+    assertEquals("function f(){var a;alert(++a)}\n",
+        optimize("function f() { var a; alert((a++, a)); }"));
+    assertEquals("alert(--a);", optimize("alert((a--, a))"));
+
+    // Confirm that we only simplify when the read is the same local
+    assertEquals("function f(){var a,b=1;alert((a++,b))}\n",
+        optimize("function f() { var a, b = 1; alert((a++, b)); }"));
+
+    // Confirm postfix exprs are left alone, even in a comma expr
+    assertEquals("alert(a++);", optimize("alert(a++)"));
+    assertEquals("alert((foo(),a++));", optimize("alert((foo(), a++))"));
+
+    // In theory this could be optimized, but it doesn't match the known pattern. If we
+    // fill this in later, it would be through some expression inliner
+    assertEquals("alert((g(),a++,a));", optimize("alert((g(), a++, a))"));
+  }
+
+  /**
+   * Delete evaluates to a boolean, the only unary that can't be cleaned up like this.
+   */
+  public void testDoNotSimplifyCommaDelete() throws Exception {
+    assertEquals("alert((delete a,a));", optimize("alert((delete a, a))"));
+  }
+
   private String optimize(String js) throws Exception {
     return optimizeToSource(js, JsSymbolResolver.class, JsStaticEval.class);
   }

--- a/dev/core/test/com/google/gwt/dev/js/JsStaticEvalTest.java
+++ b/dev/core/test/com/google/gwt/dev/js/JsStaticEvalTest.java
@@ -234,7 +234,23 @@ public class JsStaticEvalTest extends OptimizerTestBase {
     assertEquals("alert(false);", optimize("alert(null != null)"));
   }
 
+  /**
+   * Simplify (name = expr, name) to (name = expr), since the assignment expression already
+   * evaluates to the assigned value.
+   */
+  public void testSimplifyCommaAssignmentReturn() throws Exception {
+    // Assign a local name and use it
+    assertEquals("function f(){var a;alert(a=foo())}\n",
+        optimize("function f() { var a; alert((a = foo(), a)); }"));
+    // Test with a name out of scope
+    assertEquals("alert(a=foo());", optimize("alert((a = foo(), a))"));
+
+    // Confirm that we only use the same local (fails if resolver is not used)
+    assertEquals("function f(){var a,b=1;alert((a=foo(),b))}\n",
+        optimize("function f() { var a, b = 1; alert((a = foo(), b)); }"));
+  }
+
   private String optimize(String js) throws Exception {
-    return optimizeToSource(js, JsStaticEval.class);
+    return optimizeToSource(js, JsSymbolResolver.class, JsStaticEval.class);
   }
 }


### PR DESCRIPTION
Cleans up a pattern left by both inliners, while still retaining the assignment for any later usage. Technically this would be better fixed with a variable inlining pass, but GWT doesn't have one of those at this time, and this is a very simple pattern match to use instead.

Adds the requirement that symbols are resolved before running JsStaticEval. This should already be done in most circumstances, added that pass to tests as well.

Partially fixes a size regression from #10398.

Fixes #10399
